### PR TITLE
fix(autocomplete): remember multiple ignore positions

### DIFF
--- a/.changeset/moody-moments-buy.md
+++ b/.changeset/moody-moments-buy.md
@@ -1,0 +1,5 @@
+---
+'@prosekit/extensions': patch
+---
+
+Remember multiple ignore positions when dismissing the autocomplete menu. Previously, only the last ignore position was remembered.

--- a/packages/extensions/src/autocomplete/autocomplete-helpers.ts
+++ b/packages/extensions/src/autocomplete/autocomplete-helpers.ts
@@ -60,8 +60,8 @@ export function getPluginState(state: EditorState) {
   return pluginKey.getState(state)
 }
 
-export function getTrMeta(tr: Transaction): PredictionTransactionMeta {
-  return tr.getMeta(pluginKey) as PredictionTransactionMeta
+export function getTrMeta(tr: Transaction): PredictionTransactionMeta | undefined {
+  return tr.getMeta(pluginKey) as PredictionTransactionMeta | undefined
 }
 
 export function setTrMeta(

--- a/packages/extensions/src/autocomplete/autocomplete-helpers.ts
+++ b/packages/extensions/src/autocomplete/autocomplete-helpers.ts
@@ -21,28 +21,52 @@ function isInsideCode($pos: ResolvedPos): boolean {
   return $pos.marks().some((mark) => mark.type.name === 'code')
 }
 
+/**
+ * @internal
+ */
+export interface PredictionPluginMatching {
+  rule: AutocompleteRule
+  from: number
+  to: number
+  match: RegExpExecArray
+}
+
+/**
+ * @internal
+ */
 export interface PredictionPluginState {
-  active: boolean
-  ignore: number | null
-  matching: {
-    rule: AutocompleteRule
-    from: number
-    to: number
-    match: RegExpExecArray
-  } | null
+  /**
+   * The matching positions that should be ignored.
+   */
+  ignores: number[]
+
+  /**
+   * The current active matching.
+   */
+  matching: PredictionPluginMatching | null
+}
+
+/**
+ * @internal
+ */
+export interface PredictionTransactionMeta {
+  /**
+   * The from position that should be ignored.
+   */
+  ignore: number
 }
 
 export function getPluginState(state: EditorState) {
   return pluginKey.getState(state)
 }
 
-export function getTrMeta(tr: Transaction): PredictionPluginState {
-  return tr.getMeta(pluginKey) as PredictionPluginState
+export function getTrMeta(tr: Transaction): PredictionTransactionMeta {
+  return tr.getMeta(pluginKey) as PredictionTransactionMeta
 }
 
 export function setTrMeta(
   tr: Transaction,
-  meta: PredictionPluginState,
+  meta: PredictionTransactionMeta,
 ): Transaction {
   return tr.setMeta(pluginKey, meta)
 }

--- a/website/tests/slash-menu.test.ts
+++ b/website/tests/slash-menu.test.ts
@@ -100,6 +100,15 @@ testStory(['slash-menu'], () => {
 
     // Verify the content in the editor
     expect((await getEditorHTML(page)).replaceAll(/\s/g, '')).toEqual(`<p>/heading</p><p>/heading</p>`)
+
+    // Create the third paragraph
+    await editor.press('Enter')
+
+    // Ensure the menu is working again
+    await expect(menu).toBeHidden()
+    await editor.press('/')
+    await editor.pressSequentially('head')
+    await expect(menu).toBeVisible()
   })
 
   test('insert list', async ({ page }) => {

--- a/website/tests/slash-menu.test.ts
+++ b/website/tests/slash-menu.test.ts
@@ -6,6 +6,7 @@ import {
 
 import {
   emptyEditor,
+  getEditorHTML,
   testStory,
   waitForEditor,
 } from './helper'
@@ -51,6 +52,54 @@ testStory(['slash-menu'], () => {
     await expect(menu).toBeHidden()
     await editor.pressSequentially('heading')
     await expect(menu).toBeHidden()
+  })
+
+  test('remember hidden positions', async ({ page }) => {
+    const { editor, menu } = await setup(page)
+    await editor.focus()
+
+    // Enter /head in the first paragraph, and dismiss the menu
+    await expect(menu).toBeHidden()
+    await editor.press('/')
+    await expect(menu).toBeVisible()
+    await editor.press('Escape')
+    await expect(menu).toBeHidden()
+    await editor.pressSequentially('head')
+    await expect(menu).toBeHidden()
+
+    // Create a new paragraph
+    await editor.press('Enter')
+
+    // Enter /head in the second paragraph, and dismiss the menu
+    await expect(menu).toBeHidden()
+    await editor.press('/')
+    await expect(menu).toBeVisible()
+    await editor.press('Escape')
+    await expect(menu).toBeHidden()
+    await editor.pressSequentially('head')
+    await expect(menu).toBeHidden()
+
+    // Verify the content in the editor
+    expect((await getEditorHTML(page)).replaceAll(/\s/g, '')).toEqual(`<p>/head</p><p>/head</p>`)
+
+    // Move the cursor back to the first paragraph
+    await editor.press('ArrowUp')
+
+    // Enter text and the menu should still be hidden
+    await expect(menu).toBeHidden()
+    await editor.pressSequentially('ing')
+    await expect(menu).toBeHidden()
+
+    // Move the cursor back to the second paragraph
+    await editor.press('ArrowDown')
+
+    // Enter text and the menu should still be hidden
+    await expect(menu).toBeHidden()
+    await editor.pressSequentially('ing')
+    await expect(menu).toBeHidden()
+
+    // Verify the content in the editor
+    expect((await getEditorHTML(page)).replaceAll(/\s/g, '')).toEqual(`<p>/heading</p><p>/heading</p>`)
   })
 
   test('insert list', async ({ page }) => {


### PR DESCRIPTION
Closes https://github.com/prosekit/prosekit/issues/976

https://github.com/user-attachments/assets/6abd4670-0192-4059-835d-d9af54f4aad0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved autocomplete dismissal behavior to remember multiple ignored positions, enhancing the handling of autocomplete interactions.
- **Bug Fixes**
  - Ensured the autocomplete menu remains hidden in previously dismissed positions across multiple paragraphs.
- **Tests**
  - Added a test to verify the slash menu correctly remembers its hidden state in different paragraphs and resets for new ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->