### PR TITLE
fix(svelte): fix dispose lifecycle error

### DIFF
--- a/.changeset/strong-poems-divide.md
+++ b/.changeset/strong-poems-divide.md
@@ -1,0 +1,5 @@
+---
+'@prosekit/svelte': patch
+---
+
+fix editor dispose lifecycle error

--- a/.changeset/strong-poems-divide.md
+++ b/.changeset/strong-poems-divide.md
@@ -3,4 +3,4 @@
 '@prosekit/svelte': patch
 ---
 
-fix editor dispose lifecycle error
+Fix a bug in `useEditor` that causes `Function called outside component initialization` errors.

--- a/.changeset/strong-poems-divide.md
+++ b/.changeset/strong-poems-divide.md
@@ -1,4 +1,5 @@
 ---
+'prosekit': patch
 '@prosekit/svelte': patch
 ---
 

--- a/packages/svelte/src/hooks/use-editor.ts
+++ b/packages/svelte/src/hooks/use-editor.ts
@@ -6,7 +6,7 @@ import {
   type Extension,
   ProseKitError,
 } from '@prosekit/core'
-import { onDestroy, onMount } from 'svelte'
+import { onMount } from 'svelte'
 import { readonly, writable, type Readable } from 'svelte/store'
 
 import { useEditorContext } from '../contexts/editor-context'
@@ -46,7 +46,9 @@ export function useEditor<E extends Extension = any>(options?: {
         defineUpdateHandler(forceUpdate),
       ])
       const dispose = editor.use(extension)
-      onDestroy(dispose)
+      return () => {
+        dispose()
+      }
     })
   }
 


### PR DESCRIPTION
Closes: #607 

`onDestroy` runs on both server and client, but `onMount` (and the destroy function you return) only runs on the client.