### PR TITLE
fix: add correct contentRef param type

### DIFF
--- a/packages/svelte/src/node-view/types.ts
+++ b/packages/svelte/src/node-view/types.ts
@@ -13,7 +13,7 @@ import type { Writable } from 'svelte/store'
  */
 export interface SvelteNodeViewProps {
   // won't change
-  contentRef: (node: HTMLElement | null) => void
+  contentRef: (node: Element | null) => void
   view: EditorView
   getPos: () => number | undefined
   setAttrs: (attrs: Attrs) => void


### PR DESCRIPTION
Before I add a changeset, please let me know if I'm wrong here @ocavue 

Trying to bind an element, e.g `pre`, to the `contentRef` prop errors:

```
Type 'HTMLPreElement' is not assignable to type '(node: HTMLElement | null) => void'.
  Type 'HTMLPreElement' provides no match for the signature '(node: HTMLElement | null): void'.ts(2322)
```

<img width="1422" alt="Screenshot 2024-07-07 at 21 25 11" src="https://github.com/prosekit/prosekit/assets/87414827/41a9a59e-cd36-46d6-880d-f59a25710ee3">
