### PR TITLE
fix(core): handle mark isActive correctly for empty text block selections

### DIFF
--- a/.changeset/4000.md
+++ b/.changeset/4000.md
@@ -1,4 +1,5 @@
 ---
+'prosekit': patch
 '@prosekit/core': patch
 ---
 

--- a/.changeset/4000.md
+++ b/.changeset/4000.md
@@ -1,0 +1,5 @@
+---
+'@prosekit/core': patch
+---
+
+Fix an issue where the `MarkAction.isActive()` always returns `true` when multiple empty text blocks are selected.

--- a/packages/core/src/editor/action.spec.ts
+++ b/packages/core/src/editor/action.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { setupTest } from '../testing'
+
+describe('MarkAction', () => {
+  const { editor, m, n } = setupTest()
+
+  it('can check mark activity', () => {
+    editor.set(n.doc(n.p('<a>foo<b>')))
+    expect(editor.marks.bold.isActive()).toBe(false)
+    expect(editor.marks.italic.isActive()).toBe(false)
+
+    editor.set(n.doc(n.p('<a>', m.bold('foo'), '<b>')))
+    expect(editor.marks.bold.isActive()).toBe(true)
+    expect(editor.marks.italic.isActive()).toBe(false)
+  })
+
+  it('can check mark activity for cross-paragraph selection', () => {
+    editor.set(n.doc(n.p('<a>', m.bold('foo')), n.p(m.bold('foo'), '<b>')))
+
+    expect(editor.marks.bold.isActive()).toBe(true)
+    expect(editor.marks.italic.isActive()).toBe(false)
+  })
+
+  it('should not set isActive to true when only part of the text is marked', () => {
+    editor.set(n.doc(n.p('<a>', 'foo', m.bold('bar'), 'baz', '<b>')))
+    expect(editor.marks.bold.isActive()).toBe(false)
+
+    editor.set(n.doc(n.p('<a>', m.bold('foo'), 'bar', '<b>')))
+    expect(editor.marks.bold.isActive()).toBe(false)
+
+    editor.set(n.doc(n.p('<a>', 'foo', m.bold('bar'), '<b>')))
+    expect(editor.marks.bold.isActive()).toBe(false)
+
+    editor.set(n.doc(n.p('<a>', m.bold('foo', 'bar'), '<b>')))
+    expect(editor.marks.bold.isActive()).toBe(true)
+  })
+
+  it('should not set isActive to true when multiple empty paragraphs are selected', () => {
+    editor.set(n.doc(n.p('<a>'), n.p(''), n.p('<b>')))
+    expect(editor.marks.bold.isActive()).toBe(false)
+  })
+})

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -46,6 +46,21 @@ function defineHeading() {
   })
 }
 
+function defineCodeBlock() {
+  return defineNodeSpec({
+    name: 'codeBlock',
+    content: 'text*',
+    group: 'block',
+    code: true,
+    defining: true,
+    marks: '',
+    attrs: { language: { default: '' } },
+    toDOM() {
+      return ['pre', ['code', 0]]
+    },
+  })
+}
+
 /**
  * @internal
  */
@@ -60,6 +75,7 @@ export function defineTestExtension() {
     defineBold(),
     defineItalic(),
     defineHeading(),
+    defineCodeBlock(),
   ])
 }
 
