### PR TITLE
chore: remove import conditions in package.json

### DIFF
--- a/packages/basic/package.json
+++ b/packages/basic/package.json
@@ -53,7 +53,6 @@
     "exports": {
       ".": {
         "types": "./dist/prosekit-basic.d.ts",
-        "import": "./dist/prosekit-basic.js",
         "default": "./dist/prosekit-basic.js"
       },
       "./style.css": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,12 +55,10 @@
     "exports": {
       ".": {
         "types": "./dist/prosekit-core.d.ts",
-        "import": "./dist/prosekit-core.js",
         "default": "./dist/prosekit-core.js"
       },
       "./test": {
         "types": "./dist/prosekit-core-test.d.ts",
-        "import": "./dist/prosekit-core-test.js",
         "default": "./dist/prosekit-core-test.js"
       }
     },

--- a/packages/dev/src/normalize-package-json.ts
+++ b/packages/dev/src/normalize-package-json.ts
@@ -55,7 +55,6 @@ export async function normalizePackageJson(pkg: Package) {
       exports[path] = sourcePath
       publishExports[path] = {
         types: `./dist/${distName}.d.ts`,
-        import: `./dist/${distName}.js`,
         default: `./dist/${distName}.js`,
       }
     } else if (path.endsWith('.css')) {

--- a/packages/dev/src/normalize-package-json.ts
+++ b/packages/dev/src/normalize-package-json.ts
@@ -107,7 +107,6 @@ export async function normalizePackageJson(pkg: Package) {
       publishExports[path] = {
         types: `./dist/${distName}.d.ts`,
         svelte: isSvelte ? `./dist/${distName}.js` : undefined,
-        import: `./dist/${distName}.js`,
         default: `./dist/${distName}.js`,
       }
     }

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -127,37 +127,30 @@
     "exports": {
       ".": {
         "types": "./dist/prosekit-extensions.d.ts",
-        "import": "./dist/prosekit-extensions.js",
         "default": "./dist/prosekit-extensions.js"
       },
       "./autocomplete": {
         "types": "./dist/prosekit-extensions-autocomplete.d.ts",
-        "import": "./dist/prosekit-extensions-autocomplete.js",
         "default": "./dist/prosekit-extensions-autocomplete.js"
       },
       "./blockquote": {
         "types": "./dist/prosekit-extensions-blockquote.d.ts",
-        "import": "./dist/prosekit-extensions-blockquote.js",
         "default": "./dist/prosekit-extensions-blockquote.js"
       },
       "./bold": {
         "types": "./dist/prosekit-extensions-bold.d.ts",
-        "import": "./dist/prosekit-extensions-bold.js",
         "default": "./dist/prosekit-extensions-bold.js"
       },
       "./code": {
         "types": "./dist/prosekit-extensions-code.d.ts",
-        "import": "./dist/prosekit-extensions-code.js",
         "default": "./dist/prosekit-extensions-code.js"
       },
       "./code-block": {
         "types": "./dist/prosekit-extensions-code-block.d.ts",
-        "import": "./dist/prosekit-extensions-code-block.js",
         "default": "./dist/prosekit-extensions-code-block.js"
       },
       "./commit": {
         "types": "./dist/prosekit-extensions-commit.d.ts",
-        "import": "./dist/prosekit-extensions-commit.js",
         "default": "./dist/prosekit-extensions-commit.js"
       },
       "./commit/style.css": {
@@ -165,27 +158,22 @@
       },
       "./doc": {
         "types": "./dist/prosekit-extensions-doc.d.ts",
-        "import": "./dist/prosekit-extensions-doc.js",
         "default": "./dist/prosekit-extensions-doc.js"
       },
       "./drop-cursor": {
         "types": "./dist/prosekit-extensions-drop-cursor.d.ts",
-        "import": "./dist/prosekit-extensions-drop-cursor.js",
         "default": "./dist/prosekit-extensions-drop-cursor.js"
       },
       "./enter-rule": {
         "types": "./dist/prosekit-extensions-enter-rule.d.ts",
-        "import": "./dist/prosekit-extensions-enter-rule.js",
         "default": "./dist/prosekit-extensions-enter-rule.js"
       },
       "./file": {
         "types": "./dist/prosekit-extensions-file.d.ts",
-        "import": "./dist/prosekit-extensions-file.js",
         "default": "./dist/prosekit-extensions-file.js"
       },
       "./gap-cursor": {
         "types": "./dist/prosekit-extensions-gap-cursor.d.ts",
-        "import": "./dist/prosekit-extensions-gap-cursor.js",
         "default": "./dist/prosekit-extensions-gap-cursor.js"
       },
       "./gap-cursor/style.css": {
@@ -193,37 +181,30 @@
       },
       "./heading": {
         "types": "./dist/prosekit-extensions-heading.d.ts",
-        "import": "./dist/prosekit-extensions-heading.js",
         "default": "./dist/prosekit-extensions-heading.js"
       },
       "./horizontal-rule": {
         "types": "./dist/prosekit-extensions-horizontal-rule.d.ts",
-        "import": "./dist/prosekit-extensions-horizontal-rule.js",
         "default": "./dist/prosekit-extensions-horizontal-rule.js"
       },
       "./image": {
         "types": "./dist/prosekit-extensions-image.d.ts",
-        "import": "./dist/prosekit-extensions-image.js",
         "default": "./dist/prosekit-extensions-image.js"
       },
       "./input-rule": {
         "types": "./dist/prosekit-extensions-input-rule.d.ts",
-        "import": "./dist/prosekit-extensions-input-rule.js",
         "default": "./dist/prosekit-extensions-input-rule.js"
       },
       "./italic": {
         "types": "./dist/prosekit-extensions-italic.d.ts",
-        "import": "./dist/prosekit-extensions-italic.js",
         "default": "./dist/prosekit-extensions-italic.js"
       },
       "./link": {
         "types": "./dist/prosekit-extensions-link.d.ts",
-        "import": "./dist/prosekit-extensions-link.js",
         "default": "./dist/prosekit-extensions-link.js"
       },
       "./list": {
         "types": "./dist/prosekit-extensions-list.d.ts",
-        "import": "./dist/prosekit-extensions-list.js",
         "default": "./dist/prosekit-extensions-list.js"
       },
       "./list/style.css": {
@@ -231,7 +212,6 @@
       },
       "./loro": {
         "types": "./dist/prosekit-extensions-loro.d.ts",
-        "import": "./dist/prosekit-extensions-loro.js",
         "default": "./dist/prosekit-extensions-loro.js"
       },
       "./loro/style.css": {
@@ -239,27 +219,22 @@
       },
       "./mark-rule": {
         "types": "./dist/prosekit-extensions-mark-rule.d.ts",
-        "import": "./dist/prosekit-extensions-mark-rule.js",
         "default": "./dist/prosekit-extensions-mark-rule.js"
       },
       "./mention": {
         "types": "./dist/prosekit-extensions-mention.d.ts",
-        "import": "./dist/prosekit-extensions-mention.js",
         "default": "./dist/prosekit-extensions-mention.js"
       },
       "./mod-click-prevention": {
         "types": "./dist/prosekit-extensions-mod-click-prevention.d.ts",
-        "import": "./dist/prosekit-extensions-mod-click-prevention.js",
         "default": "./dist/prosekit-extensions-mod-click-prevention.js"
       },
       "./paragraph": {
         "types": "./dist/prosekit-extensions-paragraph.d.ts",
-        "import": "./dist/prosekit-extensions-paragraph.js",
         "default": "./dist/prosekit-extensions-paragraph.js"
       },
       "./placeholder": {
         "types": "./dist/prosekit-extensions-placeholder.d.ts",
-        "import": "./dist/prosekit-extensions-placeholder.js",
         "default": "./dist/prosekit-extensions-placeholder.js"
       },
       "./placeholder/style.css": {
@@ -267,12 +242,10 @@
       },
       "./readonly": {
         "types": "./dist/prosekit-extensions-readonly.d.ts",
-        "import": "./dist/prosekit-extensions-readonly.js",
         "default": "./dist/prosekit-extensions-readonly.js"
       },
       "./search": {
         "types": "./dist/prosekit-extensions-search.d.ts",
-        "import": "./dist/prosekit-extensions-search.js",
         "default": "./dist/prosekit-extensions-search.js"
       },
       "./search/style.css": {
@@ -280,12 +253,10 @@
       },
       "./strike": {
         "types": "./dist/prosekit-extensions-strike.d.ts",
-        "import": "./dist/prosekit-extensions-strike.js",
         "default": "./dist/prosekit-extensions-strike.js"
       },
       "./table": {
         "types": "./dist/prosekit-extensions-table.d.ts",
-        "import": "./dist/prosekit-extensions-table.js",
         "default": "./dist/prosekit-extensions-table.js"
       },
       "./table/style.css": {
@@ -293,22 +264,18 @@
       },
       "./text": {
         "types": "./dist/prosekit-extensions-text.d.ts",
-        "import": "./dist/prosekit-extensions-text.js",
         "default": "./dist/prosekit-extensions-text.js"
       },
       "./text-align": {
         "types": "./dist/prosekit-extensions-text-align.d.ts",
-        "import": "./dist/prosekit-extensions-text-align.js",
         "default": "./dist/prosekit-extensions-text-align.js"
       },
       "./underline": {
         "types": "./dist/prosekit-extensions-underline.d.ts",
-        "import": "./dist/prosekit-extensions-underline.js",
         "default": "./dist/prosekit-extensions-underline.js"
       },
       "./virtual-selection": {
         "types": "./dist/prosekit-extensions-virtual-selection.d.ts",
-        "import": "./dist/prosekit-extensions-virtual-selection.js",
         "default": "./dist/prosekit-extensions-virtual-selection.js"
       },
       "./virtual-selection/style.css": {
@@ -316,7 +283,6 @@
       },
       "./yjs": {
         "types": "./dist/prosekit-extensions-yjs.d.ts",
-        "import": "./dist/prosekit-extensions-yjs.js",
         "default": "./dist/prosekit-extensions-yjs.js"
       },
       "./yjs/style.css": {

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -54,42 +54,34 @@
     "exports": {
       ".": {
         "types": "./dist/prosekit-lit.d.ts",
-        "import": "./dist/prosekit-lit.js",
         "default": "./dist/prosekit-lit.js"
       },
       "./autocomplete": {
         "types": "./dist/prosekit-lit-autocomplete.d.ts",
-        "import": "./dist/prosekit-lit-autocomplete.js",
         "default": "./dist/prosekit-lit-autocomplete.js"
       },
       "./block-handle": {
         "types": "./dist/prosekit-lit-block-handle.d.ts",
-        "import": "./dist/prosekit-lit-block-handle.js",
         "default": "./dist/prosekit-lit-block-handle.js"
       },
       "./inline-popover": {
         "types": "./dist/prosekit-lit-inline-popover.d.ts",
-        "import": "./dist/prosekit-lit-inline-popover.js",
         "default": "./dist/prosekit-lit-inline-popover.js"
       },
       "./popover": {
         "types": "./dist/prosekit-lit-popover.d.ts",
-        "import": "./dist/prosekit-lit-popover.js",
         "default": "./dist/prosekit-lit-popover.js"
       },
       "./resizable": {
         "types": "./dist/prosekit-lit-resizable.d.ts",
-        "import": "./dist/prosekit-lit-resizable.js",
         "default": "./dist/prosekit-lit-resizable.js"
       },
       "./table-handle": {
         "types": "./dist/prosekit-lit-table-handle.d.ts",
-        "import": "./dist/prosekit-lit-table-handle.js",
         "default": "./dist/prosekit-lit-table-handle.js"
       },
       "./tooltip": {
         "types": "./dist/prosekit-lit-tooltip.d.ts",
-        "import": "./dist/prosekit-lit-tooltip.js",
         "default": "./dist/prosekit-lit-tooltip.js"
       }
     },

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -63,47 +63,38 @@
     "exports": {
       ".": {
         "types": "./dist/prosekit-pm.d.ts",
-        "import": "./dist/prosekit-pm.js",
         "default": "./dist/prosekit-pm.js"
       },
       "./commands": {
         "types": "./dist/prosekit-pm-commands.d.ts",
-        "import": "./dist/prosekit-pm-commands.js",
         "default": "./dist/prosekit-pm-commands.js"
       },
       "./history": {
         "types": "./dist/prosekit-pm-history.d.ts",
-        "import": "./dist/prosekit-pm-history.js",
         "default": "./dist/prosekit-pm-history.js"
       },
       "./inputrules": {
         "types": "./dist/prosekit-pm-inputrules.d.ts",
-        "import": "./dist/prosekit-pm-inputrules.js",
         "default": "./dist/prosekit-pm-inputrules.js"
       },
       "./keymap": {
         "types": "./dist/prosekit-pm-keymap.d.ts",
-        "import": "./dist/prosekit-pm-keymap.js",
         "default": "./dist/prosekit-pm-keymap.js"
       },
       "./model": {
         "types": "./dist/prosekit-pm-model.d.ts",
-        "import": "./dist/prosekit-pm-model.js",
         "default": "./dist/prosekit-pm-model.js"
       },
       "./state": {
         "types": "./dist/prosekit-pm-state.d.ts",
-        "import": "./dist/prosekit-pm-state.js",
         "default": "./dist/prosekit-pm-state.js"
       },
       "./transform": {
         "types": "./dist/prosekit-pm-transform.d.ts",
-        "import": "./dist/prosekit-pm-transform.js",
         "default": "./dist/prosekit-pm-transform.js"
       },
       "./view": {
         "types": "./dist/prosekit-pm-view.d.ts",
-        "import": "./dist/prosekit-pm-view.js",
         "default": "./dist/prosekit-pm-view.js"
       },
       "./view/style/prosemirror.css": {

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -66,42 +66,34 @@
     "exports": {
       ".": {
         "types": "./dist/prosekit-preact.d.ts",
-        "import": "./dist/prosekit-preact.js",
         "default": "./dist/prosekit-preact.js"
       },
       "./autocomplete": {
         "types": "./dist/prosekit-preact-autocomplete.d.ts",
-        "import": "./dist/prosekit-preact-autocomplete.js",
         "default": "./dist/prosekit-preact-autocomplete.js"
       },
       "./block-handle": {
         "types": "./dist/prosekit-preact-block-handle.d.ts",
-        "import": "./dist/prosekit-preact-block-handle.js",
         "default": "./dist/prosekit-preact-block-handle.js"
       },
       "./inline-popover": {
         "types": "./dist/prosekit-preact-inline-popover.d.ts",
-        "import": "./dist/prosekit-preact-inline-popover.js",
         "default": "./dist/prosekit-preact-inline-popover.js"
       },
       "./popover": {
         "types": "./dist/prosekit-preact-popover.d.ts",
-        "import": "./dist/prosekit-preact-popover.js",
         "default": "./dist/prosekit-preact-popover.js"
       },
       "./resizable": {
         "types": "./dist/prosekit-preact-resizable.d.ts",
-        "import": "./dist/prosekit-preact-resizable.js",
         "default": "./dist/prosekit-preact-resizable.js"
       },
       "./table-handle": {
         "types": "./dist/prosekit-preact-table-handle.d.ts",
-        "import": "./dist/prosekit-preact-table-handle.js",
         "default": "./dist/prosekit-preact-table-handle.js"
       },
       "./tooltip": {
         "types": "./dist/prosekit-preact-tooltip.d.ts",
-        "import": "./dist/prosekit-preact-tooltip.js",
         "default": "./dist/prosekit-preact-tooltip.js"
       }
     },

--- a/packages/prosekit/package.json
+++ b/packages/prosekit/package.json
@@ -232,12 +232,10 @@
     "exports": {
       ".": {
         "types": "./dist/prosekit.d.ts",
-        "import": "./dist/prosekit.js",
         "default": "./dist/prosekit.js"
       },
       "./basic": {
         "types": "./dist/prosekit-basic.d.ts",
-        "import": "./dist/prosekit-basic.js",
         "default": "./dist/prosekit-basic.js"
       },
       "./basic/style.css": {
@@ -248,47 +246,38 @@
       },
       "./core": {
         "types": "./dist/prosekit-core.d.ts",
-        "import": "./dist/prosekit-core.js",
         "default": "./dist/prosekit-core.js"
       },
       "./core/test": {
         "types": "./dist/prosekit-core-test.d.ts",
-        "import": "./dist/prosekit-core-test.js",
         "default": "./dist/prosekit-core-test.js"
       },
       "./extensions": {
         "types": "./dist/prosekit-extensions.d.ts",
-        "import": "./dist/prosekit-extensions.js",
         "default": "./dist/prosekit-extensions.js"
       },
       "./extensions/autocomplete": {
         "types": "./dist/prosekit-extensions-autocomplete.d.ts",
-        "import": "./dist/prosekit-extensions-autocomplete.js",
         "default": "./dist/prosekit-extensions-autocomplete.js"
       },
       "./extensions/blockquote": {
         "types": "./dist/prosekit-extensions-blockquote.d.ts",
-        "import": "./dist/prosekit-extensions-blockquote.js",
         "default": "./dist/prosekit-extensions-blockquote.js"
       },
       "./extensions/bold": {
         "types": "./dist/prosekit-extensions-bold.d.ts",
-        "import": "./dist/prosekit-extensions-bold.js",
         "default": "./dist/prosekit-extensions-bold.js"
       },
       "./extensions/code": {
         "types": "./dist/prosekit-extensions-code.d.ts",
-        "import": "./dist/prosekit-extensions-code.js",
         "default": "./dist/prosekit-extensions-code.js"
       },
       "./extensions/code-block": {
         "types": "./dist/prosekit-extensions-code-block.d.ts",
-        "import": "./dist/prosekit-extensions-code-block.js",
         "default": "./dist/prosekit-extensions-code-block.js"
       },
       "./extensions/commit": {
         "types": "./dist/prosekit-extensions-commit.d.ts",
-        "import": "./dist/prosekit-extensions-commit.js",
         "default": "./dist/prosekit-extensions-commit.js"
       },
       "./extensions/commit/style.css": {
@@ -296,27 +285,22 @@
       },
       "./extensions/doc": {
         "types": "./dist/prosekit-extensions-doc.d.ts",
-        "import": "./dist/prosekit-extensions-doc.js",
         "default": "./dist/prosekit-extensions-doc.js"
       },
       "./extensions/drop-cursor": {
         "types": "./dist/prosekit-extensions-drop-cursor.d.ts",
-        "import": "./dist/prosekit-extensions-drop-cursor.js",
         "default": "./dist/prosekit-extensions-drop-cursor.js"
       },
       "./extensions/enter-rule": {
         "types": "./dist/prosekit-extensions-enter-rule.d.ts",
-        "import": "./dist/prosekit-extensions-enter-rule.js",
         "default": "./dist/prosekit-extensions-enter-rule.js"
       },
       "./extensions/file": {
         "types": "./dist/prosekit-extensions-file.d.ts",
-        "import": "./dist/prosekit-extensions-file.js",
         "default": "./dist/prosekit-extensions-file.js"
       },
       "./extensions/gap-cursor": {
         "types": "./dist/prosekit-extensions-gap-cursor.d.ts",
-        "import": "./dist/prosekit-extensions-gap-cursor.js",
         "default": "./dist/prosekit-extensions-gap-cursor.js"
       },
       "./extensions/gap-cursor/style.css": {
@@ -324,37 +308,30 @@
       },
       "./extensions/heading": {
         "types": "./dist/prosekit-extensions-heading.d.ts",
-        "import": "./dist/prosekit-extensions-heading.js",
         "default": "./dist/prosekit-extensions-heading.js"
       },
       "./extensions/horizontal-rule": {
         "types": "./dist/prosekit-extensions-horizontal-rule.d.ts",
-        "import": "./dist/prosekit-extensions-horizontal-rule.js",
         "default": "./dist/prosekit-extensions-horizontal-rule.js"
       },
       "./extensions/image": {
         "types": "./dist/prosekit-extensions-image.d.ts",
-        "import": "./dist/prosekit-extensions-image.js",
         "default": "./dist/prosekit-extensions-image.js"
       },
       "./extensions/input-rule": {
         "types": "./dist/prosekit-extensions-input-rule.d.ts",
-        "import": "./dist/prosekit-extensions-input-rule.js",
         "default": "./dist/prosekit-extensions-input-rule.js"
       },
       "./extensions/italic": {
         "types": "./dist/prosekit-extensions-italic.d.ts",
-        "import": "./dist/prosekit-extensions-italic.js",
         "default": "./dist/prosekit-extensions-italic.js"
       },
       "./extensions/link": {
         "types": "./dist/prosekit-extensions-link.d.ts",
-        "import": "./dist/prosekit-extensions-link.js",
         "default": "./dist/prosekit-extensions-link.js"
       },
       "./extensions/list": {
         "types": "./dist/prosekit-extensions-list.d.ts",
-        "import": "./dist/prosekit-extensions-list.js",
         "default": "./dist/prosekit-extensions-list.js"
       },
       "./extensions/list/style.css": {
@@ -362,7 +339,6 @@
       },
       "./extensions/loro": {
         "types": "./dist/prosekit-extensions-loro.d.ts",
-        "import": "./dist/prosekit-extensions-loro.js",
         "default": "./dist/prosekit-extensions-loro.js"
       },
       "./extensions/loro/style.css": {
@@ -370,27 +346,22 @@
       },
       "./extensions/mark-rule": {
         "types": "./dist/prosekit-extensions-mark-rule.d.ts",
-        "import": "./dist/prosekit-extensions-mark-rule.js",
         "default": "./dist/prosekit-extensions-mark-rule.js"
       },
       "./extensions/mention": {
         "types": "./dist/prosekit-extensions-mention.d.ts",
-        "import": "./dist/prosekit-extensions-mention.js",
         "default": "./dist/prosekit-extensions-mention.js"
       },
       "./extensions/mod-click-prevention": {
         "types": "./dist/prosekit-extensions-mod-click-prevention.d.ts",
-        "import": "./dist/prosekit-extensions-mod-click-prevention.js",
         "default": "./dist/prosekit-extensions-mod-click-prevention.js"
       },
       "./extensions/paragraph": {
         "types": "./dist/prosekit-extensions-paragraph.d.ts",
-        "import": "./dist/prosekit-extensions-paragraph.js",
         "default": "./dist/prosekit-extensions-paragraph.js"
       },
       "./extensions/placeholder": {
         "types": "./dist/prosekit-extensions-placeholder.d.ts",
-        "import": "./dist/prosekit-extensions-placeholder.js",
         "default": "./dist/prosekit-extensions-placeholder.js"
       },
       "./extensions/placeholder/style.css": {
@@ -398,12 +369,10 @@
       },
       "./extensions/readonly": {
         "types": "./dist/prosekit-extensions-readonly.d.ts",
-        "import": "./dist/prosekit-extensions-readonly.js",
         "default": "./dist/prosekit-extensions-readonly.js"
       },
       "./extensions/search": {
         "types": "./dist/prosekit-extensions-search.d.ts",
-        "import": "./dist/prosekit-extensions-search.js",
         "default": "./dist/prosekit-extensions-search.js"
       },
       "./extensions/search/style.css": {
@@ -411,12 +380,10 @@
       },
       "./extensions/strike": {
         "types": "./dist/prosekit-extensions-strike.d.ts",
-        "import": "./dist/prosekit-extensions-strike.js",
         "default": "./dist/prosekit-extensions-strike.js"
       },
       "./extensions/table": {
         "types": "./dist/prosekit-extensions-table.d.ts",
-        "import": "./dist/prosekit-extensions-table.js",
         "default": "./dist/prosekit-extensions-table.js"
       },
       "./extensions/table/style.css": {
@@ -424,22 +391,18 @@
       },
       "./extensions/text": {
         "types": "./dist/prosekit-extensions-text.d.ts",
-        "import": "./dist/prosekit-extensions-text.js",
         "default": "./dist/prosekit-extensions-text.js"
       },
       "./extensions/text-align": {
         "types": "./dist/prosekit-extensions-text-align.d.ts",
-        "import": "./dist/prosekit-extensions-text-align.js",
         "default": "./dist/prosekit-extensions-text-align.js"
       },
       "./extensions/underline": {
         "types": "./dist/prosekit-extensions-underline.d.ts",
-        "import": "./dist/prosekit-extensions-underline.js",
         "default": "./dist/prosekit-extensions-underline.js"
       },
       "./extensions/virtual-selection": {
         "types": "./dist/prosekit-extensions-virtual-selection.d.ts",
-        "import": "./dist/prosekit-extensions-virtual-selection.js",
         "default": "./dist/prosekit-extensions-virtual-selection.js"
       },
       "./extensions/virtual-selection/style.css": {
@@ -447,7 +410,6 @@
       },
       "./extensions/yjs": {
         "types": "./dist/prosekit-extensions-yjs.d.ts",
-        "import": "./dist/prosekit-extensions-yjs.js",
         "default": "./dist/prosekit-extensions-yjs.js"
       },
       "./extensions/yjs/style.css": {
@@ -455,87 +417,70 @@
       },
       "./lit": {
         "types": "./dist/prosekit-lit.d.ts",
-        "import": "./dist/prosekit-lit.js",
         "default": "./dist/prosekit-lit.js"
       },
       "./lit/autocomplete": {
         "types": "./dist/prosekit-lit-autocomplete.d.ts",
-        "import": "./dist/prosekit-lit-autocomplete.js",
         "default": "./dist/prosekit-lit-autocomplete.js"
       },
       "./lit/block-handle": {
         "types": "./dist/prosekit-lit-block-handle.d.ts",
-        "import": "./dist/prosekit-lit-block-handle.js",
         "default": "./dist/prosekit-lit-block-handle.js"
       },
       "./lit/inline-popover": {
         "types": "./dist/prosekit-lit-inline-popover.d.ts",
-        "import": "./dist/prosekit-lit-inline-popover.js",
         "default": "./dist/prosekit-lit-inline-popover.js"
       },
       "./lit/popover": {
         "types": "./dist/prosekit-lit-popover.d.ts",
-        "import": "./dist/prosekit-lit-popover.js",
         "default": "./dist/prosekit-lit-popover.js"
       },
       "./lit/resizable": {
         "types": "./dist/prosekit-lit-resizable.d.ts",
-        "import": "./dist/prosekit-lit-resizable.js",
         "default": "./dist/prosekit-lit-resizable.js"
       },
       "./lit/table-handle": {
         "types": "./dist/prosekit-lit-table-handle.d.ts",
-        "import": "./dist/prosekit-lit-table-handle.js",
         "default": "./dist/prosekit-lit-table-handle.js"
       },
       "./lit/tooltip": {
         "types": "./dist/prosekit-lit-tooltip.d.ts",
-        "import": "./dist/prosekit-lit-tooltip.js",
         "default": "./dist/prosekit-lit-tooltip.js"
       },
       "./pm": {
         "types": "./dist/prosekit-pm.d.ts",
-        "import": "./dist/prosekit-pm.js",
         "default": "./dist/prosekit-pm.js"
       },
       "./pm/commands": {
         "types": "./dist/prosekit-pm-commands.d.ts",
-        "import": "./dist/prosekit-pm-commands.js",
         "default": "./dist/prosekit-pm-commands.js"
       },
       "./pm/history": {
         "types": "./dist/prosekit-pm-history.d.ts",
-        "import": "./dist/prosekit-pm-history.js",
         "default": "./dist/prosekit-pm-history.js"
       },
       "./pm/inputrules": {
         "types": "./dist/prosekit-pm-inputrules.d.ts",
-        "import": "./dist/prosekit-pm-inputrules.js",
         "default": "./dist/prosekit-pm-inputrules.js"
       },
       "./pm/keymap": {
         "types": "./dist/prosekit-pm-keymap.d.ts",
-        "import": "./dist/prosekit-pm-keymap.js",
         "default": "./dist/prosekit-pm-keymap.js"
       },
       "./pm/model": {
         "types": "./dist/prosekit-pm-model.d.ts",
-        "import": "./dist/prosekit-pm-model.js",
         "default": "./dist/prosekit-pm-model.js"
       },
       "./pm/state": {
         "types": "./dist/prosekit-pm-state.d.ts",
-        "import": "./dist/prosekit-pm-state.js",
         "default": "./dist/prosekit-pm-state.js"
       },
       "./pm/transform": {
         "types": "./dist/prosekit-pm-transform.d.ts",
-        "import": "./dist/prosekit-pm-transform.js",
         "default": "./dist/prosekit-pm-transform.js"
       },
       "./pm/view": {
         "types": "./dist/prosekit-pm-view.d.ts",
-        "import": "./dist/prosekit-pm-view.js",
         "default": "./dist/prosekit-pm-view.js"
       },
       "./pm/view/style/prosemirror.css": {
@@ -543,242 +488,194 @@
       },
       "./preact": {
         "types": "./dist/prosekit-preact.d.ts",
-        "import": "./dist/prosekit-preact.js",
         "default": "./dist/prosekit-preact.js"
       },
       "./preact/autocomplete": {
         "types": "./dist/prosekit-preact-autocomplete.d.ts",
-        "import": "./dist/prosekit-preact-autocomplete.js",
         "default": "./dist/prosekit-preact-autocomplete.js"
       },
       "./preact/block-handle": {
         "types": "./dist/prosekit-preact-block-handle.d.ts",
-        "import": "./dist/prosekit-preact-block-handle.js",
         "default": "./dist/prosekit-preact-block-handle.js"
       },
       "./preact/inline-popover": {
         "types": "./dist/prosekit-preact-inline-popover.d.ts",
-        "import": "./dist/prosekit-preact-inline-popover.js",
         "default": "./dist/prosekit-preact-inline-popover.js"
       },
       "./preact/popover": {
         "types": "./dist/prosekit-preact-popover.d.ts",
-        "import": "./dist/prosekit-preact-popover.js",
         "default": "./dist/prosekit-preact-popover.js"
       },
       "./preact/resizable": {
         "types": "./dist/prosekit-preact-resizable.d.ts",
-        "import": "./dist/prosekit-preact-resizable.js",
         "default": "./dist/prosekit-preact-resizable.js"
       },
       "./preact/table-handle": {
         "types": "./dist/prosekit-preact-table-handle.d.ts",
-        "import": "./dist/prosekit-preact-table-handle.js",
         "default": "./dist/prosekit-preact-table-handle.js"
       },
       "./preact/tooltip": {
         "types": "./dist/prosekit-preact-tooltip.d.ts",
-        "import": "./dist/prosekit-preact-tooltip.js",
         "default": "./dist/prosekit-preact-tooltip.js"
       },
       "./react": {
         "types": "./dist/prosekit-react.d.ts",
-        "import": "./dist/prosekit-react.js",
         "default": "./dist/prosekit-react.js"
       },
       "./react/autocomplete": {
         "types": "./dist/prosekit-react-autocomplete.d.ts",
-        "import": "./dist/prosekit-react-autocomplete.js",
         "default": "./dist/prosekit-react-autocomplete.js"
       },
       "./react/block-handle": {
         "types": "./dist/prosekit-react-block-handle.d.ts",
-        "import": "./dist/prosekit-react-block-handle.js",
         "default": "./dist/prosekit-react-block-handle.js"
       },
       "./react/inline-popover": {
         "types": "./dist/prosekit-react-inline-popover.d.ts",
-        "import": "./dist/prosekit-react-inline-popover.js",
         "default": "./dist/prosekit-react-inline-popover.js"
       },
       "./react/popover": {
         "types": "./dist/prosekit-react-popover.d.ts",
-        "import": "./dist/prosekit-react-popover.js",
         "default": "./dist/prosekit-react-popover.js"
       },
       "./react/resizable": {
         "types": "./dist/prosekit-react-resizable.d.ts",
-        "import": "./dist/prosekit-react-resizable.js",
         "default": "./dist/prosekit-react-resizable.js"
       },
       "./react/table-handle": {
         "types": "./dist/prosekit-react-table-handle.d.ts",
-        "import": "./dist/prosekit-react-table-handle.js",
         "default": "./dist/prosekit-react-table-handle.js"
       },
       "./react/tooltip": {
         "types": "./dist/prosekit-react-tooltip.d.ts",
-        "import": "./dist/prosekit-react-tooltip.js",
         "default": "./dist/prosekit-react-tooltip.js"
       },
       "./solid": {
         "types": "./dist/prosekit-solid.d.ts",
-        "import": "./dist/prosekit-solid.js",
         "default": "./dist/prosekit-solid.js"
       },
       "./solid/autocomplete": {
         "types": "./dist/prosekit-solid-autocomplete.d.ts",
-        "import": "./dist/prosekit-solid-autocomplete.js",
         "default": "./dist/prosekit-solid-autocomplete.js"
       },
       "./solid/block-handle": {
         "types": "./dist/prosekit-solid-block-handle.d.ts",
-        "import": "./dist/prosekit-solid-block-handle.js",
         "default": "./dist/prosekit-solid-block-handle.js"
       },
       "./solid/inline-popover": {
         "types": "./dist/prosekit-solid-inline-popover.d.ts",
-        "import": "./dist/prosekit-solid-inline-popover.js",
         "default": "./dist/prosekit-solid-inline-popover.js"
       },
       "./solid/popover": {
         "types": "./dist/prosekit-solid-popover.d.ts",
-        "import": "./dist/prosekit-solid-popover.js",
         "default": "./dist/prosekit-solid-popover.js"
       },
       "./solid/resizable": {
         "types": "./dist/prosekit-solid-resizable.d.ts",
-        "import": "./dist/prosekit-solid-resizable.js",
         "default": "./dist/prosekit-solid-resizable.js"
       },
       "./solid/table-handle": {
         "types": "./dist/prosekit-solid-table-handle.d.ts",
-        "import": "./dist/prosekit-solid-table-handle.js",
         "default": "./dist/prosekit-solid-table-handle.js"
       },
       "./solid/tooltip": {
         "types": "./dist/prosekit-solid-tooltip.d.ts",
-        "import": "./dist/prosekit-solid-tooltip.js",
         "default": "./dist/prosekit-solid-tooltip.js"
       },
       "./svelte": {
         "types": "./dist/prosekit-svelte.d.ts",
-        "import": "./dist/prosekit-svelte.js",
         "default": "./dist/prosekit-svelte.js"
       },
       "./svelte/autocomplete": {
         "types": "./dist/prosekit-svelte-autocomplete.d.ts",
-        "import": "./dist/prosekit-svelte-autocomplete.js",
         "default": "./dist/prosekit-svelte-autocomplete.js"
       },
       "./svelte/block-handle": {
         "types": "./dist/prosekit-svelte-block-handle.d.ts",
-        "import": "./dist/prosekit-svelte-block-handle.js",
         "default": "./dist/prosekit-svelte-block-handle.js"
       },
       "./svelte/inline-popover": {
         "types": "./dist/prosekit-svelte-inline-popover.d.ts",
-        "import": "./dist/prosekit-svelte-inline-popover.js",
         "default": "./dist/prosekit-svelte-inline-popover.js"
       },
       "./svelte/popover": {
         "types": "./dist/prosekit-svelte-popover.d.ts",
-        "import": "./dist/prosekit-svelte-popover.js",
         "default": "./dist/prosekit-svelte-popover.js"
       },
       "./svelte/resizable": {
         "types": "./dist/prosekit-svelte-resizable.d.ts",
-        "import": "./dist/prosekit-svelte-resizable.js",
         "default": "./dist/prosekit-svelte-resizable.js"
       },
       "./svelte/table-handle": {
         "types": "./dist/prosekit-svelte-table-handle.d.ts",
-        "import": "./dist/prosekit-svelte-table-handle.js",
         "default": "./dist/prosekit-svelte-table-handle.js"
       },
       "./svelte/tooltip": {
         "types": "./dist/prosekit-svelte-tooltip.d.ts",
-        "import": "./dist/prosekit-svelte-tooltip.js",
         "default": "./dist/prosekit-svelte-tooltip.js"
       },
       "./vue": {
         "types": "./dist/prosekit-vue.d.ts",
-        "import": "./dist/prosekit-vue.js",
         "default": "./dist/prosekit-vue.js"
       },
       "./vue/autocomplete": {
         "types": "./dist/prosekit-vue-autocomplete.d.ts",
-        "import": "./dist/prosekit-vue-autocomplete.js",
         "default": "./dist/prosekit-vue-autocomplete.js"
       },
       "./vue/block-handle": {
         "types": "./dist/prosekit-vue-block-handle.d.ts",
-        "import": "./dist/prosekit-vue-block-handle.js",
         "default": "./dist/prosekit-vue-block-handle.js"
       },
       "./vue/inline-popover": {
         "types": "./dist/prosekit-vue-inline-popover.d.ts",
-        "import": "./dist/prosekit-vue-inline-popover.js",
         "default": "./dist/prosekit-vue-inline-popover.js"
       },
       "./vue/popover": {
         "types": "./dist/prosekit-vue-popover.d.ts",
-        "import": "./dist/prosekit-vue-popover.js",
         "default": "./dist/prosekit-vue-popover.js"
       },
       "./vue/resizable": {
         "types": "./dist/prosekit-vue-resizable.d.ts",
-        "import": "./dist/prosekit-vue-resizable.js",
         "default": "./dist/prosekit-vue-resizable.js"
       },
       "./vue/table-handle": {
         "types": "./dist/prosekit-vue-table-handle.d.ts",
-        "import": "./dist/prosekit-vue-table-handle.js",
         "default": "./dist/prosekit-vue-table-handle.js"
       },
       "./vue/tooltip": {
         "types": "./dist/prosekit-vue-tooltip.d.ts",
-        "import": "./dist/prosekit-vue-tooltip.js",
         "default": "./dist/prosekit-vue-tooltip.js"
       },
       "./web": {
         "types": "./dist/prosekit-web.d.ts",
-        "import": "./dist/prosekit-web.js",
         "default": "./dist/prosekit-web.js"
       },
       "./web/autocomplete": {
         "types": "./dist/prosekit-web-autocomplete.d.ts",
-        "import": "./dist/prosekit-web-autocomplete.js",
         "default": "./dist/prosekit-web-autocomplete.js"
       },
       "./web/block-handle": {
         "types": "./dist/prosekit-web-block-handle.d.ts",
-        "import": "./dist/prosekit-web-block-handle.js",
         "default": "./dist/prosekit-web-block-handle.js"
       },
       "./web/inline-popover": {
         "types": "./dist/prosekit-web-inline-popover.d.ts",
-        "import": "./dist/prosekit-web-inline-popover.js",
         "default": "./dist/prosekit-web-inline-popover.js"
       },
       "./web/popover": {
         "types": "./dist/prosekit-web-popover.d.ts",
-        "import": "./dist/prosekit-web-popover.js",
         "default": "./dist/prosekit-web-popover.js"
       },
       "./web/resizable": {
         "types": "./dist/prosekit-web-resizable.d.ts",
-        "import": "./dist/prosekit-web-resizable.js",
         "default": "./dist/prosekit-web-resizable.js"
       },
       "./web/table-handle": {
         "types": "./dist/prosekit-web-table-handle.d.ts",
-        "import": "./dist/prosekit-web-table-handle.js",
         "default": "./dist/prosekit-web-table-handle.js"
       },
       "./web/tooltip": {
         "types": "./dist/prosekit-web-tooltip.d.ts",
-        "import": "./dist/prosekit-web-tooltip.js",
         "default": "./dist/prosekit-web-tooltip.js"
       }
     },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -75,42 +75,34 @@
     "exports": {
       ".": {
         "types": "./dist/prosekit-react.d.ts",
-        "import": "./dist/prosekit-react.js",
         "default": "./dist/prosekit-react.js"
       },
       "./autocomplete": {
         "types": "./dist/prosekit-react-autocomplete.d.ts",
-        "import": "./dist/prosekit-react-autocomplete.js",
         "default": "./dist/prosekit-react-autocomplete.js"
       },
       "./block-handle": {
         "types": "./dist/prosekit-react-block-handle.d.ts",
-        "import": "./dist/prosekit-react-block-handle.js",
         "default": "./dist/prosekit-react-block-handle.js"
       },
       "./inline-popover": {
         "types": "./dist/prosekit-react-inline-popover.d.ts",
-        "import": "./dist/prosekit-react-inline-popover.js",
         "default": "./dist/prosekit-react-inline-popover.js"
       },
       "./popover": {
         "types": "./dist/prosekit-react-popover.d.ts",
-        "import": "./dist/prosekit-react-popover.js",
         "default": "./dist/prosekit-react-popover.js"
       },
       "./resizable": {
         "types": "./dist/prosekit-react-resizable.d.ts",
-        "import": "./dist/prosekit-react-resizable.js",
         "default": "./dist/prosekit-react-resizable.js"
       },
       "./table-handle": {
         "types": "./dist/prosekit-react-table-handle.d.ts",
-        "import": "./dist/prosekit-react-table-handle.js",
         "default": "./dist/prosekit-react-table-handle.js"
       },
       "./tooltip": {
         "types": "./dist/prosekit-react-tooltip.d.ts",
-        "import": "./dist/prosekit-react-tooltip.js",
         "default": "./dist/prosekit-react-tooltip.js"
       }
     },

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -67,42 +67,34 @@
     "exports": {
       ".": {
         "types": "./dist/prosekit-solid.d.ts",
-        "import": "./dist/prosekit-solid.js",
         "default": "./dist/prosekit-solid.js"
       },
       "./autocomplete": {
         "types": "./dist/prosekit-solid-autocomplete.d.ts",
-        "import": "./dist/prosekit-solid-autocomplete.js",
         "default": "./dist/prosekit-solid-autocomplete.js"
       },
       "./block-handle": {
         "types": "./dist/prosekit-solid-block-handle.d.ts",
-        "import": "./dist/prosekit-solid-block-handle.js",
         "default": "./dist/prosekit-solid-block-handle.js"
       },
       "./inline-popover": {
         "types": "./dist/prosekit-solid-inline-popover.d.ts",
-        "import": "./dist/prosekit-solid-inline-popover.js",
         "default": "./dist/prosekit-solid-inline-popover.js"
       },
       "./popover": {
         "types": "./dist/prosekit-solid-popover.d.ts",
-        "import": "./dist/prosekit-solid-popover.js",
         "default": "./dist/prosekit-solid-popover.js"
       },
       "./resizable": {
         "types": "./dist/prosekit-solid-resizable.d.ts",
-        "import": "./dist/prosekit-solid-resizable.js",
         "default": "./dist/prosekit-solid-resizable.js"
       },
       "./table-handle": {
         "types": "./dist/prosekit-solid-table-handle.d.ts",
-        "import": "./dist/prosekit-solid-table-handle.js",
         "default": "./dist/prosekit-solid-table-handle.js"
       },
       "./tooltip": {
         "types": "./dist/prosekit-solid-tooltip.d.ts",
-        "import": "./dist/prosekit-solid-tooltip.js",
         "default": "./dist/prosekit-solid-tooltip.js"
       }
     },

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -91,49 +91,41 @@
     "exports": {
       ".": {
         "types": "./dist/prosekit-svelte.d.ts",
-        "import": "./dist/prosekit-svelte.js",
         "default": "./dist/prosekit-svelte.js"
       },
       "./autocomplete": {
         "types": "./dist/prosekit-svelte-autocomplete.d.ts",
         "svelte": "./dist/prosekit-svelte-autocomplete.js",
-        "import": "./dist/prosekit-svelte-autocomplete.js",
         "default": "./dist/prosekit-svelte-autocomplete.js"
       },
       "./block-handle": {
         "types": "./dist/prosekit-svelte-block-handle.d.ts",
         "svelte": "./dist/prosekit-svelte-block-handle.js",
-        "import": "./dist/prosekit-svelte-block-handle.js",
         "default": "./dist/prosekit-svelte-block-handle.js"
       },
       "./inline-popover": {
         "types": "./dist/prosekit-svelte-inline-popover.d.ts",
         "svelte": "./dist/prosekit-svelte-inline-popover.js",
-        "import": "./dist/prosekit-svelte-inline-popover.js",
         "default": "./dist/prosekit-svelte-inline-popover.js"
       },
       "./popover": {
         "types": "./dist/prosekit-svelte-popover.d.ts",
         "svelte": "./dist/prosekit-svelte-popover.js",
-        "import": "./dist/prosekit-svelte-popover.js",
         "default": "./dist/prosekit-svelte-popover.js"
       },
       "./resizable": {
         "types": "./dist/prosekit-svelte-resizable.d.ts",
         "svelte": "./dist/prosekit-svelte-resizable.js",
-        "import": "./dist/prosekit-svelte-resizable.js",
         "default": "./dist/prosekit-svelte-resizable.js"
       },
       "./table-handle": {
         "types": "./dist/prosekit-svelte-table-handle.d.ts",
         "svelte": "./dist/prosekit-svelte-table-handle.js",
-        "import": "./dist/prosekit-svelte-table-handle.js",
         "default": "./dist/prosekit-svelte-table-handle.js"
       },
       "./tooltip": {
         "types": "./dist/prosekit-svelte-tooltip.d.ts",
         "svelte": "./dist/prosekit-svelte-tooltip.js",
-        "import": "./dist/prosekit-svelte-tooltip.js",
         "default": "./dist/prosekit-svelte-tooltip.js"
       }
     },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -69,42 +69,34 @@
     "exports": {
       ".": {
         "types": "./dist/prosekit-vue.d.ts",
-        "import": "./dist/prosekit-vue.js",
         "default": "./dist/prosekit-vue.js"
       },
       "./autocomplete": {
         "types": "./dist/prosekit-vue-autocomplete.d.ts",
-        "import": "./dist/prosekit-vue-autocomplete.js",
         "default": "./dist/prosekit-vue-autocomplete.js"
       },
       "./block-handle": {
         "types": "./dist/prosekit-vue-block-handle.d.ts",
-        "import": "./dist/prosekit-vue-block-handle.js",
         "default": "./dist/prosekit-vue-block-handle.js"
       },
       "./inline-popover": {
         "types": "./dist/prosekit-vue-inline-popover.d.ts",
-        "import": "./dist/prosekit-vue-inline-popover.js",
         "default": "./dist/prosekit-vue-inline-popover.js"
       },
       "./popover": {
         "types": "./dist/prosekit-vue-popover.d.ts",
-        "import": "./dist/prosekit-vue-popover.js",
         "default": "./dist/prosekit-vue-popover.js"
       },
       "./resizable": {
         "types": "./dist/prosekit-vue-resizable.d.ts",
-        "import": "./dist/prosekit-vue-resizable.js",
         "default": "./dist/prosekit-vue-resizable.js"
       },
       "./table-handle": {
         "types": "./dist/prosekit-vue-table-handle.d.ts",
-        "import": "./dist/prosekit-vue-table-handle.js",
         "default": "./dist/prosekit-vue-table-handle.js"
       },
       "./tooltip": {
         "types": "./dist/prosekit-vue-tooltip.d.ts",
-        "import": "./dist/prosekit-vue-tooltip.js",
         "default": "./dist/prosekit-vue-tooltip.js"
       }
     },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -69,42 +69,34 @@
     "exports": {
       ".": {
         "types": "./dist/prosekit-web.d.ts",
-        "import": "./dist/prosekit-web.js",
         "default": "./dist/prosekit-web.js"
       },
       "./autocomplete": {
         "types": "./dist/prosekit-web-autocomplete.d.ts",
-        "import": "./dist/prosekit-web-autocomplete.js",
         "default": "./dist/prosekit-web-autocomplete.js"
       },
       "./block-handle": {
         "types": "./dist/prosekit-web-block-handle.d.ts",
-        "import": "./dist/prosekit-web-block-handle.js",
         "default": "./dist/prosekit-web-block-handle.js"
       },
       "./inline-popover": {
         "types": "./dist/prosekit-web-inline-popover.d.ts",
-        "import": "./dist/prosekit-web-inline-popover.js",
         "default": "./dist/prosekit-web-inline-popover.js"
       },
       "./popover": {
         "types": "./dist/prosekit-web-popover.d.ts",
-        "import": "./dist/prosekit-web-popover.js",
         "default": "./dist/prosekit-web-popover.js"
       },
       "./resizable": {
         "types": "./dist/prosekit-web-resizable.d.ts",
-        "import": "./dist/prosekit-web-resizable.js",
         "default": "./dist/prosekit-web-resizable.js"
       },
       "./table-handle": {
         "types": "./dist/prosekit-web-table-handle.d.ts",
-        "import": "./dist/prosekit-web-table-handle.js",
         "default": "./dist/prosekit-web-table-handle.js"
       },
       "./tooltip": {
         "types": "./dist/prosekit-web-tooltip.d.ts",
-        "import": "./dist/prosekit-web-tooltip.js",
         "default": "./dist/prosekit-web-tooltip.js"
       }
     },


### PR DESCRIPTION
1. `npm-esm-vs-cjs` incorrectly treat `prosekit` as a dual format package [^1], so it's better to only have `import` or only have `default`.
2. Node produces better error message [^2] when only having `default`. 

[^1]: https://github.com/wooorm/npm-esm-vs-cjs/blob/df05a0add544f9dd831d2779a6f8ef9faaab2e27/script/crawl.js#L296-L298
[^2]: https://github.com/orgs/nodejs/discussions/46379#discussion-4797281