### PR TITLE
chore: switch vitest coverage provider to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "@size-limit/esbuild-why": "^11.1.5",
     "@size-limit/preset-small-lib": "^11.1.5",
     "@unocss/eslint-config": "^0.62.4",
-    "@vitest/browser": "^2.1.1",
-    "@vitest/coverage-istanbul": "^2.1.1",
+    "@vitest/browser": "^2.1.2",
+    "@vitest/coverage-v8": "^2.1.2",
     "cross-env": "^7.0.3",
     "eslint": "^9.10.0",
     "eslint-plugin-command": "^0.2.5",
@@ -48,7 +48,7 @@
     "turbo": "^2.1.2",
     "typescript": "^5.6.2",
     "unocss": "^0.62.4",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.2"
   },
   "pnpm": {
     "overrides": {},

--- a/packages/basic/package.json
+++ b/packages/basic/package.json
@@ -47,7 +47,7 @@
     "postcss-nesting": "^13.0.0",
     "tsup": "^8.3.0",
     "typescript": "^5.6.2",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.2"
   },
   "publishConfig": {
     "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,10 +46,10 @@
   },
   "devDependencies": {
     "@prosekit/dev": "workspace:*",
-    "@vitest/browser": "^2.1.1",
+    "@vitest/browser": "^2.1.2",
     "tsup": "^8.3.0",
     "typescript": "^5.6.2",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.2"
   },
   "publishConfig": {
     "exports": {

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -49,6 +49,6 @@
     "just-pascal-case": "^3.2.0",
     "tsx": "^4.19.1",
     "typescript": "^5.6.2",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.2"
   }
 }

