### PR TITLE
feat(web): add `stateChange` event to `BlockHandlePopover`

### DIFF
--- a/.changeset/short-candles-learn.md
+++ b/.changeset/short-candles-learn.md
@@ -1,4 +1,5 @@
 ---
+'prosekit': patch
 '@prosekit/web': patch
 ---
 

--- a/.changeset/short-candles-learn.md
+++ b/.changeset/short-candles-learn.md
@@ -1,0 +1,5 @@
+---
+'@prosekit/web': patch
+---
+
+Add event handling with changeNode.

--- a/.changeset/short-candles-learn.md
+++ b/.changeset/short-candles-learn.md
@@ -3,4 +3,4 @@
 '@prosekit/web': patch
 ---
 
-Add event handling with changeNode.
+Add a new `stateChange` event to the `BlockHandlePopover` component.

--- a/packages/web/src/components/block-handle/block-handle-popover/setup.ts
+++ b/packages/web/src/components/block-handle/block-handle-popover/setup.ts
@@ -22,7 +22,10 @@ import {
   defineElementHoverHandler,
   type ElementHoverHandler,
 } from './pointer-move'
-import type { BlockHandlePopoverProps, BlockHandlePopoverEvents } from './types'
+import type {
+  BlockHandlePopoverEvents,
+  BlockHandlePopoverProps,
+} from './types'
 
 /**
  * @internal

--- a/packages/web/src/components/block-handle/block-handle-popover/setup.ts
+++ b/packages/web/src/components/block-handle/block-handle-popover/setup.ts
@@ -50,7 +50,7 @@ export function useBlockHandlePopover(
   useHoverExtension(host, editor, (referenceValue, hoverState) => {
     reference.set(referenceValue)
     context.set(hoverState)
-    const stateChangeDetails = hoverState ? { node: hoverState.node, pos: hoverState.pos } : null 
+    const stateChangeDetails = hoverState ? { node: hoverState.node, pos: hoverState.pos } : null
     emit('stateChange', stateChangeDetails)
   })
 

--- a/packages/web/src/components/block-handle/block-handle-popover/setup.ts
+++ b/packages/web/src/components/block-handle/block-handle-popover/setup.ts
@@ -50,7 +50,8 @@ export function useBlockHandlePopover(
   useHoverExtension(host, editor, (referenceValue, hoverState) => {
     reference.set(referenceValue)
     context.set(hoverState)
-    emit('changeNode', hoverState)
+    const stateChangeDetails = hoverState ? { node: hoverState.node, pos: hoverState.pos } : null 
+    emit('stateChange', stateChangeDetails)
   })
 
   useAttribute(host, 'data-state', () => (open.get() ? 'open' : 'closed'))

--- a/packages/web/src/components/block-handle/block-handle-popover/setup.ts
+++ b/packages/web/src/components/block-handle/block-handle-popover/setup.ts
@@ -4,7 +4,7 @@ import {
   useEffect,
   type ConnectableElement,
   type ReadonlySignal,
-  type SignalState,
+  type SetupOptions,
 } from '@aria-ui/core'
 import { useOverlayPositionerState } from '@aria-ui/overlay/elements'
 import { usePresence } from '@aria-ui/presence'
@@ -22,14 +22,14 @@ import {
   defineElementHoverHandler,
   type ElementHoverHandler,
 } from './pointer-move'
-import type { BlockHandlePopoverProps } from './types'
+import type { BlockHandlePopoverProps, BlockHandlePopoverEvents } from './types'
 
 /**
  * @internal
  */
 export function useBlockHandlePopover(
   host: ConnectableElement,
-  { state }: { state: SignalState<BlockHandlePopoverProps> },
+  { state, emit }: SetupOptions<BlockHandlePopoverProps, BlockHandlePopoverEvents>,
 ): void {
   const { editor, ...overlayState } = state
   const reference = createSignal<VirtualElement | null>(null)
@@ -47,6 +47,7 @@ export function useBlockHandlePopover(
   useHoverExtension(host, editor, (referenceValue, hoverState) => {
     reference.set(referenceValue)
     context.set(hoverState)
+    emit('changeNode', hoverState)
   })
 
   useAttribute(host, 'data-state', () => (open.get() ? 'open' : 'closed'))

--- a/packages/web/src/components/block-handle/block-handle-popover/types.ts
+++ b/packages/web/src/components/block-handle/block-handle-popover/types.ts
@@ -52,11 +52,11 @@ export interface BlockHandlePopoverEvents extends OverlayPositionerEvents {
   /**
    * Fired when the hovered block changes.
    */
-  changeNode: CustomEvent<{ node: ProseMirrorNode; pos: number } | null>
+  stateChange: CustomEvent<{ node: ProseMirrorNode; pos: number } | null>
 }
 
 /** @internal */
 export const blockHandlePopoverEvents: EventDeclarations<BlockHandlePopoverEvents> = {
   ...overlayPositionerEvents,
-  changeNode: {},
+  stateChange: {},
 }

--- a/packages/web/src/components/block-handle/block-handle-popover/types.ts
+++ b/packages/web/src/components/block-handle/block-handle-popover/types.ts
@@ -3,11 +3,14 @@ import type {
   PropDeclarations,
 } from '@aria-ui/core'
 import {
+  overlayPositionerEvents,
   overlayPositionerProps,
+  type OverlayPositionerEvents,
   type OverlayPositionerProps,
 } from '@aria-ui/overlay/elements'
 import type { Placement } from '@floating-ui/dom'
 import type { Editor } from '@prosekit/core'
+import type { ProseMirrorNode } from '@prosekit/pm/model'
 
 export interface BlockHandlePopoverProps extends Omit<OverlayPositionerProps, 'placement' | 'hoist'> {
   /**
@@ -45,8 +48,15 @@ export const blockHandlePopoverProps: PropDeclarations<BlockHandlePopoverProps> 
   hoist: { default: false },
 }
 
-/** @internal */
-export interface BlockHandlePopoverEvents {}
+export interface BlockHandlePopoverEvents extends OverlayPositionerEvents {
+  /**
+   * Fired when the hovered block changes.
+   */
+  changeNode: CustomEvent<{ node: ProseMirrorNode; pos: number } | null>
+}
 
 /** @internal */
-export const blockHandlePopoverEvents: EventDeclarations<BlockHandlePopoverEvents> = {}
+export const blockHandlePopoverEvents: EventDeclarations<BlockHandlePopoverEvents> = {
+  ...overlayPositionerEvents,
+  changeNode: {},
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

https://github.com/prosekit/prosekit/discussions/1079 https://github.com/prosekit/prosekit/issues/1081 

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Using this event, you can catch the active node and then manipulate it as you wish — for example, delete, move, or transform it.

You can also use this to create auxiliary menus.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `stateChange` event for the block handle popover to notify on hover state updates.
- **Refactor**
  - Enhanced component event interfaces to support the new state change event and improved event emission on hover changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->