### PR TITLE
test(web): add tests for getStateWithDefaults

### DIFF
--- a/packages/web/src/utils/get-default-state.spec.ts
+++ b/packages/web/src/utils/get-default-state.spec.ts
@@ -1,5 +1,13 @@
-import { createSignal, type PropDeclarations, type SignalState } from '@aria-ui/core'
-import { describe, it, expect } from 'vitest'
+import {
+  createSignal,
+  type PropDeclarations,
+  type SignalState,
+} from '@aria-ui/core'
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
 
 import { getStateWithDefaults } from './get-default-state'
 

--- a/packages/web/src/utils/get-default-state.spec.ts
+++ b/packages/web/src/utils/get-default-state.spec.ts
@@ -1,0 +1,42 @@
+import { createSignal, type PropDeclarations, type SignalState } from '@aria-ui/core'
+import { describe, it, expect } from 'vitest'
+
+import { getStateWithDefaults } from './get-default-state'
+
+type TestProps = {
+  bool: boolean
+  num: number
+}
+
+describe('getStateWithDefaults', () => {
+  it('keeps falsy signal values from state', () => {
+    const props: PropDeclarations<TestProps> = {
+      bool: { default: true },
+      num: { default: 1 },
+    }
+
+    const state: Partial<SignalState<TestProps>> = {
+      bool: createSignal(false),
+      num: createSignal(0),
+    }
+
+    const merged = getStateWithDefaults(state, props)
+    expect(merged.bool.get()).toBe(false)
+    expect(merged.num.get()).toBe(0)
+  })
+
+  it('uses default value when state property is undefined', () => {
+    const props: PropDeclarations<TestProps> = {
+      bool: { default: true },
+      num: { default: 1 },
+    }
+
+    const state: Partial<SignalState<TestProps>> = {
+      bool: undefined,
+    }
+
+    const merged = getStateWithDefaults(state, props)
+    expect(merged.bool.get()).toBe(true)
+    expect(merged.num.get()).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for `getStateWithDefaults` to ensure falsy values are preserved and defaults applied for undefined

## Testing
- `npx vitest run packages/web/src/utils/get-default-state.spec.ts --browser.enabled=false`

------
https://chatgpt.com/codex/tasks/task_e_6840476e1a548320aa16e57faad62544

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added unit tests to verify correct merging of state with default values, ensuring falsy values are preserved and undefined values use defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->