--- a/packages/dev/src/config-vitest.js
+++ b/packages/dev/src/config-vitest.js
@@ -2,6 +2,9 @@ import { defineProject } from 'vitest/config'
 
 /** @type {import('vitest/config').UserProjectConfigExport} */
 const config = defineProject({
+  optimizeDeps: {
+    include: ['@vitest/coverage-v8/browser', '@vue/test-utils'],
+  },
   test: {
     browser: {
       enabled: true,

--- a/packages/dev/src/config-vitest.js
+++ b/packages/dev/src/config-vitest.js
@@ -3,7 +3,7 @@ import { defineProject } from 'vitest/config'
 /** @type {import('vitest/config').UserProjectConfigExport} */
 const config = defineProject({
   optimizeDeps: {
-    include: ['@vitest/coverage-v8/browser', '@vue/test-utils'],
+    include: ['@vitest/coverage-v8/browser'],
   },
   test: {
     browser: {

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -106,14 +106,14 @@
   },
   "devDependencies": {
     "@prosekit/dev": "workspace:*",
-    "@vitest/browser": "^2.1.1",
+    "@vitest/browser": "^2.1.2",
     "just-pick": "^4.2.0",
     "loro-crdt": "^0.16.12",
     "loro-prosemirror": "^0.0.7",
     "tsup": "^8.3.0",
     "type-fest": "^4.26.1",
     "typescript": "^5.6.2",
-    "vitest": "^2.1.1",
+    "vitest": "^2.1.2",
     "y-prosemirror": "^1.2.12",
     "y-protocols": "^1.0.6",
     "yjs": "^13.6.19"

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -48,7 +48,7 @@
     "@prosekit/dev": "workspace:*",
     "tsup": "^8.3.0",
     "typescript": "^5.6.2",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.2"
   },
   "publishConfig": {
     "exports": {

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -57,7 +57,7 @@
     "@prosekit/dev": "workspace:*",
     "tsup": "^8.3.0",
     "typescript": "^5.6.2",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.2"
   },
   "publishConfig": {
     "exports": {

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -60,7 +60,7 @@
     "preact": "^10.24.0",
     "tsup": "^8.3.0",
     "typescript": "^5.6.2",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.2"
   },
   "publishConfig": {
     "exports": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -68,7 +68,7 @@
     "react-dom": "^18.3.1",
     "tsup": "^8.3.0",
     "typescript": "^5.6.2",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.2"
   },
   "publishConfig": {
     "exports": {

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -60,7 +60,7 @@
     "solid-js": "^1.8.22",
     "tsup": "^8.3.0",
     "typescript": "^5.6.2",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.2"
   },
   "publishConfig": {
     "exports": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -84,7 +84,7 @@
     "svelte-check": "^4.0.2",
     "tsx": "^4.19.1",
     "typescript": "^5.6.2",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.2"
   },
   "publishConfig": {
     "exports": {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -41,6 +41,6 @@
     "prettier": "^3.3.3",
     "typescript": "^5.6.2",
     "unplugin-macros": "^0.13.3",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.2"
   }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -60,7 +60,7 @@
     "@vue/test-utils": "^2.4.6",
     "tsup": "^8.3.0",
     "typescript": "^5.6.2",
-    "vitest": "^2.1.1",
+    "vitest": "^2.1.2",
     "vue": "^3.5.6"
   },
   "publishConfig": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -62,7 +62,7 @@
     "@prosekit/dev": "workspace:*",
     "tsup": "^8.3.0",
     "typescript": "^5.6.2",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.2"
   },
   "publishConfig": {
     "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,11 +38,11 @@ importers:
         specifier: ^0.62.4
         version: 0.62.4(eslint@9.10.0(jiti@1.21.6))(typescript@5.6.2)
       '@vitest/browser':
-        specifier: ^2.1.1
-        version: 2.1.1(@vitest/spy@2.1.1)(playwright@1.47.1)(typescript@5.6.2)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))(vitest@2.1.1)
-      '@vitest/coverage-istanbul':
-        specifier: ^2.1.1
-        version: 2.1.1(vitest@2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2)))
+        specifier: ^2.1.2
+        version: 2.1.2(@vitest/spy@2.1.2)(playwright@1.47.1)(typescript@5.6.2)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))(vitest@2.1.2)
+      '@vitest/coverage-v8':
+        specifier: ^2.1.2
+        version: 2.1.2(@vitest/browser@2.1.2(@vitest/spy@2.1.2)(playwright@1.47.1)(typescript@5.6.2)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))(vitest@2.1.2))(vitest@2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2)))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -80,8 +80,8 @@ importers:
         specifier: ^0.62.4
         version: 0.62.4(postcss@8.4.47)(rollup@4.21.1)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+        specifier: ^2.1.2
+        version: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
 
   packages/basic:
     dependencies:
@@ -111,8 +111,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+        specifier: ^2.1.2
+        version: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
 
   packages/core:
     dependencies:
@@ -142,8 +142,8 @@ importers:
         specifier: workspace:*
         version: link:../dev
       '@vitest/browser':
-        specifier: ^2.1.1
-        version: 2.1.1(@vitest/spy@2.1.1)(playwright@1.47.1)(typescript@5.6.2)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))(vitest@2.1.1)
+        specifier: ^2.1.2
+        version: 2.1.2(@vitest/spy@2.1.2)(playwright@1.47.1)(typescript@5.6.2)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))(vitest@2.1.2)
       tsup:
         specifier: ^8.3.0
         version: 8.3.0(@microsoft/api-extractor@7.47.9(@types/node@20.16.5))(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.1)(typescript@5.6.2)(yaml@2.5.1)
@@ -151,8 +151,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+        specifier: ^2.1.2
+        version: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
 
   packages/dev:
     dependencies:
@@ -227,8 +227,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+        specifier: ^2.1.2
+        version: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
 
   packages/extensions:
     dependencies:
@@ -267,8 +267,8 @@ importers:
         specifier: workspace:*
         version: link:../dev
       '@vitest/browser':
-        specifier: ^2.1.1
-        version: 2.1.1(@vitest/spy@2.1.1)(playwright@1.47.1)(typescript@5.6.2)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))(vitest@2.1.1)
+        specifier: ^2.1.2
+        version: 2.1.2(@vitest/spy@2.1.2)(playwright@1.47.1)(typescript@5.6.2)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))(vitest@2.1.2)
       just-pick:
         specifier: ^4.2.0
         version: 4.2.0
