### PR TITLE
fix(preact): prevent event handler from being called twice

### DIFF
--- a/.changeset/fancy-singers-tie.md
+++ b/.changeset/fancy-singers-tie.md
@@ -1,4 +1,5 @@
 ---
+'prosekit': patch
 '@prosekit/preact': patch
 ---
 

--- a/.changeset/fancy-singers-tie.md
+++ b/.changeset/fancy-singers-tie.md
@@ -1,0 +1,5 @@
+---
+'@prosekit/preact': patch
+---
+
+Fix a bug where event handlers passed to components can be called twice.

--- a/packages/preact/src/components/create-component.ts
+++ b/packages/preact/src/components/create-component.ts
@@ -32,7 +32,7 @@ export function createComponent<
   Partial<Props> & RefAttributes<CustomElement> & HTMLAttributes<CustomElement>
 > {
   const hasEditor = propNames.includes('editor')
-  const lowerCaseEventNameMap = Object.fromEntries(
+  const lowerCaseEventNameMap = new Map(
     eventNames.map((name) => [name.toLowerCase(), name]),
   )
 
@@ -56,16 +56,16 @@ export function createComponent<
 
       if (name.startsWith('on')) {
         const lowerCaseEventName = name.slice(2).toLowerCase()
-        const eventName = lowerCaseEventNameMap[lowerCaseEventName]
-        const handler = value as AnyFunction | null
-        if (eventName && handler) {
+        const eventName = lowerCaseEventNameMap.get(lowerCaseEventName)
+        if (eventName) {
           const extractDetail = eventName.endsWith('Change')
-          const normalizedHandler = extractDetail
-            ? (event: Event) => {
-              handler((event as CustomEvent).detail)
+          eventHandlers[eventName] = (event: Event) => {
+            const handler = value as AnyFunction | null
+            if (typeof handler === 'function') {
+              handler(extractDetail ? (event as CustomEvent).detail : event)
             }
-            : handler
-          eventHandlers[eventName] = normalizedHandler
+          }
+          continue
         }
       }
 

--- a/packages/react/src/components/create-component.ts
+++ b/packages/react/src/components/create-component.ts
@@ -30,7 +30,7 @@ export function createComponent<
   Partial<Props> & RefAttributes<CustomElement> & HTMLAttributes<CustomElement>
 > {
   const hasEditor = propNames.includes('editor')
-  const lowerCaseEventNameMap = Object.fromEntries(
+  const lowerCaseEventNameMap = new Map(
     eventNames.map((name) => [name.toLowerCase(), name]),
   )
 
@@ -54,16 +54,16 @@ export function createComponent<
 
       if (name.startsWith('on')) {
         const lowerCaseEventName = name.slice(2).toLowerCase()
-        const eventName = lowerCaseEventNameMap[lowerCaseEventName]
-        const handler = value as AnyFunction | null
-        if (eventName && handler) {
+        const eventName = lowerCaseEventNameMap.get(lowerCaseEventName)
+        if (eventName) {
           const extractDetail = eventName.endsWith('Change')
-          const normalizedHandler = extractDetail
-            ? (event: Event) => {
-              handler((event as CustomEvent).detail)
+          eventHandlers[eventName] = (event: Event) => {
+            const handler = value as AnyFunction | null
+            if (typeof handler === 'function') {
+              handler(extractDetail ? (event as CustomEvent).detail : event)
             }
-            : handler
-          eventHandlers[eventName] = normalizedHandler
+          }
+          continue
         }
       }
 

--- a/packages/solid/src/components/create-component.ts
+++ b/packages/solid/src/components/create-component.ts
@@ -14,7 +14,7 @@ export function createComponent<
   eventNames: string[],
 ): Component<PropsWithElement<Props, CustomElement>> {
   const hasEditor = propNames.includes('editor')
-  const lowerCaseEventNameMap = Object.fromEntries(
+  const lowerCaseEventNameMap = new Map(
     eventNames.map((name) => [name.toLowerCase(), name]),
   )
 
@@ -30,12 +30,14 @@ export function createComponent<
 
       if (name.startsWith('on')) {
         const lowerCaseEventName = name.slice(2).toLowerCase()
-        const eventName = lowerCaseEventNameMap[lowerCaseEventName]
+        const eventName = lowerCaseEventNameMap.get(lowerCaseEventName)
         if (eventName) {
           const extractDetail = eventName.endsWith('Change')
           eventHandlers['on:' + eventName] = (event: Event) => {
-            const handler = props[name] as AnyFunction
-            handler(extractDetail ? (event as CustomEvent).detail : event)
+            const handler = props[name] as AnyFunction | null
+            if (typeof handler === 'function') {
+              handler(extractDetail ? (event as CustomEvent).detail : event)
+            }
           }
           continue
         }

--- a/packages/svelte/src/components/use-component.ts
+++ b/packages/svelte/src/components/use-component.ts
@@ -12,7 +12,7 @@ export function useComponent(
   eventNames: string[],
 ): (element: HTMLElement | undefined, $$props: Record<string, unknown>) => [Record<string, unknown>, Record<string, EventHandler>] {
   const hasEditor = propNames.includes('editor')
-  const lowerCaseEventNameMap = Object.fromEntries(
+  const lowerCaseEventNameMap = new Map(
     eventNames.map((name) => [name.toLowerCase(), name]),
   )
 
@@ -38,12 +38,14 @@ export function useComponent(
 
       if (name.startsWith('on')) {
         const lowerCaseEventName = name.slice(2).toLowerCase()
-        const eventName = lowerCaseEventNameMap[lowerCaseEventName]
+        const eventName = lowerCaseEventNameMap.get(lowerCaseEventName)
         if (eventName) {
           const extractDetail = eventName.endsWith('Change')
           eventHandlers[eventName] = (event: Event) => {
-            const handler = value as AnyFunction
-            handler(extractDetail ? (event as CustomEvent).detail : event)
+            const handler = value as AnyFunction | null
+            if (typeof handler === 'function') {
+              handler(extractDetail ? (event as CustomEvent).detail : event)
+            }
           }
           continue
         }

--- a/website/tests/slash-menu.test.ts
+++ b/website/tests/slash-menu.test.ts
@@ -149,6 +149,20 @@ testStory(['slash-menu'], () => {
     await expect(orderedList).toBeVisible()
   })
 
+  test('insert blockquote', async ({ page }) => {
+    const { editor, focusedItem } = await setup(page)
+
+    const blockquote = editor.locator('blockquote')
+
+    await expect(blockquote).toHaveCount(0)
+
+    await editor.pressSequentially('/quote')
+    await expect(focusedItem).toHaveText('Quote')
+
+    await editor.press('Enter')
+    await expect(blockquote).toHaveCount(1)
+  })
+
   test('press arrow keys to select item', async ({ page }) => {
     const { editor, itemText, itemH1, itemH2, focusedItem } = await setup(page)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where event handlers in certain components were being triggered twice. Event handlers are now called only once per event.
- **Tests**
	- Added a new test to verify that using the slash command "/quote" correctly inserts a blockquote in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->