### PR TITLE
docs: add Svelte save-json example

### DIFF
--- a/playground/example.meta.ts
+++ b/playground/example.meta.ts
@@ -1397,6 +1397,17 @@ export const exampleMeta = {
       ]
     },
     {
+      "name": "svelte-save-json",
+      "framework": "svelte",
+      "story": "save-json",
+      "files": [
+        {
+          "path": "editor.svelte",
+          "hidden": false
+        }
+      ]
+    },
+    {
       "name": "svelte-slash-menu",
       "framework": "svelte",
       "story": "slash-menu",

--- a/playground/example.meta.yaml
+++ b/playground/example.meta.yaml
@@ -727,6 +727,12 @@ examples:
         hidden: false
       - path: button.svelte
         hidden: false
+  - name: svelte-save-json
+    framework: svelte
+    story: save-json
+    files:
+      - path: editor.svelte
+        hidden: false
   - name: svelte-slash-menu
     framework: svelte
     story: slash-menu

--- a/playground/examples/svelte-save-json/editor.svelte
+++ b/playground/examples/svelte-save-json/editor.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+import 'prosekit/basic/style.css'
+
+import { defineBasicExtension } from 'prosekit/basic'
+import { createEditor, jsonFromNode, type NodeJSON } from 'prosekit/core'
+import { ProseKit, useDocChange } from 'prosekit/svelte'
+
+let defaultDoc: NodeJSON | undefined
+let hasUnsavedChange = false
+let records: string[] = []
+let key = 1
+
+const extension = defineBasicExtension()
+const editor = createEditor({ extension, defaultDoc })
+
+useDocChange(() => (hasUnsavedChange = true), { editor })
+
+// Save the current document as a JSON string
+function handleSave() {
+  const record = JSON.stringify(jsonFromNode(editor.view.state.doc))
+  records = [...records, record]
+  hasUnsavedChange = false
+}
+
+// Load a document from a JSON string
+function handleLoad(record: string) {
+  defaultDoc = JSON.parse(record)
+  key += 1
+  hasUnsavedChange = false
+}
+
+const mount = (element: HTMLElement) => {
+  editor.mount(element)
+  return { destroy: () => editor.unmount() }
+}
+</script>
+
+<ProseKit {editor}>
+  <div
+    class="box-border h-full w-full min-h-36 overflow-y-hidden overflow-x-hidden rounded-md border border-solid border-gray-200 shadow dark:border-zinc-700 flex flex-col bg-white dark:bg-neutral-900"
+  >
+    <button
+      on:click={handleSave}
+      disabled={!hasUnsavedChange}
+      class="m-1 border border-solid bg-white px-2 py-1 text-sm text-black disabled:cursor-not-allowed disabled:text-gray-500"
+    >
+      {hasUnsavedChange ? 'Save' : 'No changes to save'}
+    </button>
+    <ul class="border-b border-t border-solid text-sm">
+      {#each records as record}
+        <li class="m-1 flex gap-2">
+          <button
+            class="border border-solid bg-white px-2 py-1 text-black"
+            on:click={() => handleLoad(record)}
+          >
+            Load
+          </button>
+          <span class="flex-1 overflow-x-scroll p-2">
+            <pre>{record}</pre>
+          </span>
+        </li>
+      {/each}
+    </ul>
+    <div class="relative w-full flex-1 box-border overflow-y-scroll">
+      <div
+        use:mount
+        class="ProseMirror box-border min-h-full px-[max(40px,_calc(50%-330px))] py-[24px] outline-none outline-0 [&_span[data-mention='user']]:text-blue-500 [&_span[data-mention='tag']]:text-violet-500 [&_pre]:text-white [&_pre]:bg-zinc-800"
+      ></div>
+    </div>
+  </div>
+</ProseKit>

--- a/playground/src/pages/[example].astro
+++ b/playground/src/pages/[example].astro
@@ -64,6 +64,7 @@ import E889141525 from '../../examples/svelte-italic/editor.svelte'
 import E3351045146 from '../../examples/svelte-keymap/editor.svelte'
 import E2194307417 from '../../examples/svelte-list/editor.svelte'
 import E3540862095 from '../../examples/svelte-readonly/editor.svelte'
+import E2208676421 from '../../examples/svelte-save-json/editor.svelte'
 import E1602218818 from '../../examples/svelte-slash-menu/editor.svelte'
 import E1967201386 from '../../examples/svelte-text-align/editor.svelte'
 import E4074649968 from '../../examples/svelte-toolbar/editor.svelte'
@@ -139,6 +140,7 @@ export const getStaticPaths = () => [
   { params: { example: 'svelte-keymap' } },
   { params: { example: 'svelte-list' } },
   { params: { example: 'svelte-readonly' } },
+  { params: { example: 'svelte-save-json' } },
   { params: { example: 'svelte-slash-menu' } },
   { params: { example: 'svelte-text-align' } },
   { params: { example: 'svelte-toolbar' } },
@@ -218,6 +220,7 @@ const { example } = Astro.params
   {example === 'svelte-keymap' && <E3351045146 client:only="svelte" />}
   {example === 'svelte-list' && <E2194307417 client:only="svelte" />}
   {example === 'svelte-readonly' && <E3540862095 client:only="svelte" />}
+  {example === 'svelte-save-json' && <E2208676421 client:only="svelte" />}
   {example === 'svelte-slash-menu' && <E1602218818 client:only="svelte" />}
   {example === 'svelte-text-align' && <E1967201386 client:only="svelte" />}
   {example === 'svelte-toolbar' && <E4074649968 client:only="svelte" />}

--- a/playground/src/pages/index.astro
+++ b/playground/src/pages/index.astro
@@ -68,6 +68,7 @@ import BaseLayout from '../layouts/base-layout.astro'
   <p><a href="/_/svelte-keymap">svelte-keymap</a></p>
   <p><a href="/_/svelte-list">svelte-list</a></p>
   <p><a href="/_/svelte-readonly">svelte-readonly</a></p>
+  <p><a href="/_/svelte-save-json">svelte-save-json</a></p>
   <p><a href="/_/svelte-slash-menu">svelte-slash-menu</a></p>
   <p><a href="/_/svelte-text-align">svelte-text-align</a></p>
   <p><a href="/_/svelte-toolbar">svelte-toolbar</a></p>

--- a/website/example-code-blocks/save-json/editor.md
+++ b/website/example-code-blocks/save-json/editor.md
@@ -22,4 +22,14 @@
 
 </template>
 
+<template v-slot:svelte>
+
+::: code-group
+
+<<< @/../playground/examples/svelte-save-json/editor.svelte
+
+:::
+
+</template>
+
 </FrameworkCodeBlock>

--- a/website/examples/save-json.md
+++ b/website/examples/save-json.md
@@ -27,4 +27,14 @@ import { FrameworkCodeBlock } from '@/.vitepress/components/framework-code-block
 
 </template>
 
+<template v-slot:svelte>
+
+::: code-group
+
+<<< @/../playground/examples/svelte-save-json/editor.svelte
+
+:::
+
+</template>
+
 </ExamplePreview>


### PR DESCRIPTION
Spent a few hours, but failed to re-instantiate the `editor` with the new doc after `handleLoad` gets called. 🙁 

Marking as a draft until I get it right, (will try other examples in the meantime)

Should anyone figure out how to re-render of the `editor` when the `defaultDoc` or `key` changes, please help. 🙂 