### PR TITLE
docs: import `typography.css` in examples

### DIFF
--- a/website/src/content/docs/getting-started/styling.mdx
+++ b/website/src/content/docs/getting-started/styling.mdx
@@ -12,7 +12,7 @@ ProseKit provides a headless editor framework that gives you complete control ov
 
 ## Basic Styles
 
-ProseKit requires some basic styles to function properly. Import the `prosekit/basic/style.css` file in your project.
+ProseKit requires some basic styles to function properly. Import `prosekit/basic/style.css` in your project to include these styles.
 
 ```ts
 // Import the basic styles (required)
@@ -27,7 +27,7 @@ import 'prosekit/basic/style.css'
 
 ProseKit provides an optional set of typography styles that make your editor content look polished with minimal effort.
 
-The `typography.css` file provides a beautiful set of default styles for headings, paragraphs, lists, and other elements:
+`prosekit/basic/typography.css` provides a beautiful set of default styles for headings, paragraphs, lists, and other elements:
 
 ```ts
 // Import both basic and typography styles

--- a/website/src/examples/preact/keymap/editor.tsx
+++ b/website/src/examples/preact/keymap/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import {

--- a/website/src/examples/preact/minimal/editor.tsx
+++ b/website/src/examples/preact/minimal/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { useMemo } from 'preact/hooks'
 import { defineBasicExtension } from 'prosekit/basic'

--- a/website/src/examples/preact/readonly/editor.tsx
+++ b/website/src/examples/preact/readonly/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { useMemo } from 'preact/hooks'

--- a/website/src/examples/preact/slash-menu/editor.tsx
+++ b/website/src/examples/preact/slash-menu/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { useMemo } from 'preact/hooks'

--- a/website/src/examples/react/block-handle/editor.tsx
+++ b/website/src/examples/react/block-handle/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/blockquote/editor.tsx
+++ b/website/src/examples/react/blockquote/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/change-tracking/editor-main.tsx
+++ b/website/src/examples/react/change-tracking/editor-main.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { defineBasicExtension } from 'prosekit/basic'

--- a/website/src/examples/react/change-tracking/editor.tsx
+++ b/website/src/examples/react/change-tracking/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import type { NodeJSON } from 'prosekit/core'

--- a/website/src/examples/react/code-block-themes/editor.tsx
+++ b/website/src/examples/react/code-block-themes/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/gap-cursor/editor.tsx
+++ b/website/src/examples/react/gap-cursor/editor.tsx
@@ -1,6 +1,8 @@
+import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
+
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
-import 'prosekit/basic/style.css'
 import { ProseKit } from 'prosekit/react'
 import { useMemo } from 'react'
 

--- a/website/src/examples/react/heading/editor.tsx
+++ b/website/src/examples/react/heading/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/horizontal-rule/editor.tsx
+++ b/website/src/examples/react/horizontal-rule/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/image-view/editor.tsx
+++ b/website/src/examples/react/image-view/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/inline-menu/editor.tsx
+++ b/website/src/examples/react/inline-menu/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/keymap/editor.tsx
+++ b/website/src/examples/react/keymap/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/link-mark-view/editor.tsx
+++ b/website/src/examples/react/link-mark-view/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/link/editor.tsx
+++ b/website/src/examples/react/link/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/list/editor.tsx
+++ b/website/src/examples/react/list/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import {

--- a/website/src/examples/react/loro/editor-component.tsx
+++ b/website/src/examples/react/loro/editor-component.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 import 'prosekit/extensions/loro/style.css'
 
 import { Themes } from '@prosekit/themes'

--- a/website/src/examples/react/mark-rule/editor.tsx
+++ b/website/src/examples/react/mark-rule/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/minimal/editor.tsx
+++ b/website/src/examples/react/minimal/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { defineBasicExtension } from 'prosekit/basic'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/placeholder/editor.tsx
+++ b/website/src/examples/react/placeholder/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import {

--- a/website/src/examples/react/readonly/editor.tsx
+++ b/website/src/examples/react/readonly/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/save-html/editor-component.tsx
+++ b/website/src/examples/react/save-html/editor-component.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import type { Editor } from 'prosekit/core'

--- a/website/src/examples/react/save-html/editor.tsx
+++ b/website/src/examples/react/save-html/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { defineBasicExtension } from 'prosekit/basic'

--- a/website/src/examples/react/save-json/editor-component.tsx
+++ b/website/src/examples/react/save-json/editor-component.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import type { Editor } from 'prosekit/core'

--- a/website/src/examples/react/save-json/editor.tsx
+++ b/website/src/examples/react/save-json/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { defineBasicExtension } from 'prosekit/basic'

--- a/website/src/examples/react/save-markdown/editor-component.tsx
+++ b/website/src/examples/react/save-markdown/editor-component.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import type { Editor } from 'prosekit/core'

--- a/website/src/examples/react/save-markdown/editor.tsx
+++ b/website/src/examples/react/save-markdown/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { defineBasicExtension } from 'prosekit/basic'

--- a/website/src/examples/react/search/editor.tsx
+++ b/website/src/examples/react/search/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 import 'prosekit/extensions/search/style.css'
 
 import { Themes } from '@prosekit/themes'

--- a/website/src/examples/react/slash-menu/editor.tsx
+++ b/website/src/examples/react/slash-menu/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/table/editor.tsx
+++ b/website/src/examples/react/table/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/toolbar/editor.tsx
+++ b/website/src/examples/react/toolbar/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/unmount/editor-component.tsx
+++ b/website/src/examples/react/unmount/editor-component.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { defineBasicExtension } from 'prosekit/basic'

--- a/website/src/examples/react/user-menu-dynamic/editor.tsx
+++ b/website/src/examples/react/user-menu-dynamic/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/user-menu/editor.tsx
+++ b/website/src/examples/react/user-menu/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/word-counter/editor.tsx
+++ b/website/src/examples/react/word-counter/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/react/yjs/editor-component.tsx
+++ b/website/src/examples/react/yjs/editor-component.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 import 'prosekit/extensions/yjs/style.css'
 
 import { Themes } from '@prosekit/themes'

--- a/website/src/examples/solid/drop-cursor/editor.tsx
+++ b/website/src/examples/solid/drop-cursor/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/solid/heading/editor.tsx
+++ b/website/src/examples/solid/heading/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/solid/keymap/editor.tsx
+++ b/website/src/examples/solid/keymap/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import {

--- a/website/src/examples/solid/link-mark-view/editor.tsx
+++ b/website/src/examples/solid/link-mark-view/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/solid/minimal/editor.tsx
+++ b/website/src/examples/solid/minimal/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { defineBasicExtension } from 'prosekit/basic'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/solid/readonly/editor.tsx
+++ b/website/src/examples/solid/readonly/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/solid/slash-menu/editor.tsx
+++ b/website/src/examples/solid/slash-menu/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/solid/text-align/editor.tsx
+++ b/website/src/examples/solid/text-align/editor.tsx
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/svelte/bold/editor.svelte
+++ b/website/src/examples/svelte/bold/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/svelte/change-tracking/editor-main.svelte
+++ b/website/src/examples/svelte/change-tracking/editor-main.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { defineBasicExtension } from 'prosekit/basic'

--- a/website/src/examples/svelte/change-tracking/editor.svelte
+++ b/website/src/examples/svelte/change-tracking/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import type { NodeJSON } from 'prosekit/core'

--- a/website/src/examples/svelte/code-block-themes/editor.svelte
+++ b/website/src/examples/svelte/code-block-themes/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/svelte/code-block/editor.svelte
+++ b/website/src/examples/svelte/code-block/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/svelte/code/editor.svelte
+++ b/website/src/examples/svelte/code/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/svelte/drop-cursor/editor.svelte
+++ b/website/src/examples/svelte/drop-cursor/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/svelte/emoji-rules/editor.svelte
+++ b/website/src/examples/svelte/emoji-rules/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/svelte/full/editor.svelte
+++ b/website/src/examples/svelte/full/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/svelte/heading/editor.svelte
+++ b/website/src/examples/svelte/heading/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/svelte/italic/editor.svelte
+++ b/website/src/examples/svelte/italic/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/svelte/keymap/editor.svelte
+++ b/website/src/examples/svelte/keymap/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/svelte/link-mark-view/editor.svelte
+++ b/website/src/examples/svelte/link-mark-view/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/svelte/list/editor.svelte
+++ b/website/src/examples/svelte/list/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/svelte/minimal/editor.svelte
+++ b/website/src/examples/svelte/minimal/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { defineBasicExtension } from 'prosekit/basic'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/svelte/readonly/editor.svelte
+++ b/website/src/examples/svelte/readonly/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/svelte/save-json/editor-component.svelte
+++ b/website/src/examples/svelte/save-json/editor-component.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/svelte/save-json/editor.svelte
+++ b/website/src/examples/svelte/save-json/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import EditorComponent from './editor-component.svelte'
 

--- a/website/src/examples/svelte/slash-menu/editor.svelte
+++ b/website/src/examples/svelte/slash-menu/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/svelte/text-align/editor.svelte
+++ b/website/src/examples/svelte/text-align/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/svelte/toolbar/editor.svelte
+++ b/website/src/examples/svelte/toolbar/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/svelte/word-counter/editor.svelte
+++ b/website/src/examples/svelte/word-counter/editor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 

--- a/website/src/examples/vanilla/dom/index.js
+++ b/website/src/examples/vanilla/dom/index.js
@@ -1,4 +1,5 @@
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { defineBasicExtension } from 'prosekit/basic'

--- a/website/src/examples/vue/block-handle/editor.vue
+++ b/website/src/examples/vue/block-handle/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import BlockHandle from './block-handle.vue'
 import { defineExtension } from './extension'

--- a/website/src/examples/vue/blockquote/editor.vue
+++ b/website/src/examples/vue/blockquote/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import Toolbar from './toolbar.vue'

--- a/website/src/examples/vue/bold/editor.vue
+++ b/website/src/examples/vue/bold/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import Toolbar from './toolbar.vue'

--- a/website/src/examples/vue/code-block-themes/editor.vue
+++ b/website/src/examples/vue/code-block-themes/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defaultContent } from './default-doc'
 import { defineExtension } from './extension'

--- a/website/src/examples/vue/code-block/editor.vue
+++ b/website/src/examples/vue/code-block/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defaultContent } from './default-doc'
 import { defineExtension } from './extension'

--- a/website/src/examples/vue/code/editor.vue
+++ b/website/src/examples/vue/code/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import Toolbar from './toolbar.vue'

--- a/website/src/examples/vue/drop-cursor/editor.vue
+++ b/website/src/examples/vue/drop-cursor/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defaultContent } from './default-doc'
 import { defineExtension } from './extension'

--- a/website/src/examples/vue/full/editor.vue
+++ b/website/src/examples/vue/full/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import BlockHandle from './block-handle.vue'
 import { defineExtension } from './extension'

--- a/website/src/examples/vue/heading/editor.vue
+++ b/website/src/examples/vue/heading/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import Toolbar from './toolbar.vue'

--- a/website/src/examples/vue/image-view/editor.vue
+++ b/website/src/examples/vue/image-view/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defaultContent } from './default-doc'
 import { defineExtension } from './extension'

