### PR TITLE
docs: fix comment typo

### DIFF
--- a/packages/core/src/commands/toggle-wrap.ts
+++ b/packages/core/src/commands/toggle-wrap.ts
@@ -23,7 +23,7 @@ export interface ToggleWrapOptions {
 
 /**
  * Toggle between wrapping an inactive node with the provided node type, and
- * lifting it up into it's parent.
+ * lifting it up into its parent.
  *
  * @param options
  *


### PR DESCRIPTION
## Summary
- fix `it's` to `its` in toggle-wrap command documentation

## Testing
- `pnpm exec eslint packages/core/src/commands/toggle-wrap.ts`
- `pnpm test` *(fails: playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840476d3be083209f5bde7983010ddf