### PR TITLE
fix(web): clamp negative resizable dimensions

### DIFF
--- a/.changeset/clamp-negative-resize.md
+++ b/.changeset/clamp-negative-resize.md
@@ -1,4 +1,5 @@
 ---
+'prosekit': patch
 "@prosekit/web": patch
 ---
 

--- a/.changeset/clamp-negative-resize.md
+++ b/.changeset/clamp-negative-resize.md
@@ -1,0 +1,5 @@
+---
+"@prosekit/web": patch
+---
+
+Clamp negative resize results to keep size positive.

--- a/.changeset/clamp-negative-resize.md
+++ b/.changeset/clamp-negative-resize.md
@@ -1,6 +1,0 @@
----
-'prosekit': patch
-"@prosekit/web": patch
----
-
-Clamp negative resize results to keep size positive.

--- a/packages/web/src/components/resizable/resizable-handle/calc-resize.spec.ts
+++ b/packages/web/src/components/resizable/resizable-handle/calc-resize.spec.ts
@@ -189,6 +189,13 @@ test('calcRightResize', () => {
   testUnchanged(0, -10)
 })
 
+test('sizes are clamped to positive values', () => {
+  const [w1, h1] = [100, 200]
+  const [w2, h2] = calcResize('right', w1, h1, -500, 0, null)
+  expect(w2).toBeGreaterThan(0)
+  expect(h2).toBeGreaterThan(0)
+})
+
 test('calcBottomResize', () => {
   const testIncrease = (dx: number, dy: number) => {
     const [w1, h1] = [100, 200]

--- a/packages/web/src/components/resizable/resizable-handle/calc-resize.ts
+++ b/packages/web/src/components/resizable/resizable-handle/calc-resize.ts
@@ -19,39 +19,31 @@ export function calcResize(
   aspectRatio = aspectRatio ? aspectRatio : w / h
   aspectRatio = isFinitePositiveNumber(aspectRatio) ? aspectRatio : 1
 
-  let result: [number, number]
+  const clamp = ([nw, nh]: [number, number]): [number, number] => [
+    Math.max(nw, 1),
+    Math.max(nh, 1),
+  ]
 
   switch (position) {
     case 'bottom-right':
-      result = calcBottomRightResize(w, h, dx, dy, aspectRatio)
-      break
+      return clamp(calcBottomRightResize(w, h, dx, dy, aspectRatio))
     case 'bottom-left':
-      result = calcBottomLeftResize(w, h, dx, dy, aspectRatio)
-      break
+      return clamp(calcBottomLeftResize(w, h, dx, dy, aspectRatio))
     case 'top-right':
-      result = calcTopRightResize(w, h, dx, dy, aspectRatio)
-      break
+      return clamp(calcTopRightResize(w, h, dx, dy, aspectRatio))
     case 'top-left':
-      result = calcTopLeftResize(w, h, dx, dy, aspectRatio)
-      break
+      return clamp(calcTopLeftResize(w, h, dx, dy, aspectRatio))
     case 'top':
-      result = calcTopResize(w, h, dx, dy, aspectRatio)
-      break
+      return clamp(calcTopResize(w, h, dx, dy, aspectRatio))
     case 'right':
-      result = calcRightResize(w, h, dx, dy, aspectRatio)
-      break
+      return clamp(calcRightResize(w, h, dx, dy, aspectRatio))
     case 'bottom':
-      result = calcBottomResize(w, h, dx, dy, aspectRatio)
-      break
+      return clamp(calcBottomResize(w, h, dx, dy, aspectRatio))
     case 'left':
-      result = calcLeftResize(w, h, dx, dy, aspectRatio)
-      break
+      return clamp(calcLeftResize(w, h, dx, dy, aspectRatio))
     default:
       throw new RangeError(`Invalid position: ${position}`)
   }
-
-  const [nw, nh] = result
-  return [Math.max(nw, 1), Math.max(nh, 1)]
 }
 
 type CalcResize = (

--- a/packages/web/src/components/resizable/resizable-handle/calc-resize.ts
+++ b/packages/web/src/components/resizable/resizable-handle/calc-resize.ts
@@ -19,11 +19,6 @@ export function calcResize(
   aspectRatio = aspectRatio ? aspectRatio : w / h
   aspectRatio = isFinitePositiveNumber(aspectRatio) ? aspectRatio : 1
 
-  const clamp = ([nw, nh]: [number, number]): [number, number] => [
-    Math.max(nw, 1),
-    Math.max(nh, 1),
-  ]
-
   switch (position) {
     case 'bottom-right':
       return clamp(calcBottomRightResize(w, h, dx, dy, aspectRatio))
@@ -116,4 +111,11 @@ const calcLeftResize: CalcResize = (w, h, dx, dy, r) => {
   w -= dx
   h = w / r
   return [w, h]
+}
+
+function clamp([w, h]: [number, number]): [number, number] {
+  return [
+    Math.max(w, 1),
+    Math.max(h, 1),
+  ]
 }

--- a/packages/web/src/components/resizable/resizable-handle/calc-resize.ts
+++ b/packages/web/src/components/resizable/resizable-handle/calc-resize.ts
@@ -19,26 +19,39 @@ export function calcResize(
   aspectRatio = aspectRatio ? aspectRatio : w / h
   aspectRatio = isFinitePositiveNumber(aspectRatio) ? aspectRatio : 1
 
+  let result: [number, number]
+
   switch (position) {
     case 'bottom-right':
-      return calcBottomRightResize(w, h, dx, dy, aspectRatio)
+      result = calcBottomRightResize(w, h, dx, dy, aspectRatio)
+      break
     case 'bottom-left':
-      return calcBottomLeftResize(w, h, dx, dy, aspectRatio)
+      result = calcBottomLeftResize(w, h, dx, dy, aspectRatio)
+      break
     case 'top-right':
-      return calcTopRightResize(w, h, dx, dy, aspectRatio)
+      result = calcTopRightResize(w, h, dx, dy, aspectRatio)
+      break
     case 'top-left':
-      return calcTopLeftResize(w, h, dx, dy, aspectRatio)
+      result = calcTopLeftResize(w, h, dx, dy, aspectRatio)
+      break
     case 'top':
-      return calcTopResize(w, h, dx, dy, aspectRatio)
+      result = calcTopResize(w, h, dx, dy, aspectRatio)
+      break
     case 'right':
-      return calcRightResize(w, h, dx, dy, aspectRatio)
+      result = calcRightResize(w, h, dx, dy, aspectRatio)
+      break
     case 'bottom':
-      return calcBottomResize(w, h, dx, dy, aspectRatio)
+      result = calcBottomResize(w, h, dx, dy, aspectRatio)
+      break
     case 'left':
-      return calcLeftResize(w, h, dx, dy, aspectRatio)
+      result = calcLeftResize(w, h, dx, dy, aspectRatio)
+      break
     default:
       throw new RangeError(`Invalid position: ${position}`)
   }
+
+  const [nw, nh] = result
+  return [Math.max(nw, 1), Math.max(nh, 1)]
 }
 
 type CalcResize = (


### PR DESCRIPTION
## Summary
- clamp negative resize result to keep size positive
- test that calcResize never returns negative sizes

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_68404e5ed5348320a169d142c5486c23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resizing behavior to ensure dimensions cannot be reduced to zero or negative values during resize operations.

- **Tests**
  - Added a test to verify that resized dimensions are always clamped to positive values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->