--- a/website/src/examples/vue/inline-menu/editor.vue
+++ b/website/src/examples/vue/inline-menu/editor.vue
@@ -1,22 +1,20 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import InlineMenu from './inline-menu.vue'
 
-const defaultContent = '<p><b>Try to select some text</b></p>'
-  + '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Aliquet nec ullamcorper sit amet risus. Nam aliquam sem et tortor consequat id porta. Interdum posuere lorem ipsum dolor sit amet. Lectus sit amet est placerat in egestas erat. Egestas sed tempus urna et pharetra pharetra. Sit amet cursus sit amet dictum sit amet. Porttitor leo a diam sollicitudin. Tellus orci ac auctor augue. Tellus in hac habitasse platea dictumst vestibulum. At elementum eu facilisis sed odio morbi. Dolor magna eget est lorem ipsum. Et malesuada fames ac turpis egestas. Arcu risus quis varius quam quisque id diam. Purus viverra accumsan in nisl nisi scelerisque eu ultrices. Ut tortor pretium viverra suspendisse potenti nullam ac tortor vitae.</p>'
-    .repeat(
-      10,
-    )
+const defaultContent =
+  '<p><b>Try to select some text</b></p>' +
+  '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Aliquet nec ullamcorper sit amet risus. Nam aliquam sem et tortor consequat id porta. Interdum posuere lorem ipsum dolor sit amet. Lectus sit amet est placerat in egestas erat. Egestas sed tempus urna et pharetra pharetra. Sit amet cursus sit amet dictum sit amet. Porttitor leo a diam sollicitudin. Tellus orci ac auctor augue. Tellus in hac habitasse platea dictumst vestibulum. At elementum eu facilisis sed odio morbi. Dolor magna eget est lorem ipsum. Et malesuada fames ac turpis egestas. Arcu risus quis varius quam quisque id diam. Purus viverra accumsan in nisl nisi scelerisque eu ultrices. Ut tortor pretium viverra suspendisse potenti nullam ac tortor vitae.</p>'.repeat(
+    10,
+  )
 
 const editor = createEditor({ extension: defineExtension(), defaultContent })
 