@@ -288,8 +288,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+        specifier: ^2.1.2
+        version: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
       y-prosemirror:
         specifier: ^1.2.12
         version: 1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.34.2)(y-protocols@1.0.6(yjs@13.6.19))(yjs@13.6.19)
@@ -316,8 +316,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+        specifier: ^2.1.2
+        version: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
 
   packages/pm:
     dependencies:
@@ -356,8 +356,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+        specifier: ^2.1.2
+        version: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
 
   packages/preact:
     dependencies:
@@ -387,8 +387,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+        specifier: ^2.1.2
+        version: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
 
   packages/prosekit:
     dependencies:
@@ -518,8 +518,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+        specifier: ^2.1.2
+        version: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
 
   packages/solid:
     dependencies:
@@ -549,8 +549,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+        specifier: ^2.1.2
+        version: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
 
   packages/svelte:
     dependencies:
@@ -592,8 +592,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+        specifier: ^2.1.2
+        version: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
 
   packages/themes:
     dependencies:
@@ -620,8 +620,8 @@ importers:
         specifier: ^0.13.3
         version: 0.13.3(@types/node@20.16.5)(lightningcss@1.27.0)(rollup@4.21.1)
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+        specifier: ^2.1.2
+        version: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
 
   packages/unocss-preset:
     dependencies:
@@ -673,8 +673,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+        specifier: ^2.1.2
+        version: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
       vue:
         specifier: ^3.5.6
         version: 3.5.6(typescript@5.6.2)
@@ -737,8 +737,8 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+        specifier: ^2.1.2
+        version: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
 
   playground:
     devDependencies:
@@ -1334,6 +1334,9 @@ packages:
   '@babel/types@7.25.6':
     resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@bundled-es-modules/cookie@2.0.0':
     resolution: {integrity: sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==}
@@ -2778,12 +2781,12 @@ packages:
       vite: ^5.0.0
       vue: ^3.2.25
 
-  '@vitest/browser@2.1.1':
-    resolution: {integrity: sha512-wLKqohwlZI24xMIEZAPwv9SVliv1avaIBeE0ou471D++BRPhiw2mubKBczFFIDHXuSL7UXb8/JQK9Ui6ttW9bQ==}
+  '@vitest/browser@2.1.2':
+    resolution: {integrity: sha512-tqpGfz2sfjFFNuZ2iLZ6EGRVnH8z18O93ZIicbLsxDhiLgRNz84UcjSvX4pbheuddW+BJeNbLGdM3BU8vohbEg==}
     peerDependencies:
       playwright: '*'
       safaridriver: '*'
-      vitest: 2.1.1
+      vitest: 2.1.2
       webdriverio: '*'
     peerDependenciesMeta:
       playwright:
@@ -2793,18 +2796,22 @@ packages:
       webdriverio:
         optional: true
 
-  '@vitest/coverage-istanbul@2.1.1':
-    resolution: {integrity: sha512-ZQM8uLinwmhmLp49fxLxIM46nC7NisCbaiydcQoV1hLvQfFL92Gg3tInRvowZyV78G0IknjN10JzH7oqPlPjZw==}
+  '@vitest/coverage-v8@2.1.2':
+    resolution: {integrity: sha512-b7kHrFrs2urS0cOk5N10lttI8UdJ/yP3nB4JYTREvR5o18cR99yPpK4gK8oQgI42BVv0ILWYUSYB7AXkAUDc0g==}
     peerDependencies:
-      vitest: 2.1.1
+      '@vitest/browser': 2.1.2
+      vitest: 2.1.2
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
 
-  '@vitest/expect@2.1.1':
-    resolution: {integrity: sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==}
+  '@vitest/expect@2.1.2':
+    resolution: {integrity: sha512-FEgtlN8mIUSEAAnlvn7mP8vzaWhEaAEvhSXCqrsijM7K6QqjB11qoRZYEd4AKSCDz8p0/+yH5LzhZ47qt+EyPg==}
 
