### PR TITLE
docs: add some default content to the full example

### DIFF
--- a/packages/dev/src/gen-example-symlinks.ts
+++ b/packages/dev/src/gen-example-symlinks.ts
@@ -12,6 +12,12 @@ import { vfs } from './virtual-file-system'
 //
 /// keep-sorted
 const mapping: Record<string, string[]> = {
+  'shared/common/default-content-full.ts': [
+    /// keep-sorted
+    'examples/react/full/',
+    'examples/svelte/full/',
+    'examples/vue/full/',
+  ],
   'shared/common/issue-link.ts': [
     /// keep-sorted
     'examples/react/mark-rule/',

--- a/packages/extensions/src/image/image-spec.ts
+++ b/packages/extensions/src/image/image-spec.ts
@@ -60,7 +60,6 @@ export function defineImageSpec(): ImageSpecExtension {
             width = element.naturalWidth
             height = element.naturalHeight
           }
-
           return { src, width, height }
         },
       },

--- a/packages/extensions/src/image/image-spec.ts
+++ b/packages/extensions/src/image/image-spec.ts
@@ -60,6 +60,7 @@ export function defineImageSpec(): ImageSpecExtension {
             width = element.naturalWidth
             height = element.naturalHeight
           }
+
           return { src, width, height }
         },
       },

--- a/website/example.meta.ts
+++ b/website/example.meta.ts
@@ -159,6 +159,10 @@ export const exampleMeta = {
           "hidden": false
         },
         {
+          "path": "default-content-full.ts",
+          "hidden": false
+        },
+        {
           "path": "image-upload-popover.tsx",
           "hidden": false
         },
