### PR TITLE
fix: remove placeholder text from empty table cells

### DIFF
--- a/.changeset/moody-garlics-dress.md
+++ b/.changeset/moody-garlics-dress.md
@@ -1,4 +1,5 @@
 ---
+'prosekit': patch
 '@prosekit/extensions': minor
 ---
 

--- a/.changeset/moody-garlics-dress.md
+++ b/.changeset/moody-garlics-dress.md
@@ -1,0 +1,5 @@
+---
+'@prosekit/extensions': minor
+---
+
+Fix: Removed placeholder text from empty table cells.

--- a/packages/extensions/src/placeholder/index.ts
+++ b/packages/extensions/src/placeholder/index.ts
@@ -1,4 +1,9 @@
-import { definePlugin, isInCodeBlock, maybeRun } from '@prosekit/core'
+import {
+  definePlugin,
+  findParentNode,
+  isInCodeBlock,
+  maybeRun,
+} from '@prosekit/core'
 import type { ProseMirrorNode } from '@prosekit/pm/model'
 import { type EditorState, Plugin, PluginKey } from '@prosekit/pm/state'
 import { Decoration, DecorationSet } from '@prosekit/pm/view'
@@ -70,6 +75,9 @@ function createPlaceholderDecoration(
   const $pos = selection.$anchor
   const node = $pos.parent
   if (node.content.size > 0) return null
+
+  const inTable = findParentNode((node) => node.type.name === 'table', $pos)
+  if (inTable) return null
 
   const before = $pos.before()
 


### PR DESCRIPTION
remove placeholder text from empty table cells.

<img width="1097" alt="Screenshot 2024-11-25 at 8 22 49 PM" src="https://github.com/user-attachments/assets/21928aec-c6be-4342-a766-5dda5507780b">