-  '@vitest/mocker@2.1.1':
-    resolution: {integrity: sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==}
+  '@vitest/mocker@2.1.2':
+    resolution: {integrity: sha512-ExElkCGMS13JAJy+812fw1aCv2QO/LBK6CyO4WOPAzLTmve50gydOlWhgdBJPx2ztbADUq3JVI0C5U+bShaeEA==}
     peerDependencies:
-      '@vitest/spy': 2.1.1
+      '@vitest/spy': 2.1.2
       msw: ^2.3.5
       vite: ^5.0.0
     peerDependenciesMeta:
@@ -2813,20 +2820,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@2.1.1':
-    resolution: {integrity: sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==}
+  '@vitest/pretty-format@2.1.2':
+    resolution: {integrity: sha512-FIoglbHrSUlOJPDGIrh2bjX1sNars5HbxlcsFKCtKzu4+5lpsRhOCVcuzp0fEhAGHkPZRIXVNzPcpSlkoZ3LuA==}
 
-  '@vitest/runner@2.1.1':
-    resolution: {integrity: sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==}
+  '@vitest/runner@2.1.2':
+    resolution: {integrity: sha512-UCsPtvluHO3u7jdoONGjOSil+uON5SSvU9buQh3lP7GgUXHp78guN1wRmZDX4wGK6J10f9NUtP6pO+SFquoMlw==}
 
-  '@vitest/snapshot@2.1.1':
-    resolution: {integrity: sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==}
+  '@vitest/snapshot@2.1.2':
+    resolution: {integrity: sha512-xtAeNsZ++aRIYIUsek7VHzry/9AcxeULlegBvsdLncLmNCR6tR8SRjn8BbDP4naxtccvzTqZ+L1ltZlRCfBZFA==}
 
-  '@vitest/spy@2.1.1':
-    resolution: {integrity: sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==}
+  '@vitest/spy@2.1.2':
+    resolution: {integrity: sha512-GSUi5zoy+abNRJwmFhBDC0yRuVUn8WMlQscvnbbXdKLXX9dE59YbfwXxuJ/mth6eeqIzofU8BB5XDo/Ns/qK2A==}
 
-  '@vitest/utils@2.1.1':
-    resolution: {integrity: sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==}
+  '@vitest/utils@2.1.2':
+    resolution: {integrity: sha512-zMO2KdYy6mx56btx9JvAqAZ6EyS3g49krMPPrgOp1yxGZiA93HumGk+bZ5jIZtOg5/VBYl5eBmGRQHqq4FG6uQ==}
 
   '@volar/language-core@2.4.1':
     resolution: {integrity: sha512-9AKhC7Qn2mQYxj7Dz3bVxeOk7gGJladhWixUYKef/o0o7Bm4an+A3XvmcTHVqZ8stE6lBVH++g050tBtJ4TZPQ==}
@@ -4643,10 +4650,6 @@ packages:
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
-
-  istanbul-lib-instrument@6.0.3:
-    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
-    engines: {node: '>=10'}
 
   istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
