### PR TITLE
fix(drop-indicator): prevent dragging nodes to same position

### DIFF
--- a/.changeset/honest-kids-wait.md
+++ b/.changeset/honest-kids-wait.md
@@ -1,0 +1,5 @@
+---
+"@prosekit/extensions": patch
+---
+
+Don't show the drop indicator when dragging a node to the same position.

--- a/.changeset/honest-kids-wait.md
+++ b/.changeset/honest-kids-wait.md
@@ -1,4 +1,5 @@
 ---
+'prosekit': patch
 "@prosekit/extensions": patch
 ---
 

--- a/packages/extensions/src/drop-indicator/drop-indicator-plugin.ts
+++ b/packages/extensions/src/drop-indicator/drop-indicator-plugin.ts
@@ -1,7 +1,4 @@
-import type {
-  ResolvedPos,
-  Slice,
-} from '@prosekit/pm/model'
+import type { ResolvedPos } from '@prosekit/pm/model'
 import {
   NodeSelection,
   Plugin,

--- a/packages/extensions/src/drop-indicator/drop-indicator-plugin.ts
+++ b/packages/extensions/src/drop-indicator/drop-indicator-plugin.ts
@@ -18,6 +18,7 @@ import {
 import type {
   DragEventHandler,
   ShowHandler,
+  ViewDragging,
 } from './types'
 
 /**
@@ -54,12 +55,7 @@ export function createDropIndicatorPlugin(options: DropIndicatorPluginOptions): 
 
         let tr = view.state.tr
         if (move) {
-          interface Dragging {
-            readonly slice: Slice
-            readonly move: boolean
-            readonly node?: NodeSelection
-          }
-          let { node } = (view.dragging as Dragging | null) || {}
+          let { node } = (view.dragging as ViewDragging | null) || {}
           if (node) node.replace(tr)
           else tr.deleteSelection()
         }

--- a/packages/extensions/src/drop-indicator/index.ts
+++ b/packages/extensions/src/drop-indicator/index.ts
@@ -10,4 +10,5 @@ export type {
   Point,
   ShowHandler,
   ShowHandlerOptions,
+  ViewDragging,
 } from './types'

--- a/packages/extensions/src/drop-indicator/types.ts
+++ b/packages/extensions/src/drop-indicator/types.ts
@@ -1,3 +1,5 @@
+import type { Slice } from '@prosekit/pm/model'
+import type { NodeSelection } from '@prosekit/pm/state'
 import type { EditorView } from '@prosekit/pm/view'
 
 /**
@@ -72,4 +74,17 @@ export interface Point {
 export interface Line {
   readonly p1: Point
   readonly p2: Point
+}
+
+/**
+ * An interface matching the internal ProseMirror implementation.
+ *
+ * See https://github.com/ProseMirror/prosemirror-view/blob/1.38.1/src/input.ts#L657
+ *
+ * @internal
+ */
+export interface ViewDragging {
+  readonly slice: Slice
+  readonly move: boolean
+  readonly node?: NodeSelection
 }

--- a/packages/web/src/components/block-handle/block-handle-draggable/setup.ts
+++ b/packages/web/src/components/block-handle/block-handle-draggable/setup.ts
@@ -8,6 +8,7 @@ import {
 } from '@aria-ui/core'
 import { isHTMLElement } from '@ocavue/utils'
 import type { Editor } from '@prosekit/core'
+import type { ViewDragging } from '@prosekit/extensions/drop-indicator'
 import {
   Fragment,
   Slice,
@@ -116,9 +117,7 @@ function createDraggingPreview(view: EditorView, hoverState: HoverState, event: 
 function setViewDragging(view: EditorView, hoverState: HoverState): void {
   const { node, pos } = hoverState
 
-  // An object matching the internal ProseMirror API shape.
-  // See https://github.com/ProseMirror/prosemirror-view/blob/1.38.1/src/input.ts#L657
-  const dragging = {
+  const dragging: ViewDragging = {
     slice: new Slice(Fragment.from(node), 0, 0),
     move: true,
     node: NodeSelection.create(view.state.doc, pos),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop behavior in the editor to prevent the drop indicator from appearing when dragging a node back to its original position, reducing unnecessary visual feedback.

* **Documentation**
  * Updated internal documentation to clarify the structure of drag-and-drop operations.

* **Refactor**
  * Enhanced internal type usage for drag-and-drop operations to improve code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->