@@ -1012,6 +1016,10 @@ export const exampleMeta = {
         },
         {
           "path": "code-block-view.vue",
+          "hidden": false
+        },
+        {
+          "path": "default-content-full.ts",
           "hidden": false
         },
         {
@@ -1963,6 +1971,10 @@ export const exampleMeta = {
         },
         {
           "path": "code-block-view.svelte",
+          "hidden": false
+        },
+        {
+          "path": "default-content-full.ts",
           "hidden": false
         },
         {

--- a/website/example.meta.yaml
+++ b/website/example.meta.yaml
@@ -81,6 +81,8 @@ examples:
         hidden: false
       - path: code-block-view.tsx
         hidden: false
+      - path: default-content-full.ts
+        hidden: false
       - path: image-upload-popover.tsx
         hidden: false
       - path: image-view.tsx
@@ -526,6 +528,8 @@ examples:
       - path: block-handle.vue
         hidden: false
       - path: code-block-view.vue
+        hidden: false
+      - path: default-content-full.ts
         hidden: false
       - path: image-upload-popover.vue
         hidden: false
@@ -1022,6 +1026,8 @@ examples:
       - path: block-handle.svelte
         hidden: false
       - path: code-block-view.svelte
+        hidden: false
+      - path: default-content-full.ts
         hidden: false
       - path: image-upload-popover.svelte
         hidden: false

--- a/website/src/examples/react/full/default-content-full.ts
+++ b/website/src/examples/react/full/default-content-full.ts
@@ -1,0 +1,1 @@
+../../../shared/common/default-content-full.ts

--- a/website/src/examples/react/full/editor.tsx
+++ b/website/src/examples/react/full/editor.tsx
@@ -6,6 +6,7 @@ import { ProseKit } from 'prosekit/react'
 import { useMemo } from 'react'
 
 import BlockHandle from './block-handle'
+import { DEFAULT_CONTENT } from './default-content-full'
 import { defineExtension } from './extension'
 import InlineMenu from './inline-menu'
 import SlashMenu from './slash-menu'
@@ -16,7 +17,7 @@ import UserMenu from './user-menu'
 export default function Editor() {
   const editor = useMemo(() => {
     const extension = defineExtension()
-    return createEditor({ extension })
+    return createEditor({ extension, defaultContent: DEFAULT_CONTENT })
   }, [])
 
   return (

--- a/website/src/examples/svelte/full/default-content-full.ts
+++ b/website/src/examples/svelte/full/default-content-full.ts
@@ -1,0 +1,1 @@
+../../../shared/common/default-content-full.ts

--- a/website/src/examples/svelte/full/editor.svelte
+++ b/website/src/examples/svelte/full/editor.svelte
@@ -5,6 +5,7 @@ import 'prosekit/basic/typography.css'
 import { createEditor } from 'prosekit/core'
 import { ProseKit } from 'prosekit/svelte'
 import BlockHandle from './block-handle.svelte'
+import { DEFAULT_CONTENT } from './default-content-full'
 import { defineExtension } from './extension'
 import InlineMenu from './inline-menu.svelte'
 import SlashMenu from './slash-menu.svelte'
@@ -12,7 +13,10 @@ import TagMenu from './tag-menu.svelte'
 import Toolbar from './toolbar.svelte'
 import UserMenu from './user-menu.svelte'
 
-const editor = createEditor({ extension: defineExtension() })
+const editor = createEditor({
+  extension: defineExtension(),
+  defaultContent: DEFAULT_CONTENT,
+})
 
 const mount = (element: HTMLElement) => {
   editor.mount(element)

--- a/website/src/examples/vue/full/default-content-full.ts
+++ b/website/src/examples/vue/full/default-content-full.ts
@@ -1,0 +1,1 @@
+../../../shared/common/default-content-full.ts

--- a/website/src/examples/vue/full/editor.vue
+++ b/website/src/examples/vue/full/editor.vue
@@ -10,6 +10,7 @@ import {
 } from 'vue'
 
 import BlockHandle from './block-handle.vue'
+import { DEFAULT_CONTENT } from './default-content-full'
 import { defineExtension } from './extension'
 import InlineMenu from './inline-menu.vue'
 import SlashMenu from './slash-menu.vue'
@@ -17,7 +18,10 @@ import TagMenu from './tag-menu.vue'
 import Toolbar from './toolbar.vue'
 import UserMenu from './user-menu.vue'
 
-const editor = createEditor({ extension: defineExtension() })
+const editor = createEditor({
+  extension: defineExtension(),
+  defaultContent: DEFAULT_CONTENT,
+})
 const editorRef = ref<HTMLDivElement | null>(null)
 watchPostEffect((onCleanup) => {
   editor.mount(editorRef.value)

--- a/website/src/shared/common/default-content-full.ts
+++ b/website/src/shared/common/default-content-full.ts
@@ -1,0 +1,84 @@
+// This is the default content for the full example.
+export const DEFAULT_CONTENT = `
+<h1>The editor that thinks like you</h1>
+
+<p>Every keystroke flows naturally. Every feature appears exactly when you need it. This is <strong>writing without barriers</strong>.</p>
+
+<h2>Text that shines.</h2>
+
+<p>Make your words <strong>bold</strong>, <em>italic</em>, <u>underlined</u>, or <s>crossed out</s>. Add <code>inline code</code> that stands out. Create <a href="https://prosekit.dev">links</a> that connect.</p>
+
+<p>Select any text to format it. Type <code>@</code> to mention <span data-id="39" data-mention="user" contenteditable="false">@someone</span> or <code>#</code> for <span data-id="1" data-mention="tag" contenteditable="false">#topics</span>. Press <code>/</code> and discover what's possible.</p>
+
+
+<h2>Lists that organize.</h2>
+
+<ul>
+  <li>Bullet points that guide thoughts</li>
+  <li>Nested lists for complex ideas
+    <ul>
+      <li>Sub-points flow naturally</li>
+    </ul>
+  </li>
+  <li>Tasks that focus
+    <ul>
+      <li><input type="checkbox" checked>Done feels good</li>
+      <li><input type="checkbox">Todo drives action</li>
+    </ul>
+  </li>
+</ul>
+
+<ol>
+  <li>Numbered steps</li>
+  <li>Sequential thinking</li>
+  <li>Clear progress</li>
+</ol>
+
+<h2>Code that inspires.</h2>
+
+<pre data-language="javascript"><code>// Code that reads like poetry
+const magic = createEditor()
+magic.transform(thoughts)
+</code></pre>
+
+<h2>Images that captivate.</h2>
+
+<img src="https://picsum.photos/id/302/300/200" alt="The future of writing">
+
+<p>Drag the handle in the bottom right corner to resize.</p>
+
+<h2>Tables that work.</h2>
+
+<table>
+  <tr>
+    <td><strong>Feature</strong></td>
+    <td><strong>How to use</strong></td>
+    <td><strong>Result</strong></td>
+  </tr>
+  <tr>
+    <td>Format text</td>
+    <td>Select and choose</td>
+    <td>Perfect styling</td>
+  </tr>
+  <tr>
+    <td>Add mentions</td>
+    <td>Type @ and name</td>
+    <td>Connected ideas</td>
+  </tr>
+  <tr>
+    <td>Insert anything</td>
+    <td>Press / for menu</td>
+    <td>Endless possibilities</td>
+  </tr>
+</table>
+
+<h2>Quotes that inspire.</h2>
+
+<blockquote>
+  <p>"This is not just an editor. This is how writing should feel."</p>
+</blockquote>
+
+<hr>
+
+<p>Start typing. Everything else just flows.</p>
+`

--- a/website/tests/full.test.ts
+++ b/website/tests/full.test.ts
@@ -15,7 +15,7 @@ testStory('full', () => {
   test('default content', async ({ page }) => {
     const check = async () => {
       const html = await getEditorHTML(page)
-      expect(html).toContain('ProseKit')
+      expect(html).toContain('The editor that thinks like you')
     }
     await expect(check).toPass()
   })

--- a/website/tests/full.test.ts
+++ b/website/tests/full.test.ts
@@ -5,12 +5,27 @@ import {
 
 import {
   emptyEditor,
+  getEditorHTML,
   locateEditor,
   testStory,
   waitForEditor,
 } from './helper'
 
 testStory('full', () => {
+  test('default content', async ({ page }) => {
+    const check = async () => {
+      const html = await getEditorHTML(page)
+      expect(html).toContain('ProseKit')
+    }
+    await expect(check).toPass()
+  })
+})
+
+testStory('full', () => {
+  test.beforeEach(async ({ page }) => {
+    await emptyEditor(page)
+  })
+
   test.describe('link', () => {
     test('press Space to insert a link', async ({ page }) => {
       const editor = locateEditor(page)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The React, Vue, and Svelte full examples now initialize with rich default content showcasing various formatting and interactive features.
  * The editor starts with pre-filled content including headings, formatted text, lists, code blocks, blockquotes, tables, and interactive elements like mentions and slash commands.
* **Tests**
  * Added a test to verify the editor loads with the default content correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->