@@ -90,5 +106,11 @@ export function setupTestFromExtension<E extends Extension>(
  * @internal
  */
 export function setupTest() {
-  return setupTestFromExtension(defineTestExtension())
+  const { editor, m, n } = setupTestFromExtension(defineTestExtension())
+
+  return {
+    editor,
+    m,
+    n: { ...n, p: n.paragraph },
+  }
 }

--- a/packages/core/src/utils/includes-mark.ts
+++ b/packages/core/src/utils/includes-mark.ts
@@ -1,0 +1,14 @@
+import type { Attrs, Mark, MarkType } from '@prosekit/pm/model'
+
+import { isSubset } from './is-subset'
+
+export function includesMark(
+  marks: readonly Mark[],
+  markType: MarkType,
+  attrs?: Attrs | null,
+): boolean {
+  attrs = attrs || {}
+  return marks.some((mark) => {
+    return mark.type === markType && isSubset(attrs, mark.attrs)
+  })
+}

--- a/packages/core/src/utils/is-mark-absent.spec.ts
+++ b/packages/core/src/utils/is-mark-absent.spec.ts
@@ -35,8 +35,8 @@ test('isMarkAbsent', () => {
   expect(isBoldAbsent()).toBe(true)
 
   editor.set(n.doc(n.p('<a>'), n.p(''), n.p(''), n.p('<b>')))
-  expect(isBoldAbsent()).toBe(null)
+  expect(isBoldAbsent()).toBe(true)
 
   editor.set(n.doc(n.codeBlock('<a>', m.bold('foo'), '<b>')))
-  expect(isBoldAbsent()).toBe(null)
+  expect(isBoldAbsent()).toBe(true)
 })

--- a/packages/core/src/utils/is-mark-absent.spec.ts
+++ b/packages/core/src/utils/is-mark-absent.spec.ts
@@ -37,6 +37,14 @@ test('isMarkAbsent', () => {
   editor.set(n.doc(n.p('<a>'), n.p(''), n.p(''), n.p('<b>')))
   expect(isBoldAbsent()).toBe(true)
 
+  editor.set(
+    n.doc(n.p('<a>'), n.p(m.bold('foo')), n.p(m.bold('bar')), n.p('<b>')),
+  )
+  expect(isBoldAbsent()).toBe(false)
+
+  editor.set(n.doc(n.p('<a>'), n.p(m.bold('foo')), n.p(), n.p('<b>')))
+  expect(isBoldAbsent()).toBe(false)
+
   editor.set(n.doc(n.codeBlock('<a>', m.bold('foo'), '<b>')))
   expect(isBoldAbsent()).toBe(true)
 })

--- a/packages/core/src/utils/is-mark-absent.spec.ts
+++ b/packages/core/src/utils/is-mark-absent.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from 'vitest'
+
+import { setupTest } from '../testing'
+
+import { isMarkAbsent } from './is-mark-absent'
+
+test('isMarkAbsent', () => {
+  const { editor, m, n } = setupTest()
+
+  const isBoldAbsent = () => {
+    const markType = editor.schema.marks.bold
+    const { doc, selection } = editor.state
+    return isMarkAbsent(doc, selection.from, selection.to, markType)
+  }
+
+  editor.set(n.doc(n.p('<a>foo<b>')))
+  expect(isBoldAbsent()).toBe(true)
+
+  editor.set(n.doc(n.p('<a>', m.bold('foo'), '<b>')))
+  expect(isBoldAbsent()).toBe(false)
+
+  editor.set(n.doc(n.p('<a>', 'foo', m.bold('bar'), 'baz', '<b>')))
+  expect(isBoldAbsent()).toBe(true)
+
+  editor.set(n.doc(n.p('<a>', m.bold('foo'), 'bar', '<b>')))
+  expect(isBoldAbsent()).toBe(true)
+
+  editor.set(n.doc(n.p('<a>', 'foo', m.bold('bar'), '<b>')))
+  expect(isBoldAbsent()).toBe(true)
+
+  editor.set(n.doc(n.p('<a>'), n.p('foo'), n.p('<b>')))
+  expect(isBoldAbsent()).toBe(true)
+
+  editor.set(n.doc(n.p('<a>'), n.p('foo'), n.p(m.bold('bar')), n.p('<b>')))
+  expect(isBoldAbsent()).toBe(true)
+
+  editor.set(n.doc(n.p('<a>'), n.p(''), n.p(''), n.p('<b>')))
+  expect(isBoldAbsent()).toBe(null)
+
+  editor.set(n.doc(n.codeBlock('<a>', m.bold('foo'), '<b>')))
+  expect(isBoldAbsent()).toBe(null)
+})

--- a/packages/core/src/utils/is-mark-absent.ts
+++ b/packages/core/src/utils/is-mark-absent.ts
@@ -5,7 +5,7 @@ import { includesMark } from './includes-mark'
 /**
  * Returns true if the given mark is missing in some part of the range.
  * Returns false if the entire range has the given mark.
- * Returns null if the mark is not allowed in the range.
+ * Returns true if the mark is not allowed in the range.
  *
  * @internal
  */
@@ -15,7 +15,7 @@ export function isMarkAbsent(
   to: number,
   markType: MarkType,
   attrs?: Attrs | null,
-): boolean | null {
+): boolean {
   let missing = false
   let available = false
 
@@ -35,5 +35,5 @@ export function isMarkAbsent(
       }
     }
   })