--- a/website/src/examples/vue/italic/editor.vue
+++ b/website/src/examples/vue/italic/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import Toolbar from './toolbar.vue'

--- a/website/src/examples/vue/keymap/editor.vue
+++ b/website/src/examples/vue/keymap/editor.vue
@@ -1,16 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
-import {
-  createEditor,
-  jsonFromNode,
-} from 'prosekit/core'
+import { createEditor, jsonFromNode } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import Toolbar from './toolbar.vue'

--- a/website/src/examples/vue/link-mark-view/editor.vue
+++ b/website/src/examples/vue/link-mark-view/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 

--- a/website/src/examples/vue/link/editor.vue
+++ b/website/src/examples/vue/link/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import InlineMenu from './inline-menu.vue'

--- a/website/src/examples/vue/list/editor.vue
+++ b/website/src/examples/vue/list/editor.vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 import 'prosekit/extensions/list/style.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import Toolbar from './toolbar.vue'

--- a/website/src/examples/vue/mark-rule/editor.vue
+++ b/website/src/examples/vue/mark-rule/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 

--- a/website/src/examples/vue/minimal/editor.vue
+++ b/website/src/examples/vue/minimal/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { defineBasicExtension } from 'prosekit/basic'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 const extension = defineBasicExtension()
 const editor = createEditor({ extension })

