### PR TITLE
ci: add `/docs` pull request slash command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:force": "turbo build --force",
     "build:package": "turbo build --filter='./packages/*' --concurrency=1",
     "build:website": "pnpm --filter='./website' run build",
+    "build:typedoc": "pnpm --filter='./website' run build:typedoc",
     "change": "changeset",
     "ci:publish": "pnpm run build:package && pnpm publish --access public -r --no-git-checks --tag latest",
     "ci:version": "changeset version && pnpm install --no-frozen-lockfile",

--- a/packages/core/src/commands/unset-mark.ts
+++ b/packages/core/src/commands/unset-mark.ts
@@ -4,6 +4,8 @@ import type { CommandCreator } from '../types/extension-command'
 
 /**
  * @public
+ *
+ * Options for {@link unsetMark}.
  */
 export interface UnsetMarkOptions {
   /**

--- a/scripts/inspect-docs.sh
+++ b/scripts/inspect-docs.sh
@@ -32,7 +32,7 @@ cp -r "$MASTER_DIR/$REF_DIR" "$REF_DIR"
 # Commit the master docs
 cd "$DEV_DIR"
 git add --force "$REF_DIR"
-git commit --allow-empty -m "chore: inspect docs (steps 1/3)"
+git commit --allow-empty -m "chore: [1/3] build master docs"
 
 # Build the docs from the dev branch
 cd "$DEV_DIR/website"
@@ -42,7 +42,7 @@ pnpm run build:typedoc
 # Commit the dev docs
 cd "$DEV_DIR"
 git add --force "$REF_DIR"
-git commit --allow-empty -m "chore: inspect docs (steps 2/3)"
+git commit --allow-empty -m "chore: [2/3] build dev docs"
 
 # Remove the docs
 cd "$DEV_DIR"
@@ -51,7 +51,7 @@ rm -rf "$REF_DIR"
 
 # Commit the changes
 git add --all
-git commit --allow-empty -m "chore: inspect docs (steps 3/3)"
+git commit --allow-empty -m "chore: [3/3] clean up docs"
 
 # Push the changes
 git push

--- a/scripts/inspect-docs.sh
+++ b/scripts/inspect-docs.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -ex
+
+REF_DIR="website/src/content/docs/references"
+
+cd "$(dirname "$0")/.."
+DEV_DIR=$(pwd)
+
+# Install pnpm
+npm install -g corepack@latest
+pnpm --version
+
+# Check out the master branch
+cd /tmp
+mkdir -p prosekit-docs-temp
+cd prosekit-docs-temp
+git clone https://github.com/prosekit/prosekit.git
+cd prosekit
+pnpm install
+MASTER_DIR=$(pwd)
+
+# Build the docs from the master branch
+cd "$MASTER_DIR/website"
+pnpm run build:typedoc
+
+# Copy the master docs
+cd "$DEV_DIR"
+mkdir -p "$REF_DIR"
+rm -rf "$REF_DIR"
+cp -r "$MASTER_DIR/$REF_DIR" "$REF_DIR"
+
+# Commit the master docs
+cd "$DEV_DIR"
+git add --force "$REF_DIR"
+git commit --allow-empty -m "chore: inspect docs (steps 1/3)"
+
+# Build the docs from the dev branch
+cd "$DEV_DIR/website"
+pnpm run build:typedoc
+
+# Commit the dev docs
+cd "$DEV_DIR"
+git add --force "$REF_DIR"
+git commit --allow-empty -m "chore: inspect docs (steps 2/3)"
+
+# Remove the docs
+cd "$DEV_DIR"
+mkdir -p "$REF_DIR"
+rm -rf "$REF_DIR"
+
+# Commit the changes
+git add --all
+git commit --allow-empty -m "chore: inspect docs (steps 3/3)"
+
+# Push the changes
+git push

--- a/scripts/inspect-docs.sh
+++ b/scripts/inspect-docs.sh
@@ -36,6 +36,7 @@ git commit --allow-empty -m "chore: inspect docs (steps 1/3)"
 
 # Build the docs from the dev branch
 cd "$DEV_DIR/website"
+pnpm install
 pnpm run build:typedoc
 
 # Commit the dev docs

--- a/scripts/pr-command.sh
+++ b/scripts/pr-command.sh
@@ -3,4 +3,8 @@ set -ex
 SLASH_COMMAND=$1
 echo "Running pull request slash command: $SLASH_COMMAND"
 
-echo "Hello world
+cd $(dirname $0)/..
+
+if [ "$SLASH_COMMAND" == "/docs" ]; then
+  bash scripts/inspect-docs.sh
+fi

--- a/scripts/pr-command.sh
+++ b/scripts/pr-command.sh
@@ -3,7 +3,8 @@ set -ex
 SLASH_COMMAND=$1
 echo "Running pull request slash command: $SLASH_COMMAND"
 
-cd $(dirname $0)/..
+cd "$(dirname "$0")"
+cd ..
 
 if [ "$SLASH_COMMAND" == "/docs" ]; then
   bash scripts/inspect-docs.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a script to automate inspection and comparison of documentation between branches.
  * Added support for running the documentation inspection process via a specific slash command.

* **Chores**
  * Updated script behavior to handle new documentation inspection workflow.
  * Added an npm script to streamline building typedoc documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->