### PR TITLE
fix(web): handle the second click on menu items

### DIFF
--- a/.changeset/all-shoes-wear.md
+++ b/.changeset/all-shoes-wear.md
@@ -1,0 +1,6 @@
+---
+'prosekit': patch
+'@prosekit/web': patch
+---
+
+Fix an issue where a table handle menu item doesn't fire the `select` event after the second click.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -46,7 +46,7 @@
     "@aria-ui/collection": "^0.0.5",
     "@aria-ui/core": "^0.0.21",
     "@aria-ui/listbox": "^0.0.24",
-    "@aria-ui/menu": "^0.0.19",
+    "@aria-ui/menu": "^0.0.20",
     "@aria-ui/overlay": "^0.0.24",
     "@aria-ui/popover": "^0.0.27",
     "@aria-ui/presence": "^0.0.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -773,8 +773,8 @@ importers:
         specifier: ^0.0.24
         version: 0.0.24
       '@aria-ui/menu':
-        specifier: ^0.0.19
-        version: 0.0.19
+        specifier: ^0.0.20
+        version: 0.0.20
       '@aria-ui/overlay':
         specifier: ^0.0.24
         version: 0.0.24
@@ -1020,8 +1020,8 @@ packages:
   '@aria-ui/listbox@0.0.24':
     resolution: {integrity: sha512-G/qm/EM2B5Pti9lK0W0KPNzDNncX7STKOvWi8MS+obTVn2dM+3f8yH9LGzMNg6rFvj/Bw29xh+hEsTbTzv58fQ==}
 
-  '@aria-ui/menu@0.0.19':
-    resolution: {integrity: sha512-9fU4f9kToqguejaE3KF6sP3CJ9FojQenqJcrfCLUvvtsPrPH1HaFVxb5BZ05yflM0j210PPmZWrxqWKlWg0F5w==}
+  '@aria-ui/menu@0.0.20':
+    resolution: {integrity: sha512-oyuDkhbGnnQ6CGPDiAkY+5Fc0sWU8m9EA95DsYGGhjJlVtFYEN/OB2nzFFG4JHds4wX8yOWYAzyiDbrfeQO+7g==}
 
   '@aria-ui/overlay@0.0.24':
     resolution: {integrity: sha512-kXIzQ7DtRtlSbN1tbT504M1J5HzF0U+ZvEv/f2ONiY3yu7BlZeMKJPF4MXcvl3vQhB/joFyoqXb47OyJvHVkxA==}
@@ -7395,7 +7395,7 @@ snapshots:
       '@aria-ui/presence': 0.0.19
       immer: 10.1.1
 
-  '@aria-ui/menu@0.0.19':
+  '@aria-ui/menu@0.0.20':
     dependencies:
       '@aria-ui/collection': 0.0.5
       '@aria-ui/core': 0.0.21

--- a/website/tests/table.test.ts
+++ b/website/tests/table.test.ts
@@ -117,8 +117,7 @@ testStory('table', ({ example }) => {
 
     await test.step('check table shape after second insert', async () => {
       const { cols: colsAfter } = await getTableShape()
-      // TODO: this should be colsBefore + 2. Fix this test.
-      expect(colsAfter).toBeGreaterThan(colsBefore)
+      expect(colsAfter).toBe(colsBefore + 2)
     })
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the table handle menu item did not trigger the select event on a second click.
* **Chores**
  * Updated a dependency to improve stability.
* **Tests**
  * Improved table column insertion test with stricter and more accurate assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->