### PR TITLE
docs: fix typo in typography import example

### DIFF
--- a/packages/prosekit/CHANGELOG.md
+++ b/packages/prosekit/CHANGELOG.md
@@ -948,7 +948,7 @@
 
   ```js
   import 'prosekit/basic/style.css'
-  import 'prosekit/basic/typograph.css'
+  import 'prosekit/basic/typography.css'
   ```
 
 ### Patch Changes

--- a/website/guide/get-started.md
+++ b/website/guide/get-started.md
@@ -90,7 +90,7 @@ import 'prosekit/basic/typography.css'
 
 The `prosekit/basic/style.css` file provides essential styles to ensure the editor displays correctly.
 
-The `prosekit/basic/typography.css` file offers basic typographic styles for the editor, like margins, paddings, and font sizes. This is optional, and you can exclude it if you wish to use your own styles.
+The `prosekit/basic/typography.css` file offers basic typography styles for the editor, like margins, paddings, and font sizes. This is optional, and you can exclude it if you wish to use your own styles.
 
 <!-- References -->
 

--- a/website/guide/get-started.md
+++ b/website/guide/get-started.md
@@ -85,12 +85,12 @@ import 'prosekit/basic/style.css'
 ```
 
 ```ts twoslash
-import 'prosekit/basic/typograph.css'
+import 'prosekit/basic/typography.css'
 ```
 
 The `prosekit/basic/style.css` file provides essential styles to ensure the editor displays correctly.
 
-The `prosekit/basic/typograph.css` file offers basic typographic styles for the editor, like margins, paddings, and font sizes. This is optional, and you can exclude it if you wish to use your own styles.
+The `prosekit/basic/typography.css` file offers basic typographic styles for the editor, like margins, paddings, and font sizes. This is optional, and you can exclude it if you wish to use your own styles.
 
 <!-- References -->
 


### PR DESCRIPTION
Fixes a typo in css file import example of styling docs
https://prosekit.dev/guide/get-started#styling