@@ -6871,6 +6874,11 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  vite-node@2.1.2:
+    resolution: {integrity: sha512-HPcGNN5g/7I2OtPjLqgOtCRu/qhVvBxTUD3qzitmL0SrG1cWFzxzhMDWussxSbrRYWqnKf8P2jiNhPMSN+ymsQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-plugin-inspect@0.8.5:
     resolution: {integrity: sha512-JvTUqsP1JNDw0lMZ5Z/r5cSj81VK2B7884LO1DC3GMBhdcjcsAnJjdWq7bzQL01Xbh+v60d3lju3g+z7eAtNew==}
     engines: {node: '>=14'}
@@ -6966,15 +6974,15 @@ packages:
       postcss:
         optional: true
 
-  vitest@2.1.1:
-    resolution: {integrity: sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==}
+  vitest@2.1.2:
+    resolution: {integrity: sha512-veNjLizOMkRrJ6xxb+pvxN6/QAWg95mzcRjtmkepXdN87FNfxAss9RKe2far/G9cQpipfgP2taqg0KiWsquj8A==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.1
-      '@vitest/ui': 2.1.1
+      '@vitest/browser': 2.1.2
+      '@vitest/ui': 2.1.2
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -7816,6 +7824,8 @@ snapshots:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
+
+  '@bcoe/v8-coverage@0.2.3': {}
 
   '@bundled-es-modules/cookie@2.0.0':
     dependencies:
@@ -9478,17 +9488,17 @@ snapshots:
       vite: 5.4.6(@types/node@20.16.5)(lightningcss@1.27.0)
       vue: 3.5.6(typescript@5.6.2)
 
-  '@vitest/browser@2.1.1(@vitest/spy@2.1.1)(playwright@1.47.1)(typescript@5.6.2)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))(vitest@2.1.1)':
+  '@vitest/browser@2.1.2(@vitest/spy@2.1.2)(playwright@1.47.1)(typescript@5.6.2)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))(vitest@2.1.2)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 2.1.1(@vitest/spy@2.1.1)(msw@2.4.7(typescript@5.6.2))(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))
-      '@vitest/utils': 2.1.1
+      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(msw@2.4.7(typescript@5.6.2))(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))
+      '@vitest/utils': 2.1.2
       magic-string: 0.30.11
       msw: 2.4.7(typescript@5.6.2)
       sirv: 2.0.4
       tinyrainbow: 1.2.0
-      vitest: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+      vitest: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
       ws: 8.18.0
     optionalDependencies:
       playwright: 1.47.1
@@ -9499,60 +9509,64 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-istanbul@2.1.1(vitest@2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2)))':
+  '@vitest/coverage-v8@2.1.2(@vitest/browser@2.1.2(@vitest/spy@2.1.2)(playwright@1.47.1)(typescript@5.6.2)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))(vitest@2.1.2))(vitest@2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2)))':
     dependencies:
-      '@istanbuljs/schema': 0.1.3
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
       debug: 4.3.7
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.1.7
+      magic-string: 0.30.11
       magicast: 0.3.5
+      std-env: 3.7.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+      vitest: 2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2))
+    optionalDependencies:
+      '@vitest/browser': 2.1.2(@vitest/spy@2.1.2)(playwright@1.47.1)(typescript@5.6.2)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))(vitest@2.1.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@2.1.1':
+  '@vitest/expect@2.1.2':
     dependencies:
-      '@vitest/spy': 2.1.1
-      '@vitest/utils': 2.1.1
+      '@vitest/spy': 2.1.2
+      '@vitest/utils': 2.1.2
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.1(@vitest/spy@2.1.1)(msw@2.4.7(typescript@5.6.2))(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))':
+  '@vitest/mocker@2.1.2(@vitest/spy@2.1.2)(msw@2.4.7(typescript@5.6.2))(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))':
     dependencies:
-      '@vitest/spy': 2.1.1
+      '@vitest/spy': 2.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.11
     optionalDependencies:
       msw: 2.4.7(typescript@5.6.2)
       vite: 5.4.6(@types/node@20.16.5)(lightningcss@1.27.0)
 
-  '@vitest/pretty-format@2.1.1':
+  '@vitest/pretty-format@2.1.2':
     dependencies:
       tinyrainbow: 1.2.0
 
-  '@vitest/runner@2.1.1':
+  '@vitest/runner@2.1.2':
     dependencies:
-      '@vitest/utils': 2.1.1
+      '@vitest/utils': 2.1.2
       pathe: 1.1.2
 
-  '@vitest/snapshot@2.1.1':
+  '@vitest/snapshot@2.1.2':
     dependencies:
-      '@vitest/pretty-format': 2.1.1
+      '@vitest/pretty-format': 2.1.2
       magic-string: 0.30.11
       pathe: 1.1.2
 
-  '@vitest/spy@2.1.1':
+  '@vitest/spy@2.1.2':
     dependencies:
       tinyspy: 3.0.0
 