-  return available ? missing : null
+  return available ? missing : true
 }

--- a/packages/core/src/utils/is-mark-active.ts
+++ b/packages/core/src/utils/is-mark-active.ts
@@ -1,7 +1,8 @@
-import type { Attrs, Mark, MarkType } from '@prosekit/pm/model'
+import type { Attrs, MarkType } from '@prosekit/pm/model'
 import type { EditorState } from '@prosekit/pm/state'
 
 import { getMarkType } from './get-mark-type'
+import { includesMark } from './includes-mark'
 import { isMarkAbsent } from './is-mark-absent'
 
 /**
@@ -15,9 +16,10 @@ export function isMarkActive(
   const { from, $from, to, empty } = state.selection
   const markType = getMarkType(state.schema, type)
   if (empty) {
-    const mark: Mark | MarkType = attrs ? markType.create(attrs) : markType
-    return !!mark.isInSet(state.storedMarks || $from.marks())
+    const marks = state.storedMarks || $from.marks()
+    return includesMark(marks, markType, attrs)
   } else {
-    return !isMarkAbsent(state.doc, from, to, markType, attrs)
+    const absent = isMarkAbsent(state.doc, from, to, markType, attrs)
+    return absent === null ? false : !absent
   }
 }

--- a/packages/core/src/utils/is-mark-active.ts
+++ b/packages/core/src/utils/is-mark-active.ts
@@ -19,7 +19,6 @@ export function isMarkActive(
     const marks = state.storedMarks || $from.marks()
     return includesMark(marks, markType, attrs)
   } else {
-    const absent = isMarkAbsent(state.doc, from, to, markType, attrs)
-    return absent === null ? false : !absent
+    return !isMarkAbsent(state.doc, from, to, markType, attrs)
   }
 }

--- a/packages/core/src/utils/is-subset.spec.ts
+++ b/packages/core/src/utils/is-subset.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest'
+
+import { isSubset } from './is-subset'
+
+test('isSubset', () => {
+  expect(isSubset({ a: 1, b: 2 }, { a: 1, b: 2, c: 3 })).toBe(true)
+  expect(isSubset({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 })).toBe(false)
+  expect(isSubset({ a: 1, b: 2, c: 3 }, { a: 1, b: 2, c: 4 })).toBe(false)
+})

--- a/packages/core/src/utils/is-subset.ts
+++ b/packages/core/src/utils/is-subset.ts
@@ -1,0 +1,11 @@
+/**
+ * Check if `subset` is a subset of `superset`.
+ *
+ * @internal
+ */
+export function isSubset(
+  subset: Record<string, unknown>,
+  superset: Record<string, unknown>,
+) {
+  return Object.keys(subset).every((key) => subset[key] === superset[key])
+}


### PR DESCRIPTION
Before:

<img width="424" alt="image" src="https://github.com/user-attachments/assets/74efcfb5-90d1-48ad-b6d9-a92cf4fb5bb7">


After:

<img width="384" alt="image" src="https://github.com/user-attachments/assets/802b92ca-32fc-42df-88a1-be1a235891b7">

