### PR TITLE
feat(heading): update heading keymap to use 'mod-alt' instead of 'mod'

### DIFF
--- a/.changeset/1500.md
+++ b/.changeset/1500.md
@@ -1,0 +1,7 @@
+---
+'@prosekit/extensions': minor
+---
+
+Updated heading shortcuts to use `mod-alt-1`, `mod-alt-2`, etc. instead of
+`mod-1`, `mod-2`. This matches common text editors like Google Docs, Microsoft
+Word, and Notion.

--- a/.changeset/1500.md
+++ b/.changeset/1500.md
@@ -2,6 +2,4 @@
 '@prosekit/extensions': minor
 ---
 
-Updated heading shortcuts to use `mod-alt-1`, `mod-alt-2`, etc. instead of
-`mod-1`, `mod-2`. This matches common text editors like Google Docs, Microsoft
-Word, and Notion.
+Changed heading shortcuts from `mod-1`, `mod-2` to `mod-alt-1`, `mod-alt-2`, etc. This matches popular text editors like Google Docs, Microsoft Word, and Notion.

--- a/.changeset/1500.md
+++ b/.changeset/1500.md
@@ -1,5 +1,5 @@
 ---
-'prosekit': patch
+'prosekit': minor
 '@prosekit/extensions': minor
 ---
 

--- a/packages/extensions/src/heading/heading-keymap.spec.ts
+++ b/packages/extensions/src/heading/heading-keymap.spec.ts
@@ -17,13 +17,13 @@ describe('defineHeadingKeymap', () => {
 
     editor.set(doc)
     expect(editor.state.doc.toJSON()).toEqual(doc.toJSON())
-    await pressKey('mod-1')
+    await pressKey('mod-alt-1')
     expect(editor.state.doc.toJSON()).toEqual(docH1.toJSON())
-    await pressKey('mod-1')
+    await pressKey('mod-alt-1')
     expect(editor.state.doc.toJSON()).toEqual(doc.toJSON())
-    await pressKey('mod-3')
+    await pressKey('mod-alt-3')
     expect(editor.state.doc.toJSON()).toEqual(docH3.toJSON())
-    await pressKey('mod-1')
+    await pressKey('mod-alt-1')
     expect(editor.state.doc.toJSON()).toEqual(docH1.toJSON())
   })
 

--- a/packages/extensions/src/heading/heading-keymap.ts
+++ b/packages/extensions/src/heading/heading-keymap.ts
@@ -28,12 +28,12 @@ const backspaceUnsetHeading: Command = (state, dispatch, view) => {
  */
 export function defineHeadingKeymap() {
   return defineKeymap({
-    'mod-1': toggleHeadingKeybinding(1),
-    'mod-2': toggleHeadingKeybinding(2),
-    'mod-3': toggleHeadingKeybinding(3),
-    'mod-4': toggleHeadingKeybinding(4),
-    'mod-5': toggleHeadingKeybinding(5),
-    'mod-6': toggleHeadingKeybinding(6),
+    'mod-alt-1': toggleHeadingKeybinding(1),
+    'mod-alt-2': toggleHeadingKeybinding(2),
+    'mod-alt-3': toggleHeadingKeybinding(3),
+    'mod-alt-4': toggleHeadingKeybinding(4),
+    'mod-alt-5': toggleHeadingKeybinding(5),
+    'mod-alt-6': toggleHeadingKeybinding(6),
     'Backspace': backspaceUnsetHeading,
   })
 }

--- a/website/src/content/docs/extensions/heading.mdx
+++ b/website/src/content/docs/extensions/heading.mdx
@@ -38,15 +38,15 @@ editor.commands.insertHeading({ level: 1 })
 
 ## Keyboard Shortcuts
 
-| Non-Apple   | Apple       | Description                                                                 |
-| ----------- | ----------- | --------------------------------------------------------------------------- |
-| `Ctrl-1`    | `Command-1` | Set the current block to an H1 node                                         |
-| `Ctrl-2`    | `Command-2` | Set the current block to an H2 node                                         |
-| `Ctrl-3`    | `Command-3` | Set the current block to an H3 node                                         |
-| `Ctrl-4`    | `Command-4` | Set the current block to an H4 node                                         |
-| `Ctrl-5`    | `Command-5` | Set the current block to an H5 node                                         |
-| `Ctrl-6`    | `Command-6` | Set the current block to an H6 node                                         |
-| `Backspace` | `Backspace` | When the text cursor is at the start of a heading node, set it to paragraph |
+| Non-Apple    | Apple              | Description                                                                 |
+| ------------ | ------------------ | --------------------------------------------------------------------------- |
+| `Ctrl-Alt-1` | `Command-Option-1` | Set the current block to an H1 node                                         |
+| `Ctrl-Alt-2` | `Command-Option-2` | Set the current block to an H2 node                                         |
+| `Ctrl-Alt-3` | `Command-Option-3` | Set the current block to an H3 node                                         |
+| `Ctrl-Alt-4` | `Command-Option-4` | Set the current block to an H4 node                                         |
+| `Ctrl-Alt-5` | `Command-Option-5` | Set the current block to an H5 node                                         |
+| `Ctrl-Alt-6` | `Command-Option-6` | Set the current block to an H6 node                                         |
+| `Backspace`  | `Backspace`        | When the text cursor is at the start of a heading node, set it to paragraph |
 
 ## Keyboard Interaction
 


### PR DESCRIPTION
Closes https://github.com/prosekit/prosekit/issues/931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated keyboard shortcuts for setting heading levels. The new combinations (using alternative modifiers) now mirror those found in popular text editors.

- **Documentation**
  - Revised documentation to reflect the updated key combinations for both non-Apple (Ctrl-Alt) and Apple (Command-Option) users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->