-  '@vitest/utils@2.1.1':
+  '@vitest/utils@2.1.2':
     dependencies:
-      '@vitest/pretty-format': 2.1.1
+      '@vitest/pretty-format': 2.1.2
       loupe: 3.1.1
       tinyrainbow: 1.2.0
 
@@ -11753,16 +11767,6 @@ snapshots:
   isomorphic.js@0.2.5: {}
 
   istanbul-lib-coverage@3.2.2: {}
-
-  istanbul-lib-instrument@6.0.3:
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/parser': 7.25.6
-      '@istanbuljs/schema': 0.1.3
-      istanbul-lib-coverage: 3.2.2
-      semver: 7.6.3
-    transitivePeerDependencies:
-      - supports-color
 
   istanbul-lib-report@3.0.1:
     dependencies:
@@ -14382,6 +14386,23 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.2(@types/node@20.16.5)(lightningcss@1.27.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.7
+      pathe: 1.1.2
+      vite: 5.4.6(@types/node@20.16.5)(lightningcss@1.27.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-plugin-inspect@0.8.5(rollup@4.21.1)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0)):
     dependencies:
       '@antfu/utils': 0.7.10
@@ -14512,15 +14533,15 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@2.1.1(@types/node@20.16.5)(@vitest/browser@2.1.1)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2)):
+  vitest@2.1.2(@types/node@20.16.5)(@vitest/browser@2.1.2)(jsdom@24.1.3)(lightningcss@1.27.0)(msw@2.4.7(typescript@5.6.2)):
     dependencies:
-      '@vitest/expect': 2.1.1
-      '@vitest/mocker': 2.1.1(@vitest/spy@2.1.1)(msw@2.4.7(typescript@5.6.2))(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))
-      '@vitest/pretty-format': 2.1.1
-      '@vitest/runner': 2.1.1
-      '@vitest/snapshot': 2.1.1
-      '@vitest/spy': 2.1.1
-      '@vitest/utils': 2.1.1
+      '@vitest/expect': 2.1.2
+      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(msw@2.4.7(typescript@5.6.2))(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))
+      '@vitest/pretty-format': 2.1.2
+      '@vitest/runner': 2.1.2
+      '@vitest/snapshot': 2.1.2
+      '@vitest/spy': 2.1.2
+      '@vitest/utils': 2.1.2
       chai: 5.1.1
       debug: 4.3.7
       magic-string: 0.30.11
@@ -14531,11 +14552,11 @@ snapshots:
       tinypool: 1.0.0
       tinyrainbow: 1.2.0
       vite: 5.4.6(@types/node@20.16.5)(lightningcss@1.27.0)
-      vite-node: 2.1.1(@types/node@20.16.5)(lightningcss@1.27.0)
+      vite-node: 2.1.2(@types/node@20.16.5)(lightningcss@1.27.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.16.5
-      '@vitest/browser': 2.1.1(@vitest/spy@2.1.1)(playwright@1.47.1)(typescript@5.6.2)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))(vitest@2.1.1)
+      '@vitest/browser': 2.1.2(@vitest/spy@2.1.2)(playwright@1.47.1)(typescript@5.6.2)(vite@5.4.6(@types/node@20.16.5)(lightningcss@1.27.0))(vitest@2.1.2)
       jsdom: 24.1.3
     transitivePeerDependencies:
       - less

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     coverage: {
       enabled: false,
       all: false,
-      provider: 'istanbul',
+      provider: 'v8',
     },
     browser: {
       enabled: true,


### PR DESCRIPTION
Hope this can resolve the following warning:

```
[vitest] Vite unexpectedly reloaded a test. This may cause tests to fail, lead to flaky behaviour or duplicated test runs.
For a stable experience, please add mentioned dependencies to your config's `optimizeDeps.include` field manually.
10:13:23 AM [vite] ✨ new dependencies optimized: @vitest/coverage-istanbul
10:13:23 AM [vite] ✨ optimized dependencies changed. reloading

```