### PR TITLE
chore(deps): update vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "@size-limit/esbuild-why": "^11.1.6",
     "@size-limit/preset-small-lib": "^11.1.6",
     "@unocss/eslint-config": "^0.65.1",
-    "@vitest/browser": "^3.0.3",
-    "@vitest/coverage-v8": "^3.0.3",
+    "@vitest/browser": "^3.0.4",
+    "@vitest/coverage-v8": "^3.0.4",
     "cross-env": "^7.0.3",
     "dprint": "^0.48.0",
     "eslint": "^9.17.0",
@@ -50,7 +50,7 @@
     "turbo": "^2.3.3",
     "typescript": "~5.7.2",
     "unocss": "^0.65.1",
-    "vitest": "^3.0.3"
+    "vitest": "^3.0.4"
   },
   "pnpm": {
     "overrides": {},

--- a/packages/basic/package.json
+++ b/packages/basic/package.json
@@ -47,7 +47,7 @@
     "postcss-nesting": "^13.0.1",
     "tsup": "^8.3.5",
     "typescript": "~5.7.2",
-    "vitest": "^3.0.3"
+    "vitest": "^3.0.4"
   },
   "publishConfig": {
     "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,10 +46,10 @@
   },
   "devDependencies": {
     "@prosekit/dev": "workspace:*",
-    "@vitest/browser": "^3.0.3",
+    "@vitest/browser": "^3.0.4",
     "tsup": "^8.3.5",
     "typescript": "~5.7.2",
-    "vitest": "^3.0.3"
+    "vitest": "^3.0.4"
   },
   "publishConfig": {
     "exports": {

--- a/packages/core/src/commands/insert-default-block.spec.ts
+++ b/packages/core/src/commands/insert-default-block.spec.ts
@@ -4,10 +4,8 @@ import {
   it,
 } from 'vitest'
 
-import {
-  inputText,
-  setupTest,
-} from '../testing'
+import { setupTest } from '../testing'
+import { inputText } from '../testing/keyboard'
 
 import { insertDefaultBlock } from './insert-default-block'
 

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -1,7 +1,6 @@
 import '@prosekit/pm/view/style/prosemirror.css'
 
 import type { Attrs } from '@prosekit/pm/model'
-import { userEvent } from '@vitest/browser/context'
 
 import { union } from '../editor/union'
 import { defineBaseCommands } from '../extensions/command'
@@ -181,8 +180,4 @@ export function setupTest() {
     m,
     n: { ...n, p: n.paragraph },
   }
-}
-
-export async function inputText(input: string): Promise<void> {
-  return await userEvent.keyboard(input)
 }

--- a/packages/core/src/testing/keyboard.ts
+++ b/packages/core/src/testing/keyboard.ts
@@ -1,0 +1,5 @@
+import { userEvent } from '@vitest/browser/context'
+
+export async function inputText(input: string): Promise<void> {
+  return await userEvent.keyboard(input)
+}

--- a/packages/dev/src/config-vitest.js
+++ b/packages/dev/src/config-vitest.js
@@ -29,14 +29,8 @@ const defaultConfig = {
  * @returns {import('vitest/config').UserWorkspaceConfig}
  */
 export function config(options = undefined) {
-  if (!options) {
-    return defaultConfig
-  }
-
   /**
    * @type {import('vitest/config').UserWorkspaceConfig}
    */
-  const merged = merge({}, defaultConfig, options)
-
-  return merged
+  return merge({}, defaultConfig, options || {})
 }

--- a/packages/dev/src/config-vitest.js
+++ b/packages/dev/src/config-vitest.js
@@ -1,11 +1,14 @@
 // @ts-check
 
+/// <reference types="@vitest/browser/providers/playwright" />
+
 import { merge } from 'lodash-es'
 
 /** @type {import('vitest/config').UserWorkspaceConfig} */
 const defaultConfig = {
   optimizeDeps: {
     include: ['@vitest/coverage-v8/browser'],
+    // exclude: ['prettier', 'prettier/parser-html'],
   },
   test: {
     browser: {
@@ -18,6 +21,10 @@ const defaultConfig = {
       instances: [
         {
           browser: 'chromium',
+          context: {
+            hasTouch: true,
+            permissions: ['clipboard-read', 'clipboard-write'],
+          },
         },
       ],
     },

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -107,14 +107,14 @@
   },
   "devDependencies": {
     "@prosekit/dev": "workspace:*",
-    "@vitest/browser": "^3.0.3",
+    "@vitest/browser": "^3.0.4",
     "just-pick": "^4.2.0",
     "loro-crdt": "^1.3.0",
     "loro-prosemirror": "^0.2.1",
     "tsup": "^8.3.5",
     "type-fest": "^4.32.0",
     "typescript": "~5.7.2",
-    "vitest": "^3.0.3",
+    "vitest": "^3.0.4",
     "y-prosemirror": "^1.2.15",
     "y-protocols": "^1.0.6",
     "yjs": "^13.6.22"

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -111,6 +111,7 @@
     "just-pick": "^4.2.0",
     "loro-crdt": "^1.3.0",
     "loro-prosemirror": "^0.2.1",
+    "prettier": "^3.4.2",
     "tsup": "^8.3.5",
     "type-fest": "^4.32.0",
     "typescript": "~5.7.2",

--- a/packages/extensions/src/blockquote/blockquote-keymap.spec.ts
+++ b/packages/extensions/src/blockquote/blockquote-keymap.spec.ts
@@ -4,10 +4,8 @@ import {
   it,
 } from 'vitest'
 
-import {
-  pressKey,
-  setupTest,
-} from '../testing'
+import { setupTest } from '../testing'
+import { pressKey } from '../testing/keyboard'
 
 describe('blockquote keymap', () => {
   it('should wrap paragraph into blockquote with shortcut', async () => {

--- a/packages/extensions/src/heading/heading-keymap.spec.ts
+++ b/packages/extensions/src/heading/heading-keymap.spec.ts
@@ -4,10 +4,8 @@ import {
   it,
 } from 'vitest'
 
-import {
-  pressKey,
-  setupTest,
-} from '../testing'
+import { setupTest } from '../testing'
+import { pressKey } from '../testing/keyboard'
 
 describe('defineHeadingKeymap', () => {
   it('should toggle heading', async () => {

--- a/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.spec.ts
+++ b/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.spec.ts
@@ -4,10 +4,8 @@ import {
   it,
 } from 'vitest'
 
-import {
-  inputText,
-  setupTest,
-} from '../testing'
+import { setupTest } from '../testing'
+import { inputText } from '../testing/keyboard'
 
 describe('defineHorizontalRuleInputRule', () => {
   const { editor, n } = setupTest()

--- a/packages/extensions/src/list/list-keymap.spec.ts
+++ b/packages/extensions/src/list/list-keymap.spec.ts
@@ -4,10 +4,8 @@ import {
   it,
 } from 'vitest'
 
-import {
-  pressKey,
-  setupTest,
-} from '../testing'
+import { setupTest } from '../testing'
+import { pressKey } from '../testing/keyboard'
 
 describe('keymap', () => {
   const { editor, n } = setupTest()

--- a/packages/extensions/src/list/list.spec.ts
+++ b/packages/extensions/src/list/list.spec.ts
@@ -13,8 +13,6 @@ import {
 } from 'vitest'
 
 import { setupTest } from '../testing'
-import { readHtmlTextFromClipboard } from '../testing/clipboard'
-import { pressKey } from '../testing/keyboard'
 
 import { defineList } from './index'
 
@@ -33,21 +31,17 @@ describe('defineList', () => {
   })
 
   it('can copy lists as native HTML <li> elements', async () => {
-    const { editor, n } = setupTest()
+    const { editor, n, copy } = setupTest()
 
-    const copy = async (doc: ProseMirrorNode) => {
+    const copyAndGetHTML = async (doc: ProseMirrorNode) => {
       editor.set(doc)
-
-      // Select all and copy
       editor.commands.selectAll()
-      editor.view.dom.focus()
-      await pressKey('mod-C')
-
-      return await readHtmlTextFromClipboard()
+      const { html } = await copy()
+      return html
     }
 
     expect(
-      await copy(
+      await copyAndGetHTML(
         n.doc(
           n.bullet(n.paragraph('Bullet 1')),
           n.bullet(n.paragraph('Bullet 2')),
@@ -62,7 +56,7 @@ describe('defineList', () => {
     `)
 
     expect(
-      await copy(
+      await copyAndGetHTML(
         n.doc(
           n.ordered(n.paragraph('Ordered 1')),
           n.ordered(n.paragraph('Ordered 2')),
@@ -77,7 +71,7 @@ describe('defineList', () => {
     `)
 
     expect(
-      await copy(
+      await copyAndGetHTML(
         n.doc(
           n.checked(n.paragraph('Checked 1')),
           n.unchecked(n.paragraph('Unchecked 2')),

--- a/packages/extensions/src/list/list.spec.ts
+++ b/packages/extensions/src/list/list.spec.ts
@@ -12,11 +12,9 @@ import {
   it,
 } from 'vitest'
 
-import {
-  pressKey,
-  setupTest,
-} from '../testing'
+import { setupTest } from '../testing'
 import { readHtmlTextFromClipboard } from '../testing/clipboard'
+import { pressKey } from '../testing/keyboard'
 
 import { defineList } from './index'
 

--- a/packages/extensions/src/list/list.spec.ts
+++ b/packages/extensions/src/list/list.spec.ts
@@ -5,11 +5,18 @@ import {
   defineText,
   union,
 } from '@prosekit/core'
+import type { ProseMirrorNode } from '@prosekit/pm/model'
 import {
   describe,
   expect,
   it,
 } from 'vitest'
+
+import {
+  pressKey,
+  setupTest,
+} from '../testing'
+import { readHtmlTextFromClipboard } from '../testing/clipboard'
 
 import { defineList } from './index'
 
@@ -25,5 +32,65 @@ describe('defineList', () => {
     const schema = editor.schema
     const nodes = Object.keys(schema.nodes)
     expect(nodes.includes('list')).toBe(true)
+  })
+
+  it('can copy lists as native HTML <li> elements', async () => {
+    const { editor, n } = setupTest()
+
+    const copy = async (doc: ProseMirrorNode) => {
+      editor.set(doc)
+
+      // Select all and copy
+      editor.commands.selectAll()
+      editor.view.dom.focus()
+      await pressKey('mod-C')
+
+      return await readHtmlTextFromClipboard()
+    }
+
+    expect(
+      await copy(
+        n.doc(
+          n.bullet(n.paragraph('Bullet 1')),
+          n.bullet(n.paragraph('Bullet 2')),
+        ),
+      ),
+    ).toMatchInlineSnapshot(`
+      "<ul data-pm-slice="0 0 []">
+        <li class="prosemirror-flat-list" data-list-kind="bullet"><p>Bullet 1</p></li>
+        <li class="prosemirror-flat-list" data-list-kind="bullet"><p>Bullet 2</p></li>
+      </ul>
+      "
+    `)
+
+    expect(
+      await copy(
+        n.doc(
+          n.ordered(n.paragraph('Ordered 1')),
+          n.ordered(n.paragraph('Ordered 2')),
+        ),
+      ),
+    ).toMatchInlineSnapshot(`
+      "<ol data-pm-slice="0 0 []">
+        <li class="prosemirror-flat-list" data-list-kind="ordered"><p>Ordered 1</p></li>
+        <li class="prosemirror-flat-list" data-list-kind="ordered"><p>Ordered 2</p></li>
+      </ol>
+      "
+    `)
+
+    expect(
+      await copy(
+        n.doc(
+          n.checked(n.paragraph('Checked 1')),
+          n.unchecked(n.paragraph('Unchecked 2')),
+        ),
+      ),
+    ).toMatchInlineSnapshot(`
+      "<ul data-pm-slice="0 0 []">
+        <li class="prosemirror-flat-list" data-list-kind="task" data-list-checked=""><p>Checked 1</p></li>
+        <li class="prosemirror-flat-list" data-list-kind="task"><p>Unchecked 2</p></li>
+      </ul>
+      "
+    `)
   })
 })

--- a/packages/extensions/src/table/table-commands.spec.ts
+++ b/packages/extensions/src/table/table-commands.spec.ts
@@ -9,10 +9,8 @@ import {
   it,
 } from 'vitest'
 
-import {
-  inputText,
-  setupTest,
-} from '../testing'
+import { setupTest } from '../testing'
+import { inputText } from '../testing/keyboard'
 
 import { isCellSelection } from './table-utils'
 

--- a/packages/extensions/src/testing/clipboard.ts
+++ b/packages/extensions/src/testing/clipboard.ts
@@ -1,0 +1,33 @@
+import { formatHTML } from './format-html'
+
+async function readBlobFromClipboard(mimeType: string): Promise<Blob | undefined> {
+  const clipboardItems = await navigator.clipboard.read()
+  const clipboardItem = clipboardItems[0]
+  if (!clipboardItem) {
+    return undefined
+  }
+  if (!clipboardItem.types.includes(mimeType)) {
+    return undefined
+  }
+  return await clipboardItem.getType(mimeType)
+}
+
+async function readTextFromClipboard(mimeType: string): Promise<string | undefined> {
+  const blob = await readBlobFromClipboard(mimeType)
+  if (!blob) {
+    return undefined
+  }
+  return await blob.text()
+}
+
+export async function readPlainTextFromClipboard(): Promise<string> {
+  return await readTextFromClipboard('text/plain') || ''
+}
+
+export async function readHtmlTextFromClipboard(format = true): Promise<string> {
+  let html = await readTextFromClipboard('text/html') || ''
+  if (format) {
+    html = await formatHTML(html)
+  }
+  return html
+}

--- a/packages/extensions/src/testing/format-html.ts
+++ b/packages/extensions/src/testing/format-html.ts
@@ -1,0 +1,11 @@
+export async function formatHTML(html: string) {
+  const prettier = await import('prettier')
+  const prettierHTML = await import('prettier/plugins/html')
+
+  return await prettier.format(html, {
+    parser: 'html',
+    htmlWhitespaceSensitivity: 'ignore',
+    plugins: [prettierHTML],
+    printWidth: 180,
+  })
+}

--- a/packages/extensions/src/testing/index.ts
+++ b/packages/extensions/src/testing/index.ts
@@ -34,6 +34,12 @@ import { defineStrike } from '../strike'
 import { defineTable } from '../table'
 import { defineUnderline } from '../underline'
 
+import {
+  readHtmlTextFromClipboard,
+  readPlainTextFromClipboard,
+} from './clipboard'
+import { pressKey } from './keyboard'
+
 /**
  * @internal
  */
@@ -101,6 +107,14 @@ export function setupTest() {
     }
   }
 
+  const copy = async () => {
+    editor.view.dom.focus()
+    await pressKey('mod-C')
+    const html = await readHtmlTextFromClipboard()
+    const plain = await readPlainTextFromClipboard()
+    return { html, plain }
+  }
+
   return {
     editor,
     m,
@@ -123,5 +137,6 @@ export function setupTest() {
       collapsed: listWithAttrs({ kind: 'toggle', collapsed: true }),
       expanded: listWithAttrs({ kind: 'toggle', collapsed: false }),
     },
+    copy,
   }
 }

--- a/packages/extensions/src/testing/index.ts
+++ b/packages/extensions/src/testing/index.ts
@@ -7,7 +7,6 @@ import {
   defineHistory,
   defineParagraph,
   defineText,
-  isApple,
   union,
   type Extension,
   type ExtractMarkActions,
@@ -18,7 +17,6 @@ import {
   createTestEditor,
   type TestEditor,
 } from '@prosekit/core/test'
-import { userEvent } from '@vitest/browser/context'
 
 import { defineBlockquote } from '../blockquote'
 import { defineBold } from '../bold'
@@ -126,37 +124,4 @@ export function setupTest() {
       expanded: listWithAttrs({ kind: 'toggle', collapsed: false }),
     },
   }
-}
-
-/**
- * @example
- *
- * ```ts
- * await pressKey('mod-1')
- * await pressKey('Backspace')
- * ```
- *
- * @internal
- */
-export async function pressKey(input: string) {
-  const keys = input.split('-').map((key) => {
-    if (key.toLowerCase() === 'mod') {
-      return isApple ? 'Meta' : 'Control'
-    }
-    return key
-  })
-  const seq: string[] = []
-  for (const key of keys) {
-    // Press key without releasing it
-    seq.push('{' + key + '>}')
-  }
-  for (const key of keys.toReversed()) {
-    // Release a previously pressed key
-    seq.push('{/' + key + '}')
-  }
-  return await userEvent.keyboard(seq.join(''))
-}
-
-export async function inputText(input: string) {
-  return await userEvent.keyboard(input)
 }

--- a/packages/extensions/src/testing/keyboard.ts
+++ b/packages/extensions/src/testing/keyboard.ts
@@ -1,0 +1,36 @@
+import { isApple } from '@prosekit/core'
+import { userEvent } from '@vitest/browser/context'
+
+/**
+ * @example
+ *
+ * ```ts
+ * await pressKey('mod-1')
+ * await pressKey('Backspace')
+ * ```
+ *
+ * @internal
+ */
+
+export async function pressKey(input: string) {
+  const keys = input.split('-').map((key) => {
+    if (key.toLowerCase() === 'mod') {
+      return isApple ? 'Meta' : 'Control'
+    }
+    return key
+  })
+  const seq: string[] = []
+  for (const key of keys) {
+    // Press key without releasing it
+    seq.push('{' + key + '>}')
+  }
+  for (const key of keys.toReversed()) {
+    // Release a previously pressed key
+    seq.push('{/' + key + '}')
+  }
+  return await userEvent.keyboard(seq.join(''))
+}
+
+export async function inputText(input: string) {
+  return await userEvent.keyboard(input)
+}

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -48,7 +48,7 @@
     "@prosekit/dev": "workspace:*",
     "tsup": "^8.3.5",
     "typescript": "~5.7.2",
-    "vitest": "^3.0.3"
+    "vitest": "^3.0.4"
   },
   "publishConfig": {
     "exports": {

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -57,7 +57,7 @@
     "@prosekit/dev": "workspace:*",
     "tsup": "^8.3.5",
     "typescript": "~5.7.2",
-    "vitest": "^3.0.3"
+    "vitest": "^3.0.4"
   },
   "publishConfig": {
     "exports": {

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -60,7 +60,7 @@
     "preact": "^10.25.4",
     "tsup": "^8.3.5",
     "typescript": "~5.7.2",
-    "vitest": "^3.0.3"
+    "vitest": "^3.0.4"
   },
   "publishConfig": {
     "exports": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -69,7 +69,7 @@
     "react-dom": "^18.3.1",
     "tsup": "^8.3.5",
     "typescript": "~5.7.2",
-    "vitest": "^3.0.3"
+    "vitest": "^3.0.4"
   },
   "publishConfig": {
     "exports": {

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -61,7 +61,7 @@
     "solid-js": "^1.9.4",
     "tsup": "^8.3.5",
     "typescript": "~5.7.2",
-    "vitest": "^3.0.3"
+    "vitest": "^3.0.4"
   },
   "publishConfig": {
     "exports": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -85,7 +85,7 @@
     "svelte-check": "^4.1.4",
     "tsx": "^4.19.2",
     "typescript": "~5.7.2",
-    "vitest": "^3.0.3"
+    "vitest": "^3.0.4"
   },
   "publishConfig": {
     "exports": {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -41,6 +41,6 @@
     "prettier": "^3.4.2",
     "typescript": "~5.7.2",
     "unplugin-macros": "^0.14.0",
-    "vitest": "^3.0.3"
+    "vitest": "^3.0.4"
   }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -62,7 +62,7 @@
     "@vue/test-utils": "^2.4.6",
     "tsup": "^8.3.5",
     "typescript": "~5.7.2",
-    "vitest": "^3.0.3",
+    "vitest": "^3.0.4",
     "vue": "^3.5.13"
   },
   "publishConfig": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -63,7 +63,7 @@
     "@prosekit/dev": "workspace:*",
     "tsup": "^8.3.5",
     "typescript": "~5.7.2",
-    "vitest": "^3.0.3"
+    "vitest": "^3.0.4"
   },
   "publishConfig": {
     "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,11 +41,11 @@ importers:
         specifier: ^0.65.1
         version: 0.65.1(eslint@9.18.0(jiti@2.4.1))(typescript@5.7.2)
       '@vitest/browser':
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(playwright@1.49.1)(typescript@5.7.2)(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.3)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/node@20.17.9)(playwright@1.49.1)(typescript@5.7.2)(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.4)
       '@vitest/coverage-v8':
-        specifier: ^3.0.3
-        version: 3.0.3(@vitest/browser@3.0.3)(vitest@3.0.3)
+        specifier: ^3.0.4
+        version: 3.0.4(@vitest/browser@3.0.4)(vitest@3.0.4)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -86,8 +86,8 @@ importers:
         specifier: ^0.65.1
         version: 0.65.1(postcss@8.5.0)(rollup@4.28.1)(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))(vue@3.5.13(typescript@5.7.2))
       vitest:
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
 
   packages/basic:
     dependencies:
@@ -117,8 +117,8 @@ importers:
         specifier: ~5.7.2
         version: 5.7.2
       vitest:
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
 
   packages/core:
     dependencies:
@@ -148,8 +148,8 @@ importers:
         specifier: workspace:*
         version: link:../dev
       '@vitest/browser':
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(playwright@1.49.1)(typescript@5.7.2)(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.3)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/node@20.17.9)(playwright@1.49.1)(typescript@5.7.2)(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.4)
       tsup:
         specifier: ^8.3.5
         version: 8.3.5(@microsoft/api-extractor@7.49.1(@types/node@20.17.9))(jiti@2.4.1)(postcss@8.5.0)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.6.1)
@@ -157,8 +157,8 @@ importers:
         specifier: ~5.7.2
         version: 5.7.2
       vitest:
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
 
   packages/dev:
     dependencies:
@@ -270,8 +270,8 @@ importers:
         specifier: workspace:*
         version: link:../dev
       '@vitest/browser':
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(playwright@1.49.1)(typescript@5.7.2)(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.3)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/node@20.17.9)(playwright@1.49.1)(typescript@5.7.2)(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.4)
       just-pick:
         specifier: ^4.2.0
         version: 4.2.0
@@ -291,8 +291,8 @@ importers:
         specifier: ~5.7.2
         version: 5.7.2
       vitest:
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
       y-prosemirror:
         specifier: ^1.2.15
         version: 1.2.15(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.37.1)(y-protocols@1.0.6(yjs@13.6.22))(yjs@13.6.22)
@@ -319,8 +319,8 @@ importers:
         specifier: ~5.7.2
         version: 5.7.2
       vitest:
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
 
   packages/pm:
     dependencies:
@@ -359,8 +359,8 @@ importers:
         specifier: ~5.7.2
         version: 5.7.2
       vitest:
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
 
   packages/preact:
     dependencies:
@@ -390,8 +390,8 @@ importers:
         specifier: ~5.7.2
         version: 5.7.2
       vitest:
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
 
   packages/prosekit:
     dependencies:
@@ -536,8 +536,8 @@ importers:
         specifier: ~5.7.2
         version: 5.7.2
       vitest:
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
 
   packages/solid:
     dependencies:
@@ -570,8 +570,8 @@ importers:
         specifier: ~5.7.2
         version: 5.7.2
       vitest:
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
 
   packages/svelte:
     dependencies:
@@ -616,8 +616,8 @@ importers:
         specifier: ~5.7.2
         version: 5.7.2
       vitest:
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
 
   packages/themes:
     dependencies:
@@ -644,8 +644,8 @@ importers:
         specifier: ^0.14.0
         version: 0.14.0(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(rollup@4.28.1)(tsx@4.19.2)(yaml@2.6.1)
       vitest:
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
 
   packages/unocss-preset:
     dependencies:
@@ -703,8 +703,8 @@ importers:
         specifier: ~5.7.2
         version: 5.7.2
       vitest:
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
       vue:
         specifier: ^3.5.13
         version: 3.5.13(typescript@5.7.2)
@@ -770,8 +770,8 @@ importers:
         specifier: ~5.7.2
         version: 5.7.2
       vitest:
-        specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+        specifier: ^3.0.4
+        version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
 
   playground:
     devDependencies:
@@ -3092,12 +3092,12 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
-  '@vitest/browser@3.0.3':
-    resolution: {integrity: sha512-Vm6X8gPWotRC/B+CGnBNEOXArISkLmZaN7wmQf/j7WmJJt7tqRvFdOioUzp29HZg2vIGjWq/0pVp6KEiUhEDBA==}
+  '@vitest/browser@3.0.4':
+    resolution: {integrity: sha512-CMUG+OYJvXoe5ylGzmAU3eVX6d848FvRc+1j/STOi3bHBIv4kfXgUrvPuxJVzl6kOad57Vg+SKBvNjeBoc4esw==}
     peerDependencies:
       playwright: '*'
       safaridriver: '*'
-      vitest: 3.0.3
+      vitest: 3.0.4
       webdriverio: '*'
     peerDependenciesMeta:
       playwright:
@@ -3107,20 +3107,20 @@ packages:
       webdriverio:
         optional: true
 
-  '@vitest/coverage-v8@3.0.3':
-    resolution: {integrity: sha512-uVbJ/xhImdNtzPnLyxCZJMTeTIYdgcC2nWtBBBpR1H6z0w8m7D+9/zrDIx2nNxgMg9r+X8+RY2qVpUDeW2b3nw==}
+  '@vitest/coverage-v8@3.0.4':
+    resolution: {integrity: sha512-f0twgRCHgbs24Dp8cLWagzcObXMcuKtAwgxjJV/nnysPAJJk1JiKu/W0gIehZLmkljhJXU/E0/dmuQzsA/4jhA==}
     peerDependencies:
-      '@vitest/browser': 3.0.3
-      vitest: 3.0.3
+      '@vitest/browser': 3.0.4
+      vitest: 3.0.4
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@3.0.3':
-    resolution: {integrity: sha512-SbRCHU4qr91xguu+dH3RUdI5dC86zm8aZWydbp961aIR7G8OYNN6ZiayFuf9WAngRbFOfdrLHCGgXTj3GtoMRQ==}
+  '@vitest/expect@3.0.4':
+    resolution: {integrity: sha512-Nm5kJmYw6P2BxhJPkO3eKKhGYKRsnqJqf+r0yOGRKpEP+bSCBDsjXgiu1/5QFrnPMEgzfC38ZEjvCFgaNBC0Eg==}
 
-  '@vitest/mocker@3.0.3':
-    resolution: {integrity: sha512-XT2XBc4AN9UdaxJAeIlcSZ0ILi/GzmG5G8XSly4gaiqIvPV3HMTSIDZWJVX6QRJ0PX1m+W8Cy0K9ByXNb/bPIA==}
+  '@vitest/mocker@3.0.4':
+    resolution: {integrity: sha512-gEef35vKafJlfQbnyOXZ0Gcr9IBUsMTyTLXsEQwuyYAerpHqvXhzdBnDFuHLpFqth3F7b6BaFr4qV/Cs1ULx5A==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0
@@ -3130,20 +3130,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.0.3':
-    resolution: {integrity: sha512-gCrM9F7STYdsDoNjGgYXKPq4SkSxwwIU5nkaQvdUxiQ0EcNlez+PdKOVIsUJvh9P9IeIFmjn4IIREWblOBpP2Q==}
+  '@vitest/pretty-format@3.0.4':
+    resolution: {integrity: sha512-ts0fba+dEhK2aC9PFuZ9LTpULHpY/nd6jhAQ5IMU7Gaj7crPCTdCFfgvXxruRBLFS+MLraicCuFXxISEq8C93g==}
 
-  '@vitest/runner@3.0.3':
-    resolution: {integrity: sha512-Rgi2kOAk5ZxWZlwPguRJFOBmWs6uvvyAAR9k3MvjRvYrG7xYvKChZcmnnpJCS98311CBDMqsW9MzzRFsj2gX3g==}
+  '@vitest/runner@3.0.4':
+    resolution: {integrity: sha512-dKHzTQ7n9sExAcWH/0sh1elVgwc7OJ2lMOBrAm73J7AH6Pf9T12Zh3lNE1TETZaqrWFXtLlx3NVrLRb5hCK+iw==}
 
-  '@vitest/snapshot@3.0.3':
-    resolution: {integrity: sha512-kNRcHlI4txBGztuJfPEJ68VezlPAXLRT1u5UCx219TU3kOG2DplNxhWLwDf2h6emwmTPogzLnGVwP6epDaJN6Q==}
+  '@vitest/snapshot@3.0.4':
+    resolution: {integrity: sha512-+p5knMLwIk7lTQkM3NonZ9zBewzVp9EVkVpvNta0/PlFWpiqLaRcF4+33L1it3uRUCh0BGLOaXPPGEjNKfWb4w==}
 
-  '@vitest/spy@3.0.3':
-    resolution: {integrity: sha512-7/dgux8ZBbF7lEIKNnEqQlyRaER9nkAL9eTmdKJkDO3hS8p59ATGwKOCUDHcBLKr7h/oi/6hP+7djQk8049T2A==}
+  '@vitest/spy@3.0.4':
+    resolution: {integrity: sha512-sXIMF0oauYyUy2hN49VFTYodzEAu744MmGcPR3ZBsPM20G+1/cSW/n1U+3Yu/zHxX2bIDe1oJASOkml+osTU6Q==}
 
-  '@vitest/utils@3.0.3':
-    resolution: {integrity: sha512-f+s8CvyzPtMFY1eZKkIHGhPsQgYo5qCm6O8KZoim9qm1/jT64qBgGpO5tHscNH6BzRHM+edLNOP+3vO8+8pE/A==}
+  '@vitest/utils@3.0.4':
+    resolution: {integrity: sha512-8BqC1ksYsHtbWH+DfpOAKrFw3jl3Uf9J7yeFh85Pz52IWuh1hBBtyfEbRNNZNjl8H8A5yMLH9/t+k7HIKzQcZQ==}
 
   '@volar/language-core@2.4.11':
     resolution: {integrity: sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==}
@@ -5788,6 +5788,9 @@ packages:
   pathe@2.0.1:
     resolution: {integrity: sha512-6jpjMpOth5S9ITVu5clZ7NOgHNsv5vRQdheL9ztp2vZmM6fRbLvyua1tiBIL4lk8SAe3ARzeXEly6siXCjDHDw==}
 
+  pathe@2.0.2:
+    resolution: {integrity: sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==}
+
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
@@ -7095,8 +7098,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite-node@3.0.3:
-    resolution: {integrity: sha512-0sQcwhwAEw/UJGojbhOrnq3HtiZ3tC7BzpAa0lx3QaTX0S3YX70iGcik25UBdB96pmdwjyY2uyKNYruxCDmiEg==}
+  vite-node@3.0.4:
+    resolution: {integrity: sha512-7JZKEzcYV2Nx3u6rlvN8qdo3QV7Fxyt6hx+CCKz9fbWxdX5IvUOmTWEAxMrWxaiSf7CKGLJQ5rFu8prb/jBjOA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -7227,19 +7230,22 @@ packages:
       postcss:
         optional: true
 
-  vitest@3.0.3:
-    resolution: {integrity: sha512-dWdwTFUW9rcnL0LyF2F+IfvNQWB0w9DERySCk8VMG75F8k25C7LsZoh6XfCjPvcR8Nb+Lqi9JKr6vnzH7HSrpQ==}
+  vitest@3.0.4:
+    resolution: {integrity: sha512-6XG8oTKy2gnJIFTHP6LD7ExFeNLxiTkK3CfMvT7IfR8IN+BYICCf0lXUQmX7i7JoxUP8QmeP4mTnWXgflu4yjw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.0.3
-      '@vitest/ui': 3.0.3
+      '@vitest/browser': 3.0.4
+      '@vitest/ui': 3.0.4
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -7625,7 +7631,7 @@ snapshots:
   '@antfu/install-pkg@0.4.1':
     dependencies:
       package-manager-detector: 0.2.7
-      tinyexec: 0.3.1
+      tinyexec: 0.3.2
 
   '@antfu/utils@0.7.10': {}
 
@@ -9956,17 +9962,17 @@ snapshots:
       vite: 6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1)
       vue: 3.5.13(typescript@5.7.2)
 
-  '@vitest/browser@3.0.3(@types/node@20.17.9)(playwright@1.49.1)(typescript@5.7.2)(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.3)':
+  '@vitest/browser@3.0.4(@types/node@20.17.9)(playwright@1.49.1)(typescript@5.7.2)(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.0.3(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))
-      '@vitest/utils': 3.0.3
+      '@vitest/mocker': 3.0.4(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))
+      '@vitest/utils': 3.0.4
       magic-string: 0.30.17
       msw: 2.7.0(@types/node@20.17.9)(typescript@5.7.2)
       sirv: 3.0.0
       tinyrainbow: 2.0.0
-      vitest: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+      vitest: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
       ws: 8.18.0
     optionalDependencies:
       playwright: 1.49.1
@@ -9977,7 +9983,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@3.0.3(@vitest/browser@3.0.3)(vitest@3.0.3)':
+  '@vitest/coverage-v8@3.0.4(@vitest/browser@3.0.4)(vitest@3.0.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -9991,50 +9997,50 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
+      vitest: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1)
     optionalDependencies:
-      '@vitest/browser': 3.0.3(@types/node@20.17.9)(playwright@1.49.1)(typescript@5.7.2)(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.3)
+      '@vitest/browser': 3.0.4(@types/node@20.17.9)(playwright@1.49.1)(typescript@5.7.2)(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@3.0.3':
+  '@vitest/expect@3.0.4':
     dependencies:
-      '@vitest/spy': 3.0.3
-      '@vitest/utils': 3.0.3
+      '@vitest/spy': 3.0.4
+      '@vitest/utils': 3.0.4
       chai: 5.1.2
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.3(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))':
+  '@vitest/mocker@3.0.4(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))':
     dependencies:
-      '@vitest/spy': 3.0.3
+      '@vitest/spy': 3.0.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.7.0(@types/node@20.17.9)(typescript@5.7.2)
       vite: 6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1)
 
-  '@vitest/pretty-format@3.0.3':
+  '@vitest/pretty-format@3.0.4':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.0.3':
+  '@vitest/runner@3.0.4':
     dependencies:
-      '@vitest/utils': 3.0.3
-      pathe: 2.0.1
+      '@vitest/utils': 3.0.4
+      pathe: 2.0.2
 
-  '@vitest/snapshot@3.0.3':
+  '@vitest/snapshot@3.0.4':
     dependencies:
-      '@vitest/pretty-format': 3.0.3
+      '@vitest/pretty-format': 3.0.4
       magic-string: 0.30.17
-      pathe: 2.0.1
+      pathe: 2.0.2
 
-  '@vitest/spy@3.0.3':
+  '@vitest/spy@3.0.4':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/utils@3.0.3':
+  '@vitest/utils@3.0.4':
     dependencies:
-      '@vitest/pretty-format': 3.0.3
+      '@vitest/pretty-format': 3.0.4
       loupe: 3.1.2
       tinyrainbow: 2.0.0
 
@@ -13317,6 +13323,8 @@ snapshots:
 
   pathe@2.0.1: {}
 
+  pathe@2.0.2: {}
+
   pathval@2.0.0: {}
 
   perfect-debounce@1.0.0: {}
@@ -14838,12 +14846,12 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.0.3(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1):
+  vite-node@3.0.4(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
-      pathe: 2.0.1
+      pathe: 2.0.2
       vite: 6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -15000,31 +15008,32 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@3.0.3(@types/node@20.17.9)(@vitest/browser@3.0.3)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1):
+  vitest@3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(jiti@2.4.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(tsx@4.19.2)(yaml@2.6.1):
     dependencies:
-      '@vitest/expect': 3.0.3
-      '@vitest/mocker': 3.0.3(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))
-      '@vitest/pretty-format': 3.0.3
-      '@vitest/runner': 3.0.3
-      '@vitest/snapshot': 3.0.3
-      '@vitest/spy': 3.0.3
-      '@vitest/utils': 3.0.3
+      '@vitest/expect': 3.0.4
+      '@vitest/mocker': 3.0.4(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.2))(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))
+      '@vitest/pretty-format': 3.0.4
+      '@vitest/runner': 3.0.4
+      '@vitest/snapshot': 3.0.4
+      '@vitest/spy': 3.0.4
+      '@vitest/utils': 3.0.4
       chai: 5.1.2
       debug: 4.4.0
       expect-type: 1.1.0
       magic-string: 0.30.17
-      pathe: 2.0.1
+      pathe: 2.0.2
       std-env: 3.8.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
       vite: 6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1)
-      vite-node: 3.0.3(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1)
+      vite-node: 3.0.4(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/debug': 4.1.12
       '@types/node': 20.17.9
-      '@vitest/browser': 3.0.3(@types/node@20.17.9)(playwright@1.49.1)(typescript@5.7.2)(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.3)
+      '@vitest/browser': 3.0.4(@types/node@20.17.9)(playwright@1.49.1)(typescript@5.7.2)(vite@6.0.7(@types/node@20.17.9)(jiti@2.4.1)(lightningcss@1.29.1)(tsx@4.19.2)(yaml@2.6.1))(vitest@3.0.4)
     transitivePeerDependencies:
       - jiti
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       loro-prosemirror:
         specifier: ^0.2.1
         version: 0.2.1(loro-crdt@1.3.0)(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)(prosemirror-view@1.37.1)
+      prettier:
+        specifier: ^3.4.2
+        version: 3.4.2
       tsup:
         specifier: ^8.3.5
         version: 8.3.5(@microsoft/api-extractor@7.49.1(@types/node@20.17.9))(jiti@2.4.1)(postcss@8.5.0)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.6.1)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,12 +7,6 @@ export default defineConfig({
       all: false,
       provider: 'v8',
     },
-    browser: {
-      enabled: true,
-      provider: 'playwright',
-      name: 'chromium',
-      headless: true,
-    },
     fileParallelism: false,
     workspace: ['packages/*'],
   },


### PR DESCRIPTION
This pull request includes various updates and refactors across multiple packages. The most significant changes include updating dependencies, refactoring test imports, and adding new utility functions for clipboard interactions.

### Dependency Updates:
* Updated `@vitest/browser`, `@vitest/coverage-v8`, and `vitest` to version `3.0.4` in `package.json` files across multiple packages. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L38-R39) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L53-R53) [[3]](diffhunk://#diff-964ac4baa37ca609f94f253604359d632b98291005ce7b2fa9d4e783621e17ceL50-R50) [[4]](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L49-R52) [[5]](diffhunk://#diff-eec19d5beee1c8dba2eca07c78c1d40fc3b4a7000001c9466f96206ffb28703fL110-R118) [[6]](diffhunk://#diff-2e11af57b0a63699a7fffd908445c65d61e97da4fd2a26ef8467e9b9e544532eL51-R51) [[7]](diffhunk://#diff-1ff088f5119ba6763199900bf03abb875b773a3a12c0cec1c463396b60d8243cL60-R60)

### Refactoring Test Imports:
* Split and relocated `inputText` and `pressKey` functions from `../testing` to `../testing/keyboard` in various test files. [[1]](diffhunk://#diff-575b535976da60b7292b5744b60facd51d8b9cea3fe9ae3e73ddff329d073648L7-R8) [[2]](diffhunk://#diff-a28bb1a56f88cf33470ee3bacf0e3879d92a98c34e69e75ceb715a1cfd3a3295L7-R8) [[3]](diffhunk://#diff-e4c2a1341fc08a85bd3a3196aad6e18e272e67e128c4b341867589674fb34c95L7-R8) [[4]](diffhunk://#diff-797f79ea973920d808b93da8fd2b8cf0f4b650a7905960e0b8fd4371ad9fd11eL7-R8) [[5]](diffhunk://#diff-a73ff1e340170a4733cbada6ca1e72f3bb03b72a2116103354de6edd7b1cb13fL7-R8) [[6]](diffhunk://#diff-b49c2618886a1d498f097d59c60100b56a83cc49b08f6d55089820b696125e2eL12-R13)
* Removed `userEvent` import from `packages/core/src/testing/index.ts` and moved `inputText` function to `keyboard.ts`. [[1]](diffhunk://#diff-4c0de0b4f765e13d3c84e37231390b820ecb639f731577c08f2d06c449c1a3dcL4) [[2]](diffhunk://#diff-4c0de0b4f765e13d3c84e37231390b820ecb639f731577c08f2d06c449c1a3dcL185-L188) [[3]](diffhunk://#diff-38fa43388369b0a2ff1387e00ffa0d7879cdecd02aebe8aead92b9d4dbf64d0aR1-R5)

### Clipboard Utility Functions:
* Added new functions `readPlainTextFromClipboard`, `readHtmlTextFromClipboard`, and `readBlobFromClipboard` in `clipboard.ts` to facilitate clipboard interactions.
* Implemented `formatHTML` function in `format-html.ts` for formatting HTML content using Prettier.

### Configuration Enhancements:
* Enhanced `config-vitest.js` to include browser context options and simplified the `config` function. [[1]](diffhunk://#diff-bffe7227642f30ea9fced18123f6e07d6452905d9eec52e62dedf6738821153bR3-R11) [[2]](diffhunk://#diff-bffe7227642f30ea9fced18123f6e07d6452905d9eec52e62dedf6738821153bR24-R27) [[3]](diffhunk://#diff-bffe7227642f30ea9fced18123f6e07d6452905d9eec52e62dedf6738821153bL32-R42)

### New Test Case:
* Added a new test case in `list.spec.ts` to verify copying lists as native HTML `<li>` elements. [[1]](diffhunk://#diff-5ea364fb217e9c99dd1fc48e035dc1cc48d12b0c77f2f6cead2054ac45462eceR8-R16) [[2]](diffhunk://#diff-5ea364fb217e9c99dd1fc48e035dc1cc48d12b0c77f2f6cead2054ac45462eceR32-R87)