### PR TITLE
fix(table-handle): fix overflow in a small viewport

### DIFF
--- a/packages/web/src/components/table-handle/table-handle-popover-content/props.ts
+++ b/packages/web/src/components/table-handle/table-handle-popover-content/props.ts
@@ -18,7 +18,7 @@ export interface TableHandlePopoverContentProps
 
 export const defaultTableHandlePopoverContentProps = Object.freeze({
   ...defaultMenuContentProps,
-  placement: 'bottom-start',
+  placement: 'right-start',
   offset: { mainAxis: -4, crossAxis: 4 },
   editor: null,
 } satisfies TableHandlePopoverContentProps)


### PR DESCRIPTION
**Before**

<img width="459" alt="image" src="https://github.com/user-attachments/assets/cc34ef47-ff36-46e6-9961-d04ed31df6f4">
<img width="456" alt="image" src="https://github.com/user-attachments/assets/a842fefe-1f84-44bf-9a3b-eec04f6cd791">
<img width="452" alt="image" src="https://github.com/user-attachments/assets/04221ddf-1616-4acc-8df3-4d01215ceae1">



**After**


<img width="448" alt="image" src="https://github.com/user-attachments/assets/1e092473-bd7d-43eb-8e9d-56b6cd56bed7">
<img width="451" alt="image" src="https://github.com/user-attachments/assets/e9e4600e-c0a9-465a-9e9d-5679423bb7f5">
<img width="450" alt="image" src="https://github.com/user-attachments/assets/31240ff8-30bb-448a-b499-3e0945d04efa">
