### PR TITLE
fix(markAction): keep the original marks

### DIFF
--- a/packages/core/src/editor/action.ts
+++ b/packages/core/src/editor/action.ts
@@ -140,7 +140,7 @@ const defaultApplyMark: ApplyMarkFunction = (
   mark: Mark,
   children: ProseMirrorNode[],
 ): ProseMirrorNode[] => {
-  return children.map((child) => child.mark([mark]))
+  return children.map((child) => child.mark([...child.marks, mark]))
 }
 
 export function buildNode(

--- a/packages/core/src/test/test-builder.ts
+++ b/packages/core/src/test/test-builder.ts
@@ -61,7 +61,7 @@ export const applyMarkForTest: ApplyMarkFunction = (
   children: TaggedProseMirrorNode[],
 ): TaggedProseMirrorNode[] => {
   return children.map((node) => {
-    const newNode: TaggedProseMirrorNode = node.mark([mark])
+    const newNode: TaggedProseMirrorNode = node.mark([...node.marks, mark])
     newNode.tags = node.tags
     return newNode
   })


### PR DESCRIPTION
I believe that when applying marks, it may be more in line with expectations to retain the existing marks and only add the necessary ones.