### PR TITLE
docs: improve command type inference

### DIFF
--- a/packages/extensions/src/link/index.ts
+++ b/packages/extensions/src/link/index.ts
@@ -69,9 +69,9 @@ export function defineLinkSpec(): LinkSpecExtension {
  */
 export type LinkCommandsExtension = Extension<{
   Commands: {
-    addLink: [LinkAttrs]
+    addLink: [attrs: LinkAttrs]
     removeLink: []
-    toggleLink: [LinkAttrs]
+    toggleLink: [attrs: LinkAttrs]
     expandLink: []
   }
 }>

--- a/packages/extensions/src/table/table-commands.ts
+++ b/packages/extensions/src/table/table-commands.ts
@@ -300,7 +300,7 @@ export function selectTable(options?: SelectTableOptions): Command {
  */
 export type TableCommandsExtension = Extension<{
   Commands: {
-    insertTable: [InsertTableOptions]
+    insertTable: [options: InsertTableOptions]
     exitTable: []
 
     selectTable: [options?: SelectTableOptions]


### PR DESCRIPTION

Before


<img width="869" alt="image" src="https://github.com/user-attachments/assets/5e01d352-3661-4a6a-8869-204bc94656ae" />


After

<img width="846" alt="image" src="https://github.com/user-attachments/assets/3568e573-aecc-4c6f-8614-647526e14aab" />