--- a/website/src/examples/vue/placeholder/editor.vue
+++ b/website/src/examples/vue/placeholder/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 

--- a/website/src/examples/vue/readonly/editor.vue
+++ b/website/src/examples/vue/readonly/editor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/vue/save-html/editor-component.vue
+++ b/website/src/examples/vue/save-html/editor-component.vue
@@ -1,16 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import type { Editor } from 'prosekit/core'
-import {
-  ProseKit,
-  useDocChange,
-} from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ProseKit, useDocChange } from 'prosekit/vue'
+import { ref, watchPostEffect } from 'vue'
 
 const props = defineProps<{
   editor: Editor

--- a/website/src/examples/vue/save-html/editor.vue
+++ b/website/src/examples/vue/save-html/editor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { defineBasicExtension } from 'prosekit/basic'

--- a/website/src/examples/vue/save-json/editor-component.vue
+++ b/website/src/examples/vue/save-json/editor-component.vue
@@ -1,16 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import type { Editor } from 'prosekit/core'
-import {
-  ProseKit,
-  useDocChange,
-} from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ProseKit, useDocChange } from 'prosekit/vue'
+import { ref, watchPostEffect } from 'vue'
 
 const props = defineProps<{
   editor: Editor

--- a/website/src/examples/vue/save-json/editor.vue
+++ b/website/src/examples/vue/save-json/editor.vue
@@ -1,16 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { defineBasicExtension } from 'prosekit/basic'
-import {
-  createEditor,
-  type NodeJSON,
-} from 'prosekit/core'
-import {
-  computed,
-  ref,
-} from 'vue'
+import { createEditor, type NodeJSON } from 'prosekit/core'
+import { computed, ref } from 'vue'
 
 import EditorComponent from './editor-component.vue'
 

--- a/website/src/examples/vue/save-markdown/editor-component.vue
+++ b/website/src/examples/vue/save-markdown/editor-component.vue
@@ -1,16 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import type { Editor } from 'prosekit/core'
-import {
-  ProseKit,
-  useDocChange,
-} from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ProseKit, useDocChange } from 'prosekit/vue'
+import { ref, watchPostEffect } from 'vue'
 
 const props = defineProps<{
   editor: Editor

--- a/website/src/examples/vue/save-markdown/editor.vue
+++ b/website/src/examples/vue/save-markdown/editor.vue
@@ -1,23 +1,14 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { defineBasicExtension } from 'prosekit/basic'
-import {
-  createEditor,
-  jsonFromHTML,
-  type NodeJSON,
-} from 'prosekit/core'
-import {
-  computed,
-  ref,
-} from 'vue'
+import { createEditor, jsonFromHTML, type NodeJSON } from 'prosekit/core'
+import { computed, ref } from 'vue'
 
 import EditorComponent from './editor-component.vue'
-import {
-  htmlFromMarkdown,
-  markdownFromHTML,
-} from './markdown'
+import { htmlFromMarkdown, markdownFromHTML } from './markdown'
 
 const defaultContent = ref<NodeJSON | undefined>()
 const records = ref<string[]>([])

--- a/website/src/examples/vue/slash-menu/editor.vue
+++ b/website/src/examples/vue/slash-menu/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import SlashMenu from './slash-menu.vue'

--- a/website/src/examples/vue/strike/editor.vue
+++ b/website/src/examples/vue/strike/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import Toolbar from './toolbar.vue'

--- a/website/src/examples/vue/table/editor.vue
+++ b/website/src/examples/vue/table/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import TableHandle from './table-handle.vue'

--- a/website/src/examples/vue/text-align/editor.vue
+++ b/website/src/examples/vue/text-align/editor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'

--- a/website/src/examples/vue/text-color/editor.vue
+++ b/website/src/examples/vue/text-color/editor.vue
@@ -1,26 +1,25 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import InlineMenu from './inline-menu.vue'
 
-const defaultContent = '<p>'
-  + '<span style="color: #ef4444">Select</span> '
-  + '<span style="color: #f97316">some</span> '
-  + '<span style="color: #eab308">text</span> '
-  + '<span style="color: #22c55e">to</span> '
-  + '<span style="color: #3b82f6">change</span> '
-  + '<span style="color: #6366f1">the</span> '
-  + '<span style="color: #a855f7">color</span> '
-  + '</p>'
+const defaultContent =
+  '<p>' +
+  '<span style="color: #ef4444">Select</span> ' +
+  '<span style="color: #f97316">some</span> ' +
+  '<span style="color: #eab308">text</span> ' +
+  '<span style="color: #22c55e">to</span> ' +
+  '<span style="color: #3b82f6">change</span> ' +
+  '<span style="color: #6366f1">the</span> ' +
+  '<span style="color: #a855f7">color</span> ' +
+  '</p>'
 
 const editor = createEditor({ extension: defineExtension(), defaultContent })
 

--- a/website/src/examples/vue/toolbar/editor.vue
+++ b/website/src/examples/vue/toolbar/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import Toolbar from './toolbar.vue'

--- a/website/src/examples/vue/typography/editor.vue
+++ b/website/src/examples/vue/typography/editor.vue
@@ -6,10 +6,7 @@ import { Themes } from '@prosekit/themes'
 import { defineBasicExtension } from 'prosekit/basic'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { typographyContent } from './typography-content'
 

--- a/website/src/examples/vue/underline/editor.vue
+++ b/website/src/examples/vue/underline/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import Toolbar from './toolbar.vue'

--- a/website/src/examples/vue/unmount/editor-component.vue
+++ b/website/src/examples/vue/unmount/editor-component.vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { defineBasicExtension } from 'prosekit/basic'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import ExtensionComponent from './extension-component.vue'
 

--- a/website/src/examples/vue/user-menu-dynamic/editor.vue
+++ b/website/src/examples/vue/user-menu-dynamic/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import UserMenuDynamic from './user-menu-dynamic.vue'

--- a/website/src/examples/vue/user-menu/editor.vue
+++ b/website/src/examples/vue/user-menu/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import TagMenu from './tag-menu.vue'

--- a/website/src/examples/vue/word-counter/editor.vue
+++ b/website/src/examples/vue/word-counter/editor.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
 
 import { Themes } from '@prosekit/themes'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/vue'
-import {
-  ref,
-  watchPostEffect,
-} from 'vue'
+import { ref, watchPostEffect } from 'vue'
 
 import { defineExtension } from './extension'
 import WordCounter from './word-counter.vue'

--- a/website/src/stories/container.astro
+++ b/website/src/stories/container.astro
@@ -1,7 +1,3 @@
----
-import 'prosekit/basic/typography.css'
----
-
 <div data-prosekit-story-container class="w-full h-full min-w-0 min-h-0 max-h-full">
   <div
     data-prosekit-story-container-inner


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated instructions for importing base styles to improve clarity for users configuring their projects.
  
- **Style**
  - Enhanced typography styling across examples in multiple frameworks to ensure a more consistent and visually appealing text presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->