### PR TITLE
chore: add /.well-known/assetlinks.json to remove Chrome lookalike warnings

### DIFF
--- a/website/public/.well-known/assetlinks.json
+++ b/website/public/.well-known/assetlinks.json
@@ -1,0 +1,4 @@
+[
+  { "relation": ["lookalikes/allowlist"], "target": { "namespace": "web", "site": "https://prosekit.dev" } },
+  { "relation": ["lookalikes/allowlist"], "target": { "namespace": "web", "site": "https://prosekit-dev.pages.dev" } }
+]


### PR DESCRIPTION
https://chromium.googlesource.com/chromium/src/+/master/docs/security/lookalikes/lookalike-domains.md#automated-warning-removal