### PR TITLE
docs: improve slash menu regex

### DIFF
--- a/packages/core/src/utils/can-use-regex-lookbehind.ts
+++ b/packages/core/src/utils/can-use-regex-lookbehind.ts
@@ -1,5 +1,8 @@
 import { once } from '@ocavue/utils'
 
+/**
+ * Checks if the browser supports [regex lookbehind assertion](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion).
+ */
 export const canUseRegexLookbehind: () => boolean = once(() => {
   try {
     return 'ab'.replace(new RegExp('(?<=a)b', 'g'), 'c') === 'ac'

--- a/packages/core/src/utils/can-use-regex-lookbehind.ts
+++ b/packages/core/src/utils/can-use-regex-lookbehind.ts
@@ -1,8 +1,5 @@
 import { once } from '@ocavue/utils'
 
-/**
- * Checks if the browser supports [regex lookbehind assertion](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion).
- */
 export const canUseRegexLookbehind: () => boolean = once(() => {
   try {
     return 'ab'.replace(new RegExp('(?<=a)b', 'g'), 'c') === 'ac'

--- a/packages/extensions/src/autocomplete/autocomplete-rule.ts
+++ b/packages/extensions/src/autocomplete/autocomplete-rule.ts
@@ -69,7 +69,7 @@ export interface AutocompleteRuleOptions {
    * The regular expression to match against the text before the cursor. The
    * last match before the cursor is used.
    *
-   * For a slash menu, you might use `/\/(|\S.*)$/u`.
+   * For a slash menu, you might use `/(?<!\S)\/(|\S.*)$/u`.
    * For a mention, you might use `/@\w*$/`
    */
   regex: RegExp

--- a/packages/extensions/src/autocomplete/autocomplete-rule.ts
+++ b/packages/extensions/src/autocomplete/autocomplete-rule.ts
@@ -69,7 +69,7 @@ export interface AutocompleteRuleOptions {
    * The regular expression to match against the text before the cursor. The
    * last match before the cursor is used.
    *
-   * For a slash menu, you might use `/(?<!\S)\/(|\S.*)$/u`.
+   * For a slash menu, you might use `/\/(|\S.*)$/u`.
    * For a mention, you might use `/@\w*$/`
    */
   regex: RegExp

--- a/packages/extensions/src/autocomplete/autocomplete.spec.ts
+++ b/packages/extensions/src/autocomplete/autocomplete.spec.ts
@@ -1,4 +1,7 @@
-import { union } from '@prosekit/core'
+import {
+  canUseRegexLookbehind,
+  union,
+} from '@prosekit/core'
 import {
   describe,
   expect,
@@ -23,7 +26,7 @@ import {
 } from './autocomplete-rule'
 
 function setupSlashMenu() {
-  const regex = /\/(|\S.*)$/u
+  const regex = canUseRegexLookbehind() ? /(?<!\S)\/(|\S.*)$/u : /\/(|\S.*)$/u
 
   const onEnter = vi.fn<MatchHandler>()
   const onLeave = vi.fn<VoidFunction>()

--- a/packages/extensions/src/autocomplete/autocomplete.spec.ts
+++ b/packages/extensions/src/autocomplete/autocomplete.spec.ts
@@ -1,7 +1,4 @@
-import {
-  canUseRegexLookbehind,
-  union,
-} from '@prosekit/core'
+import { union } from '@prosekit/core'
 import {
   describe,
   expect,
@@ -26,7 +23,7 @@ import {
 } from './autocomplete-rule'
 
 function setupSlashMenu() {
-  const regex = canUseRegexLookbehind() ? /(?<!\S)\/(|\S.*)$/u : /\/(|\S.*)$/u
+  const regex = /\/(|\S.*)$/u
 
   const onEnter = vi.fn<MatchHandler>()
   const onLeave = vi.fn<VoidFunction>()

--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
     baseURL: 'http://localhost:4321/astrobook/',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'retain-on-failure',
+    trace: 'on-first-retry',
     // headless: false,
   },
 

--- a/website/src/examples/solid/slash-menu/slash-menu.tsx
+++ b/website/src/examples/solid/slash-menu/slash-menu.tsx
@@ -1,4 +1,3 @@
-import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/solid'
 import {
   AutocompleteList,
@@ -13,7 +12,7 @@ export default function SlashMenu() {
   const editor = useEditor<EditorExtension>()
 
   // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-  const regex = canUseRegexLookbehind() ? /(?<!\S)\/(|\S.*)$/u : /\/(|\S.*)$/u
+  const regex = /\/(|\S.*)$/u
 
   return (
     <AutocompletePopover regex={regex} class="CSS_AUTOCOMPLETE_MENU">

--- a/website/src/examples/solid/slash-menu/slash-menu.tsx
+++ b/website/src/examples/solid/slash-menu/slash-menu.tsx
@@ -1,3 +1,4 @@
+import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/solid'
 import {
   AutocompleteList,
@@ -12,7 +13,7 @@ export default function SlashMenu() {
   const editor = useEditor<EditorExtension>()
 
   // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-  const regex = /\/(|\S.*)$/u
+  const regex = canUseRegexLookbehind() ? /(?<!\S)\/(|\S.*)$/u : /\/(|\S.*)$/u
 
   return (
     <AutocompletePopover regex={regex} class="CSS_AUTOCOMPLETE_MENU">

--- a/website/src/shared/preact/slash-menu.tsx
+++ b/website/src/shared/preact/slash-menu.tsx
@@ -1,4 +1,3 @@
-import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/preact'
 import {
   AutocompleteList,
@@ -13,7 +12,7 @@ export default function SlashMenu() {
   const editor = useEditor<EditorExtension>()
 
   // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-  const regex = canUseRegexLookbehind() ? /(?<!\S)\/(|\S.*)$/u : /\/(|\S.*)$/u
+  const regex = /\/(|\S.*)$/u
 
   return (
     <AutocompletePopover regex={regex} className="CSS_AUTOCOMPLETE_MENU">

--- a/website/src/shared/preact/slash-menu.tsx
+++ b/website/src/shared/preact/slash-menu.tsx
@@ -1,3 +1,4 @@
+import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/preact'
 import {
   AutocompleteList,
@@ -12,7 +13,7 @@ export default function SlashMenu() {
   const editor = useEditor<EditorExtension>()
 
   // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-  const regex = /\/(|\S.*)$/u
+  const regex = canUseRegexLookbehind() ? /(?<!\S)\/(|\S.*)$/u : /\/(|\S.*)$/u
 
   return (
     <AutocompletePopover regex={regex} className="CSS_AUTOCOMPLETE_MENU">

--- a/website/src/shared/react/slash-menu.tsx
+++ b/website/src/shared/react/slash-menu.tsx
@@ -1,4 +1,3 @@
-import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/react'
 import {
   AutocompleteList,
@@ -13,7 +12,7 @@ export default function SlashMenu() {
   const editor = useEditor<EditorExtension>()
 
   // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-  const regex = canUseRegexLookbehind() ? /(?<!\S)\/(|\S.*)$/u : /\/(|\S.*)$/u
+  const regex = /\/(|\S.*)$/u
 
   return (
     <AutocompletePopover regex={regex} className="CSS_AUTOCOMPLETE_MENU">

--- a/website/src/shared/react/slash-menu.tsx
+++ b/website/src/shared/react/slash-menu.tsx
@@ -1,3 +1,4 @@
+import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/react'
 import {
   AutocompleteList,
@@ -12,7 +13,7 @@ export default function SlashMenu() {
   const editor = useEditor<EditorExtension>()
 
   // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-  const regex = /\/(|\S.*)$/u
+  const regex = canUseRegexLookbehind() ? /(?<!\S)\/(|\S.*)$/u : /\/(|\S.*)$/u
 
   return (
     <AutocompletePopover regex={regex} className="CSS_AUTOCOMPLETE_MENU">

--- a/website/src/shared/svelte/slash-menu.svelte
+++ b/website/src/shared/svelte/slash-menu.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/svelte'
 import {
   AutocompleteList,
@@ -12,7 +11,7 @@ import SlashMenuItem from './slash-menu-item.svelte'
 const editor = useEditor<EditorExtension>()
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(|\S.*)$/u : /\/(|\S.*)$/u
+const regex = /\/(|\S.*)$/u
 </script>
 
 <AutocompletePopover regex={regex} class="CSS_AUTOCOMPLETE_MENU">

--- a/website/src/shared/svelte/slash-menu.svelte
+++ b/website/src/shared/svelte/slash-menu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/svelte'
 import {
   AutocompleteList,
@@ -11,7 +12,7 @@ import SlashMenuItem from './slash-menu-item.svelte'
 const editor = useEditor<EditorExtension>()
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = /\/(|\S.*)$/u
+const regex = canUseRegexLookbehind() ? /(?<!\S)\/(|\S.*)$/u : /\/(|\S.*)$/u
 </script>
 
 <AutocompletePopover regex={regex} class="CSS_AUTOCOMPLETE_MENU">

--- a/website/src/shared/vue/slash-menu.vue
+++ b/website/src/shared/vue/slash-menu.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/vue'
 import {
   AutocompleteList,
@@ -12,7 +13,7 @@ import SlashMenuItem from './slash-menu-item.vue'
 const editor = useEditor<EditorExtension>()
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = /\/(|\S.*)$/u
+const regex = canUseRegexLookbehind() ? /(?<!\S)\/(|\S.*)$/u : /\/(|\S.*)$/u
 </script>
 
 <template>

--- a/website/src/shared/vue/slash-menu.vue
+++ b/website/src/shared/vue/slash-menu.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/vue'
 import {
   AutocompleteList,
@@ -13,7 +12,7 @@ import SlashMenuItem from './slash-menu-item.vue'
 const editor = useEditor<EditorExtension>()
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(|\S.*)$/u : /\/(|\S.*)$/u
+const regex = /\/(|\S.*)$/u
 </script>
 
 <template>

--- a/website/tests/slash-menu.test.ts
+++ b/website/tests/slash-menu.test.ts
@@ -12,7 +12,7 @@ import {
   waitForEditor,
 } from './helper'
 
-testStory(['slash-menu'], () => {
+testStory(['slash-menu', 'full'], () => {
   test('execute command', async ({ page }) => {
     const { editor, menu, itemH1 } = await setup(page)
 

--- a/website/tests/slash-menu.test.ts
+++ b/website/tests/slash-menu.test.ts
@@ -237,6 +237,23 @@ testStory(['slash-menu', 'full'], () => {
     await editor.press('Enter')
     await expect(editor.locator('h3')).toBeVisible()
   })
+
+  test('should not show menu when typing a http link', async ({ page }) => {
+    const { editor, menu } = await setup(page)
+
+    await editor.focus()
+    await editor.press('Enter')
+    await expect(menu).toBeHidden()
+    for (const char of 'https://example.com/foo.bar/') {
+      await editor.pressSequentially(char)
+      await expect(menu).toBeHidden()
+    }
+
+    // Make sure the menu is still functional
+    await editor.press('Space')
+    await editor.press('/')
+    await expect(menu).toBeVisible()
+  })
 })
 
 async function setup(page: Page) {


### PR DESCRIPTION
 

https://github.com/user-attachments/assets/9a071362-8319-4173-8c9d-7a6e2c0420ef

 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved slash command detection in autocomplete menus across all frameworks, providing more accurate matching by excluding slashes preceded by non-whitespace characters when supported by the environment.

* **Bug Fixes**
  * Added a test to ensure the slash command menu does not appear when typing URLs starting with "https://".

* **Documentation**
  * Enhanced documentation for regex usage in autocomplete options and added descriptive comments for utility functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->