### PR TITLE
fix(block-handle): fix duplicated tables after dragging

### DIFF
--- a/.changeset/pink-donuts-z6000.md
+++ b/.changeset/pink-donuts-z6000.md
@@ -1,0 +1,5 @@
+---
+'@prosekit/web': patch
+---
+
+Fix a bug where an empty table was left over after dragging a table.

--- a/packages/web/src/components/block-handle/block-handle-draggable/setup.ts
+++ b/packages/web/src/components/block-handle/block-handle-draggable/setup.ts
@@ -82,11 +82,15 @@ function useDraggingPreview(
     event.dataTransfer.effectAllowed = 'copyMove'
     event.dataTransfer.setDragImage(element, 0, 0)
 
-    view.dragging = new Dragging(
-      new Slice(Fragment.from(node), 0, 0),
-      true,
-      NodeSelection.create(view.state.doc, pos),
-    )
+    // An object matching the internal ProseMirror API shape.
+    // See https://github.com/ProseMirror/prosemirror-view/blob/1.38.1/src/input.ts#L657
+    const dragging = {
+      slice: new Slice(Fragment.from(node), 0, 0),
+      move: true,
+      node: NodeSelection.create(view.state.doc, pos),
+    }
+
+    view.dragging = dragging
   })
 }
 
@@ -107,13 +111,4 @@ function useDragging(host: ConnectableElement): ReadonlySignal<boolean> {
   })
 
   return dragging
-}
-
-/**
- * Copied from internal ProseMirror API. See also https://github.com/prosemirror/prosemirror-view/commit/9d0eb67f
- *
- * @internal
- */
-class Dragging {
-  constructor(readonly slice: Slice, readonly move: boolean, readonly node?: NodeSelection) {}
 }

--- a/packages/web/src/components/block-handle/block-handle-draggable/setup.ts
+++ b/packages/web/src/components/block-handle/block-handle-draggable/setup.ts
@@ -75,17 +75,18 @@ function useDraggingPreview(
       return
     }
 
-    const { element, node } = hoverState
+    const { element, node, pos } = hoverState
 
     event.dataTransfer.clearData()
     event.dataTransfer.setData('text/html', element.outerHTML)
     event.dataTransfer.effectAllowed = 'copyMove'
     event.dataTransfer.setDragImage(element, 0, 0)
 
-    view.dragging = {
-      slice: new Slice(Fragment.from(node), 0, 0),
-      move: true,
-    }
+    view.dragging = new Dragging(
+      new Slice(Fragment.from(node), 0, 0),
+      true,
+      NodeSelection.create(view.state.doc, pos),
+    )
   })
 }
 
@@ -106,4 +107,13 @@ function useDragging(host: ConnectableElement): ReadonlySignal<boolean> {
   })
 
   return dragging
+}
+
+/**
+ * Copied from internal ProseMirror API. See also https://github.com/prosemirror/prosemirror-view/commit/9d0eb67f
+ *
+ * @internal
+ */
+class Dragging {
+  constructor(readonly slice: Slice, readonly move: boolean, readonly node?: NodeSelection) {}
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/fa2162c9-6ad1-41ac-99ad-4d6e61ae9ea3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue where an empty table would remain visible after dragging, ensuring a cleaner interface.
	- Enhanced the drag-and-drop experience for more consistent and reliable interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->