### PR TITLE
feat(link): add `target` and `rel` attributes to link

### DIFF
--- a/.changeset/stupid-otters-visit.md
+++ b/.changeset/stupid-otters-visit.md
@@ -1,0 +1,6 @@
+---
+'@prosekit/extensions': patch
+'@prosekit/core': patch
+---
+
+Add target and rel attributes to link.

--- a/.changeset/stupid-otters-visit.md
+++ b/.changeset/stupid-otters-visit.md
@@ -1,7 +1,6 @@
 ---
 'prosekit': patch
 '@prosekit/extensions': patch
-'@prosekit/core': patch
 ---
 
-Add target and rel attributes to link.
+Add `target` and `rel` attributes to link.

--- a/.changeset/stupid-otters-visit.md
+++ b/.changeset/stupid-otters-visit.md
@@ -1,4 +1,5 @@
 ---
+'prosekit': patch
 '@prosekit/extensions': patch
 '@prosekit/core': patch
 ---

--- a/packages/core/src/editor/action.spec.ts
+++ b/packages/core/src/editor/action.spec.ts
@@ -46,12 +46,12 @@ describe('MarkAction', () => {
 
   it('can apply mark with attrs', () => {
     expect(
-      n.p(m.link({ href: 'https://example.com' }, 'foo')).toJSON(),
+      n.p(m.link({ href: 'https://example.com', target: '_blank', rel: 'noopener' }, 'foo')).toJSON(),
     ).toEqual({
       type: 'paragraph',
       content: [
         {
-          marks: [{ type: 'link', attrs: { href: 'https://example.com', target: null, rel: null } }],
+          marks: [{ type: 'link', attrs: { href: 'https://example.com', target: '_blank', rel: 'noopener' } }],
           text: 'foo',
           type: 'text',
         },
@@ -69,7 +69,7 @@ describe('MarkAction', () => {
     const href1 = 'https://example.com/1'
     const href2 = 'https://example.com/2'
     const link1 = (node: NodeChild) => m.link({ href: href1 }, node)
-    const link2 = (node: NodeChild) => m.link({ href: href2 }, node)
+    const link2 = (node: NodeChild) => m.link({ href: href2, target: '_blank', rel: 'noopener' }, node)
 
     expect(n.p(link1('foo')).toJSON()).toEqual({
       type: 'paragraph',
@@ -88,7 +88,7 @@ describe('MarkAction', () => {
         {
           type: 'text',
           text: 'foo',
-          marks: [{ attrs: { href: href2, target: null, rel: null }, type: 'link' }],
+          marks: [{ attrs: { href: href2, target: '_blank', rel: 'noopener' }, type: 'link' }],
         },
       ],
     })
@@ -99,7 +99,7 @@ describe('MarkAction', () => {
         {
           type: 'text',
           text: 'foo',
-          marks: [{ attrs: { href: href2, target: null, rel: null }, type: 'link' }],
+          marks: [{ attrs: { href: href2, target: '_blank', rel: 'noopener' }, type: 'link' }],
         },
       ],
     })

--- a/packages/core/src/editor/action.spec.ts
+++ b/packages/core/src/editor/action.spec.ts
@@ -51,7 +51,7 @@ describe('MarkAction', () => {
       type: 'paragraph',
       content: [
         {
-          marks: [{ type: 'link', attrs: { href: 'https://example.com' } }],
+          marks: [{ type: 'link', attrs: { href: 'https://example.com', target: null, rel: null } }],
           text: 'foo',
           type: 'text',
         },
@@ -77,7 +77,7 @@ describe('MarkAction', () => {
         {
           type: 'text',
           text: 'foo',
-          marks: [{ attrs: { href: href1 }, type: 'link' }],
+          marks: [{ attrs: { href: href1, target: null, rel: null }, type: 'link' }],
         },
       ],
     })

--- a/packages/core/src/editor/action.spec.ts
+++ b/packages/core/src/editor/action.spec.ts
@@ -88,7 +88,7 @@ describe('MarkAction', () => {
         {
           type: 'text',
           text: 'foo',
-          marks: [{ attrs: { href: href2 }, type: 'link' }],
+          marks: [{ attrs: { href: href2, target: null, rel: null }, type: 'link' }],
         },
       ],
     })
@@ -99,7 +99,7 @@ describe('MarkAction', () => {
         {
           type: 'text',
           text: 'foo',
-          marks: [{ attrs: { href: href2 }, type: 'link' }],
+          marks: [{ attrs: { href: href2, target: null, rel: null }, type: 'link' }],
         },
       ],
     })

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -117,6 +117,8 @@ function defineItalic(): ItalicExtension {
 
 interface LinkAttrs {
   href: string
+  target?: string | null
+  rel?: string | null
 }
 
 type LinkExtension = Extension<{
@@ -134,6 +136,8 @@ function defineLink(): LinkExtension {
     inclusive: false,
     attrs: {
       href: { validate: 'string' },
+      target: { default: null, validate: 'string|null' },
+      rel: { default: null, validate: 'string|null' },
     },
     parseDOM: [
       {
@@ -141,13 +145,15 @@ function defineLink(): LinkExtension {
         getAttrs: (dom: HTMLElement) => {
           return {
             href: dom.getAttribute('href') || '',
+            target: dom.getAttribute('target') || null,
+            rel: dom.getAttribute('rel') || null,
           }
         },
       },
     ],
     toDOM(node) {
-      const { href } = node.attrs as LinkAttrs
-      return ['a', { href }, 0]
+      const { href, target, rel } = node.attrs as LinkAttrs
+      return ['a', { href, target, rel }, 0]
     },
   })
 }

--- a/packages/extensions/src/link/index.ts
+++ b/packages/extensions/src/link/index.ts
@@ -27,6 +27,8 @@ import {
  */
 export interface LinkAttrs {
   href: string
+  target?: string | null
+  rel?: string | null
 }
 
 /**
@@ -47,6 +49,8 @@ export function defineLinkSpec(): LinkSpecExtension {
     inclusive: false,
     attrs: {
       href: { validate: 'string' },
+      target: { default: null, validate: 'string|null' },
+      rel: { default: null, validate: 'string|null' },
     },
     parseDOM: [
       {
@@ -54,13 +58,15 @@ export function defineLinkSpec(): LinkSpecExtension {
         getAttrs: (dom: HTMLElement) => {
           return {
             href: dom.getAttribute('href') || '',
+            target: dom.getAttribute('target') || null,
+            rel: dom.getAttribute('rel') || null,
           }
         },
       },
     ],
     toDOM(node) {
-      const { href } = node.attrs as LinkAttrs
-      return ['a', { href }, 0]
+      const { href, target, rel } = node.attrs as LinkAttrs
+      return ['a', { href, target, rel }, 0]
     },
   })
 }


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Additional attributes are needed for links. `rel`, `target` are used quite often.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying the target and rel attributes on link elements, allowing for enhanced link behavior and security options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->