### PR TITLE
feat: improve node selection background

### DIFF
--- a/.changeset/full-ways-reply.md
+++ b/.changeset/full-ways-reply.md
@@ -1,0 +1,6 @@
+---
+'prosekit': patch
+"@prosekit/web": patch
+---
+
+Fix an issue where the drag preview has an incorrect position when the dragging element has a margin.

--- a/.changeset/puny-facts-like.md
+++ b/.changeset/puny-facts-like.md
@@ -1,0 +1,8 @@
+---
+'prosekit': patch
+"@prosekit/basic": patch
+---
+
+Improve the node selection style in `prosekit/basic/typography.css`. Add a new
+CSS variable `--prosekit-node-selection-color` to customize the color of the
+node selection background.

--- a/.changeset/swift-ants-vanish.md
+++ b/.changeset/swift-ants-vanish.md
@@ -1,0 +1,6 @@
+---
+'prosekit': patch
+"@prosekit/extensions": patch
+---
+
+Fix an issue where the virtual selection and the node selection are both shown.

--- a/packages/basic/src/typography.css
+++ b/packages/basic/src/typography.css
@@ -1,3 +1,7 @@
+:root {
+  --prosekit-node-selection-color: rgba(57, 136, 255, 0.2);
+}
+
 .ProseMirror {
   & {
     /* Disable margin collapsing */
@@ -203,5 +207,17 @@
    */
   div[data-node-view-root="true"] {
     display: contents;
+  }
+
+  & .ProseMirror-selectednode {
+    border-radius: 0.2rem;
+    outline-color: var(--prosekit-node-selection-color);
+    outline-style: solid;
+    outline-width: 0.3rem;
+    background-color: var(--prosekit-node-selection-color);
+  }
+
+  &.prosekit-dragging {
+    --prosekit-node-selection-color: transparent;
   }
 }

--- a/packages/extensions/src/virtual-selection/index.ts
+++ b/packages/extensions/src/virtual-selection/index.ts
@@ -77,7 +77,16 @@ const virtualSelectionPlugin = new ProseMirrorPlugin<PluginState>({
     decorations: (state) => {
       const { selection, doc } = state
 
-      if (selection.empty || !getFocusState(state)) {
+      if (
+        selection.empty
+        || !getFocusState(state)
+        // When `selection.visible` is false, it indicates that the selection is
+        // rendered by the editor and it's not a native browser selection. An
+        // example of this is `NodeSelection`. In this situation, since the
+        // editor already shows the selection, we don't need to display a
+        // virtual selection.
+        || !selection.visible
+      ) {
         return null
       }
 

--- a/packages/prosekit/src/basic/typography-css.ts
+++ b/packages/prosekit/src/basic/typography-css.ts
@@ -1,6 +1,10 @@
 /**
  * An optional CSS file that contains beautiful typographic defaults styles. You can import this file as a good starting point for your project, or customize it as you want.
  *
+ * CSS variables:
+ *
+ * - `--prosekit-node-selection-color`: The color of the node selection background.
+ *
  * [view source code](https://unpkg.com/prosekit/basic/typography.css)
  *
  * @module prosekit/basic/typography.css

--- a/packages/prosekit/src/extensions/list/style-css.ts
+++ b/packages/prosekit/src/extensions/list/style-css.ts
@@ -3,7 +3,7 @@
  *
  * This file is already included in [`prosekit/basic/style.css`](/references/basic/stylecss/).
  *
- * It contains the following CSS variables:
+ * CSS variables:
  *
  * - `--prosekit-list-bullet-icon`: The icon for the bullet list.
  * - `--prosekit-list-toggle-open-icon`: The icon for the toggle list when it is

--- a/packages/web/src/components/block-handle/block-handle-draggable/set-drag-preview.ts
+++ b/packages/web/src/components/block-handle/block-handle-draggable/set-drag-preview.ts
@@ -1,5 +1,6 @@
 import { assignStyles } from '../../../utils/assign-styles'
 import { deepCloneElement } from '../../../utils/clone-element'
+import { getClientRect } from '../../../utils/get-client-rect'
 import { maxZIndex } from '../../../utils/max-z-index'
 
 /**
@@ -14,8 +15,11 @@ import { maxZIndex } from '../../../utils/max-z-index'
  * - Removes the container from the document body after the next frame.
  */
 export function setDragPreview(event: DragEvent, element: HTMLElement): void {
-  const rect = element.getBoundingClientRect()
-  const { width, height, x: elementX, y: elementY } = rect
+  const { top, bottom, left, right } = getClientRect(element)
+  const width = right - left
+  const height = bottom - top
+  const elementX = left
+  const elementY = top
 
   const { clientX, clientY } = event
 
@@ -54,8 +58,12 @@ export function setDragPreview(event: DragEvent, element: HTMLElement): void {
 
   const clonedElement = deepCloneElement(element)
   assignStyles(clonedElement, {
-    outline: 'none',
+    // A hardcoded opacity.
     opacity: '0.5',
+
+    // The bounding client rect doesn't include the margin, so we need to remove
+    // the margin too from the cloned element so that it can fit the container.
+    margin: '0',
   })
 
   document.body.appendChild(container)

--- a/packages/web/src/components/block-handle/block-handle-draggable/setup.ts
+++ b/packages/web/src/components/block-handle/block-handle-draggable/setup.ts
@@ -13,11 +13,14 @@ import {
   Slice,
 } from '@prosekit/pm/model'
 import { NodeSelection } from '@prosekit/pm/state'
+import type { EditorView } from '@prosekit/pm/view'
 
+import { getSafeEditorView } from '../../../utils/get-safe-editor-view'
 import {
   blockPopoverContext,
   draggingContext,
   type BlockPopoverContext,
+  type HoverState,
 } from '../context'
 
 import { setDragPreview } from './set-drag-preview'
@@ -31,14 +34,37 @@ export function useBlockHandleDraggable(
   { state }: { state: SignalState<BlockHandleDraggableProps> },
 ): void {
   const context = blockPopoverContext.consume(host)
+  const dragging = draggingContext.consume(host)
 
   useEffect(host, () => {
     host.draggable = true
   })
 
   usePointerDownHandler(host, context, state.editor)
-  useDraggingPreview(host, context, state.editor)
-  useDataDraggingAttribute(host)
+
+  useEventListener(host, 'dragstart', (event) => {
+    dragging.set(true)
+
+    const view = getSafeEditorView(state.editor.get())
+    const hoverState = context.get()
+
+    if (view && hoverState) {
+      view.dom.classList.add('prosekit-dragging')
+      createDraggingPreview(view, hoverState, event)
+      setViewDragging(view, hoverState)
+    }
+  })
+
+  useEventListener(host, 'dragend', () => {
+    dragging.set(false)
+
+    const view = getSafeEditorView(state.editor.get())
+    if (view) {
+      view.dom.classList.remove('prosekit-dragging')
+    }
+  })
+
+  useAttribute(host, 'data-dragging', () => (dragging.get() ? '' : undefined))
 }
 
 function usePointerDownHandler(
@@ -67,58 +93,36 @@ function usePointerDownHandler(
   })
 }
 
-function useDraggingPreview(
-  host: ConnectableElement,
-  context: ReadonlySignal<BlockPopoverContext>,
-  editor: ReadonlySignal<Editor | null>,
-) {
-  useEventListener(host, 'dragstart', (event) => {
-    const hoverState = context.get()
-    const { view } = editor.get() ?? {}
+function createDraggingPreview(view: EditorView, hoverState: HoverState, event: DragEvent): void {
+  if (!event.dataTransfer) {
+    return
+  }
 
-    if (!hoverState || !view || !event.dataTransfer) {
-      return
-    }
+  const { pos } = hoverState
 
-    const { node, pos } = hoverState
+  const element = view.nodeDOM(pos)
+  if (!element || !isHTMLElement(element)) {
+    return
+  }
 
-    const element = view.nodeDOM(pos)
-    if (!element || !isHTMLElement(element)) {
-      return
-    }
+  event.dataTransfer.clearData()
+  event.dataTransfer.setData('text/html', element.outerHTML)
+  event.dataTransfer.effectAllowed = 'copyMove'
+  setDragPreview(event, element)
 
-    event.dataTransfer.clearData()
-    event.dataTransfer.setData('text/html', element.outerHTML)
-    event.dataTransfer.effectAllowed = 'copyMove'
-    setDragPreview(event, element)
-
-    // An object matching the internal ProseMirror API shape.
-    // See https://github.com/ProseMirror/prosemirror-view/blob/1.38.1/src/input.ts#L657
-    const dragging = {
-      slice: new Slice(Fragment.from(node), 0, 0),
-      move: true,
-      node: NodeSelection.create(view.state.doc, pos),
-    }
-
-    view.dragging = dragging
-  })
+  return
 }
 
-function useDataDraggingAttribute(host: ConnectableElement): void {
-  const dragging = useDragging(host)
-  useAttribute(host, 'data-dragging', () => (dragging.get() ? '' : undefined))
-}
+function setViewDragging(view: EditorView, hoverState: HoverState): void {
+  const { node, pos } = hoverState
 
-function useDragging(host: ConnectableElement): ReadonlySignal<boolean> {
-  const dragging = draggingContext.consume(host)
+  // An object matching the internal ProseMirror API shape.
+  // See https://github.com/ProseMirror/prosemirror-view/blob/1.38.1/src/input.ts#L657
+  const dragging = {
+    slice: new Slice(Fragment.from(node), 0, 0),
+    move: true,
+    node: NodeSelection.create(view.state.doc, pos),
+  }
 
-  useEventListener(host, 'dragstart', () => {
-    dragging.set(true)
-  })
-
-  useEventListener(host, 'dragend', () => {
-    dragging.set(false)
-  })
-
-  return dragging
+  view.dragging = dragging
 }

--- a/packages/web/src/utils/clone-element.ts
+++ b/packages/web/src/utils/clone-element.ts
@@ -1,6 +1,6 @@
 /**
  * Creates a deep clone of an Element, including all computed styles so that
- * it looks the same as the original element.
+ * it looks almost exactly the same as the original element.
  */
 export function deepCloneElement<T extends Element>(element: T): T {
   const clonedElement = element.cloneNode(true) as T

--- a/packages/web/src/utils/get-client-rect.ts
+++ b/packages/web/src/utils/get-client-rect.ts
@@ -20,12 +20,15 @@ export function getClientRect(element: Element): {
       if (rects.length === 1) {
         return rects[0]
       }
-      return {
-        top: Math.min(...rects.map(rect => rect.top)),
-        right: Math.max(...rects.map(rect => rect.right)),
-        bottom: Math.max(...rects.map(rect => rect.bottom)),
-        left: Math.min(...rects.map(rect => rect.left)),
+      let { top, bottom, left, right } = rects[0]
+      for (let i = 1; i < rects.length; i++) {
+        const r = rects[i]
+        if (r.top < top) top = r.top
+        if (r.bottom > bottom) bottom = r.bottom
+        if (r.left < left) left = r.left
+        if (r.right > right) right = r.right
       }
+      return { top, bottom, left, right }
     }
   }
   return rect


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected drag preview positioning during drag-and-drop to properly account for element margins.
  * Resolved an issue where both virtual and node selections could display simultaneously, ensuring only the appropriate selection appears.

* **New Features**
  * Introduced a customizable CSS variable for node selection background color, allowing easier visual customization.

* **Style**
  * Enhanced node selection appearance with improved border radius, outline, and background color.
  * Disabled selection highlight during dragging for a cleaner drag-and-drop experience.

* **Documentation**
  * Updated documentation to include information about the new node selection color CSS variable and clarified CSS variable descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->