### PR TITLE
docs: add more type aliases

### DIFF
--- a/packages/extensions/src/autocomplete/autocomplete-rule.ts
+++ b/packages/extensions/src/autocomplete/autocomplete-rule.ts
@@ -47,6 +47,21 @@ export interface MatchHandlerOptions {
 export type MatchHandler = (options: MatchHandlerOptions) => void
 
 /**
+ * Options for the {@link CanMatchPredicate} callback.
+ */
+export interface CanMatchOptions {
+  /**
+   * The editor state.
+   */
+  state: EditorState
+}
+
+/**
+ * A predicate to determine if the rule can be applied in the current editor state.
+ */
+export type CanMatchPredicate = (options: CanMatchOptions) => boolean
+
+/**
  * Options for creating an {@link AutocompleteRule}
  */
 export interface AutocompleteRuleOptions {
@@ -75,7 +90,7 @@ export interface AutocompleteRuleOptions {
    * state. If not provided, it defaults to only allowing matches in empty
    * selections that are not inside a code block or code mark.
    */
-  canMatch?: (options: { state: EditorState }) => boolean
+  canMatch?: CanMatchPredicate
 }
 
 /**

--- a/packages/extensions/src/autocomplete/index.ts
+++ b/packages/extensions/src/autocomplete/index.ts
@@ -2,6 +2,8 @@ export { defineAutocomplete } from './autocomplete'
 export {
   AutocompleteRule,
   type AutocompleteRuleOptions,
+  type CanMatchOptions,
+  type CanMatchPredicate,
   type MatchHandler,
   type MatchHandlerOptions,
 } from './autocomplete-rule'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved clarity and consistency of autocomplete rule options by formalizing and documenting the types used for predicate callbacks.
- **Refactor**
  - Updated internal type definitions for autocomplete rule configuration to enhance maintainability and type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->