### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/packages/basic/package.json
+++ b/packages/basic/package.json
@@ -48,7 +48,7 @@
     "@types/jsdom": "^21.1.7",
     "happy-dom": "^18.0.1",
     "jsdom": "^26.1.0",
-    "tsdown": "^0.13.1",
+    "tsdown": "^0.13.2",
     "typescript": "~5.8.3",
     "vitest": "^3.2.4"
   },

--- a/packages/config-tsdown/package.json
+++ b/packages/config-tsdown/package.json
@@ -13,7 +13,7 @@
     "@types/lodash-es": "^4.17.12",
     "lodash-es": "^4.17.21",
     "read-package-up": "^11.0.0",
-    "tsdown": "^0.13.1",
+    "tsdown": "^0.13.2",
     "typescript": "~5.8.3"
   }
 }

--- a/packages/config-tsdown/src/index.ts
+++ b/packages/config-tsdown/src/index.ts
@@ -24,9 +24,7 @@ export function config(input?: Options): Options {
     entry,
     sourcemap: false,
     clean: false,
-    dts: {
-      isolatedDeclarations: true,
-    },
+    dts: true,
     // Bundling CSS files to remove the `@import` statements. This increases the
     // compability of the output.
     noExternal: [/\.css$/i],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "build:tsdown": "tsdown"
   },
   "dependencies": {
-    "@ocavue/utils": "^0.6.0",
+    "@ocavue/utils": "^0.7.1",
     "@prosekit/pm": "workspace:^",
     "clsx": "^2.1.1",
     "just-clone": "^6.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,7 @@
     "@types/diffable-html": "^5.0.2",
     "@vitest/browser": "^3.2.4",
     "diffable-html": "^6.0.1",
-    "tsdown": "^0.13.1",
+    "tsdown": "^0.13.2",
     "typescript": "~5.8.3",
     "vitest": "^3.2.4"
   },

--- a/packages/core/src/utils/get-id.ts
+++ b/packages/core/src/utils/get-id.ts
@@ -4,6 +4,8 @@ let id = 0
  * Returns a unique id in the current process that can be used in various places.
  *
  * @internal
+ *
+ * @deprecated Import `getId` from `@ocavue/utils` package instead. Remove it in a future version.
  */
 export function getId(): string {
   id = (id + 1) % Number.MAX_SAFE_INTEGER

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -126,7 +126,7 @@
     "remark-html": "^16.0.1",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
-    "tsdown": "^0.13.1",
+    "tsdown": "^0.13.2",
     "type-fest": "^4.41.0",
     "typescript": "~5.8.3",
     "unified": "^11.0.5",

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -80,7 +80,7 @@
     "build:tsdown": "tsdown"
   },
   "dependencies": {
-    "@ocavue/utils": "^0.6.0",
+    "@ocavue/utils": "^0.7.1",
     "@prosekit/core": "workspace:^",
     "@prosekit/pm": "workspace:^",
     "prosemirror-changeset": "^2.3.1",

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@prosekit/config-tsdown": "workspace:*",
     "@prosekit/config-vitest": "workspace:*",
-    "tsdown": "^0.13.1",
+    "tsdown": "^0.13.2",
     "typescript": "~5.8.3",
     "vitest": "^3.2.4"
   },

--- a/packages/pm/package.json
+++ b/packages/pm/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@prosekit/config-tsdown": "workspace:*",
     "@prosekit/config-vitest": "workspace:*",
-    "tsdown": "^0.13.1",
+    "tsdown": "^0.13.2",
     "typescript": "~5.8.3",
     "vitest": "^3.2.4"
   },

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -60,7 +60,7 @@
     "@prosekit/config-tsdown": "workspace:*",
     "@prosekit/config-vitest": "workspace:*",
     "preact": "^10.27.0",
-    "tsdown": "^0.13.1",
+    "tsdown": "^0.13.2",
     "typescript": "~5.8.3",
     "vitest": "^3.2.4"
   },

--- a/packages/prosekit/package.json
+++ b/packages/prosekit/package.json
@@ -231,7 +231,7 @@
     "react-dom": "^19.1.1",
     "solid-js": "^1.9.7",
     "svelte": "^5.37.2",
-    "tsdown": "^0.13.1",
+    "tsdown": "^0.13.2",
     "tsup": "^8.5.0",
     "typedoc": "^0.28.7",
     "typedoc-plugin-external-package-links": "^0.1.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -69,7 +69,7 @@
     "@types/react-dom": "^19.1.7",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "tsdown": "^0.13.1",
+    "tsdown": "^0.13.2",
     "typescript": "~5.8.3",
     "vitest": "^3.2.4"
   },

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -62,7 +62,7 @@
     "@prosekit/config-tsdown": "workspace:*",
     "@prosekit/config-vitest": "workspace:*",
     "solid-js": "^1.9.7",
-    "tsdown": "^0.13.1",
+    "tsdown": "^0.13.2",
     "typescript": "~5.8.3",
     "vitest": "^3.2.4"
   },

--- a/packages/typedoc-plugin/package.json
+++ b/packages/typedoc-plugin/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.17.29",
-    "tsdown": "^0.13.1",
+    "tsdown": "^0.13.2",
     "typescript": "~5.8.3"
   }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -63,7 +63,7 @@
     "@prosekit/config-vitest": "workspace:*",
     "@vitejs/plugin-vue": "^5.2.4",
     "@vue/test-utils": "^2.4.6",
-    "tsdown": "^0.13.1",
+    "tsdown": "^0.13.2",
     "typescript": "~5.8.3",
     "vitest": "^3.2.4",
     "vue": "^3.5.18"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -53,7 +53,7 @@
     "@aria-ui/presence": "^0.0.19",
     "@aria-ui/tooltip": "^0.0.29",
     "@floating-ui/dom": "^1.7.3",
-    "@ocavue/utils": "^0.6.0",
+    "@ocavue/utils": "^0.7.1",
     "@prosekit/core": "workspace:^",
     "@prosekit/extensions": "workspace:^",
     "@prosekit/pm": "workspace:^",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@prosekit/config-tsdown": "workspace:*",
     "@prosekit/config-vitest": "workspace:*",
-    "tsdown": "^0.13.1",
+    "tsdown": "^0.13.2",
     "typescript": "~5.8.3",
     "vitest": "^3.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -906,8 +906,8 @@ importers:
         specifier: ^0.18.1
         version: 0.18.1(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))
       astrobook:
-        specifier: ^0.8.8
-        version: 0.8.8(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))
+        specifier: ^0.8.9
+        version: 0.8.9(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.2
         version: 19.1.0-rc.2
@@ -1104,14 +1104,14 @@ packages:
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
-  '@astrobook/core@0.8.8':
-    resolution: {integrity: sha512-YqqjCfLQ0lUcKn15xdoDsIO16u2NW+BlxvdDndcQAlTs10mW+W2ksqLqu7BCoAl4aZwT/gq+qbz4uWouUuD6sQ==}
+  '@astrobook/core@0.8.9':
+    resolution: {integrity: sha512-h7FmIlosTtJ/2ZASDHL5Vd0KuSH71iWBgbGXh981qjp1nUchfFDslcir24m9Io/mhQJDdXpoB2sREMNPUgM2MQ==}
 
-  '@astrobook/types@0.8.8':
-    resolution: {integrity: sha512-MWRiZn2+WTAv8w11JIzYxm9wE+C7S5BB9+RBYFxxMp3dWwL066cR5jfBNq06GfN4WSua2sU66kbMZl6w/3eCeA==}
+  '@astrobook/types@0.8.9':
+    resolution: {integrity: sha512-6/ZlkStbGq/ez96jdknQUo8wc59y3SdGp/aGqzb9jpwDd51ZwDk9377oldYGt40i+O1qnOFco8ulFnNV3XGlug==}
 
-  '@astrobook/ui@0.8.8':
-    resolution: {integrity: sha512-uodDruwUNgBeEtbt0Nd9Ad5KOdjdzVupxP7u6p4jaJPRt02r/zUc7/bi7vialwb34SF6z3Pfk212TY47d30swQ==}
+  '@astrobook/ui@0.8.9':
+    resolution: {integrity: sha512-GuT5UUHhH3RPzSJIGcJCXv7h8yNZIpEi4uOZM3FADXIHemV0wKTB4Q67GEv2qrFTJy7QFKrvqBua7klMoo966w==}
     peerDependencies:
       astro: '>=4.0.0'
     peerDependenciesMeta:
@@ -3392,8 +3392,8 @@ packages:
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
-  astrobook@0.8.8:
-    resolution: {integrity: sha512-9fII6lc71vVj0bhG/mHKjhFs75QMOfjJ3aFaQWIAtjNcYYTyTOLusMKT1QrMz37V6XLDSuEO/8o+jDMOg81f4A==}
+  astrobook@0.8.9:
+    resolution: {integrity: sha512-iO7lmOST7j0A4NuDjlv0i3091/krSvDYa7EzUtK70RhX3Pp2El1Wj+/VtA1aiAWRl3mpq3EwsiimBx9Nc0q3gw==}
     peerDependencies:
       astro: '>=4.0.0'
     peerDependenciesMeta:
@@ -7560,9 +7560,9 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@astrobook/core@0.8.8':
+  '@astrobook/core@0.8.9':
     dependencies:
-      '@astrobook/types': 0.8.8
+      '@astrobook/types': 0.8.9
       '@sveltejs/acorn-typescript': 1.0.5(acorn@8.15.0)
       acorn: 8.15.0
       fdir: 6.4.6(picomatch@4.0.3)
@@ -7570,12 +7570,12 @@ snapshots:
       slash: 5.1.0
       yoctocolors: 2.1.1
 
-  '@astrobook/types@0.8.8': {}
+  '@astrobook/types@0.8.9': {}
 
-  '@astrobook/ui@0.8.8(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))':
+  '@astrobook/ui@0.8.9(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))':
     dependencies:
-      '@astrobook/core': 0.8.8
-      '@astrobook/types': 0.8.8
+      '@astrobook/core': 0.8.9
+      '@astrobook/types': 0.8.9
       astro-theme-toggle: 0.6.1
       just-group-by: 2.2.0
     optionalDependencies:
@@ -10394,11 +10394,11 @@ snapshots:
       - uploadthing
       - yaml
 
-  astrobook@0.8.8(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)):
+  astrobook@0.8.9(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)):
     dependencies:
-      '@astrobook/core': 0.8.8
-      '@astrobook/types': 0.8.8
-      '@astrobook/ui': 0.8.8(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))
+      '@astrobook/core': 0.8.9
+      '@astrobook/types': 0.8.9
+      '@astrobook/ui': 0.8.9(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))
     optionalDependencies:
       astro: 5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,8 +170,8 @@ importers:
   packages/core:
     dependencies:
       '@ocavue/utils':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.1
+        version: 0.7.1
       '@prosekit/pm':
         specifier: workspace:^
         version: link:../pm

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,8 +280,8 @@ importers:
   packages/extensions:
     dependencies:
       '@ocavue/utils':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.1
+        version: 0.7.1
       '@prosekit/core':
         specifier: workspace:^
         version: link:../core
@@ -806,8 +806,8 @@ importers:
         specifier: ^1.7.3
         version: 1.7.3
       '@ocavue/utils':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.1
+        version: 0.7.1
       '@prosekit/core':
         specifier: workspace:^
         version: link:../core
@@ -873,8 +873,8 @@ importers:
         specifier: ^1.2.20
         version: 1.2.20
       '@ocavue/utils':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.1
+        version: 0.7.1
       '@playwright/test':
         specifier: ^1.54.2
         version: 1.54.2
@@ -2112,6 +2112,9 @@ packages:
 
   '@ocavue/utils@0.6.0':
     resolution: {integrity: sha512-ulsUYE5EvGIFvSyjPb57KoZ2WgztgIYgHL4n0/zvSeqo3VZUVeMpIq8tsAe9IQvFMQHnKa3Nzl+8QfZ03/sIKQ==}
+
+  '@ocavue/utils@0.7.1':
+    resolution: {integrity: sha512-gY/YWdyTPGx8YTT0q/0tQJs6kPJ2XeXRPfdzWLt+wefIOuwb1n5Nq3GwKM/AY+Wab3dbx6w+MkX8VSbrm3l6Xg==}
 
   '@octokit/action@6.1.0':
     resolution: {integrity: sha512-lo+nHx8kAV86bxvOVOI3vFjX3gXPd/L7guAUbvs3pUvnR2KC+R7yjBkA1uACt4gYhs4LcWP3AXSGQzsbeN2XXw==}
@@ -8850,6 +8853,8 @@ snapshots:
   '@ocavue/tsconfig@0.3.7': {}
 
   '@ocavue/utils@0.6.0': {}
+
+  '@ocavue/utils@0.7.1': {}
 
   '@octokit/action@6.1.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -906,8 +906,8 @@ importers:
         specifier: ^0.18.1
         version: 0.18.1(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))
       astrobook:
-        specifier: ^0.8.7
-        version: 0.8.7(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))
+        specifier: ^0.8.8
+        version: 0.8.8(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.2
         version: 19.1.0-rc.2
@@ -1104,14 +1104,14 @@ packages:
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
-  '@astrobook/core@0.8.7':
-    resolution: {integrity: sha512-bXPyKuJBcKYwD/3ZIaMJ0jlaWHmJkWSrTlmFEkU7dCLKr/rXZUi25RFK0ZuY1rRkaOaI+riSIDWLiHe+FmjMvA==}
+  '@astrobook/core@0.8.8':
+    resolution: {integrity: sha512-YqqjCfLQ0lUcKn15xdoDsIO16u2NW+BlxvdDndcQAlTs10mW+W2ksqLqu7BCoAl4aZwT/gq+qbz4uWouUuD6sQ==}
 
-  '@astrobook/types@0.8.7':
-    resolution: {integrity: sha512-Bc3tBMFPwxa/LNU8gF5se6ypBIIexDkLj1ZOKrNz35quErVltqglv3clKC3wj/dVXA5bx5LNbYlj0+EWjWXI5Q==}
+  '@astrobook/types@0.8.8':
+    resolution: {integrity: sha512-MWRiZn2+WTAv8w11JIzYxm9wE+C7S5BB9+RBYFxxMp3dWwL066cR5jfBNq06GfN4WSua2sU66kbMZl6w/3eCeA==}
 
-  '@astrobook/ui@0.8.7':
-    resolution: {integrity: sha512-GIhXV3svKtwSgkb8EerVQ+VERzx7Pw+jIYIah3d963DUxvdsW/sjetE+kr2PfDHzyg/kanfbtMduRuoAfxJ/2g==}
+  '@astrobook/ui@0.8.8':
+    resolution: {integrity: sha512-uodDruwUNgBeEtbt0Nd9Ad5KOdjdzVupxP7u6p4jaJPRt02r/zUc7/bi7vialwb34SF6z3Pfk212TY47d30swQ==}
     peerDependencies:
       astro: '>=4.0.0'
     peerDependenciesMeta:
@@ -3392,8 +3392,8 @@ packages:
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
-  astrobook@0.8.7:
-    resolution: {integrity: sha512-cME+81e3BcTUDGExcbbO2FnvsgUxwW9N7axDRnbLiAXEWokh28Q+7g55euS9SmqoRZFvwqF1pJ/3W9FH0oFYhQ==}
+  astrobook@0.8.8:
+    resolution: {integrity: sha512-9fII6lc71vVj0bhG/mHKjhFs75QMOfjJ3aFaQWIAtjNcYYTyTOLusMKT1QrMz37V6XLDSuEO/8o+jDMOg81f4A==}
     peerDependencies:
       astro: '>=4.0.0'
     peerDependenciesMeta:
@@ -7560,9 +7560,9 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@astrobook/core@0.8.7':
+  '@astrobook/core@0.8.8':
     dependencies:
-      '@astrobook/types': 0.8.7
+      '@astrobook/types': 0.8.8
       '@sveltejs/acorn-typescript': 1.0.5(acorn@8.15.0)
       acorn: 8.15.0
       fdir: 6.4.6(picomatch@4.0.3)
@@ -7570,12 +7570,12 @@ snapshots:
       slash: 5.1.0
       yoctocolors: 2.1.1
 
-  '@astrobook/types@0.8.7': {}
+  '@astrobook/types@0.8.8': {}
 
-  '@astrobook/ui@0.8.7(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))':
+  '@astrobook/ui@0.8.8(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))':
     dependencies:
-      '@astrobook/core': 0.8.7
-      '@astrobook/types': 0.8.7
+      '@astrobook/core': 0.8.8
+      '@astrobook/types': 0.8.8
       astro-theme-toggle: 0.6.1
       just-group-by: 2.2.0
     optionalDependencies:
@@ -10394,11 +10394,11 @@ snapshots:
       - uploadthing
       - yaml
 
-  astrobook@0.8.7(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)):
+  astrobook@0.8.8(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)):
     dependencies:
-      '@astrobook/core': 0.8.7
-      '@astrobook/types': 0.8.7
-      '@astrobook/ui': 0.8.7(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))
+      '@astrobook/core': 0.8.8
+      '@astrobook/types': 0.8.8
+      '@astrobook/ui': 0.8.8(astro@5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0))
     optionalDependencies:
       astro: 5.12.8(@types/node@20.17.57)(jiti@2.4.2)(rollup@4.41.1)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^26.1.0
         version: 26.1.0
       tsdown:
-        specifier: ^0.13.1
-        version: 0.13.1(typescript@5.8.3)
+        specifier: ^0.13.2
+        version: 0.13.2(typescript@5.8.3)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -118,8 +118,8 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       tsdown:
-        specifier: ^0.13.1
-        version: 0.13.1(typescript@5.8.3)
+        specifier: ^0.13.2
+        version: 0.13.2(typescript@5.8.3)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -210,8 +210,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       tsdown:
-        specifier: ^0.13.1
-        version: 0.13.1(typescript@5.8.3)
+        specifier: ^0.13.2
+        version: 0.13.2(typescript@5.8.3)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -353,8 +353,8 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       tsdown:
-        specifier: ^0.13.1
-        version: 0.13.1(typescript@5.8.3)
+        specifier: ^0.13.2
+        version: 0.13.2(typescript@5.8.3)
       type-fest:
         specifier: ^4.41.0
         version: 4.41.0
@@ -390,8 +390,8 @@ importers:
         specifier: workspace:*
         version: link:../config-vitest
       tsdown:
-        specifier: ^0.13.1
-        version: 0.13.1(typescript@5.8.3)
+        specifier: ^0.13.2
+        version: 0.13.2(typescript@5.8.3)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -433,8 +433,8 @@ importers:
         specifier: workspace:*
         version: link:../config-vitest
       tsdown:
-        specifier: ^0.13.1
-        version: 0.13.1(typescript@5.8.3)
+        specifier: ^0.13.2
+        version: 0.13.2(typescript@5.8.3)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -464,8 +464,8 @@ importers:
         specifier: ^10.27.0
         version: 10.27.0
       tsdown:
-        specifier: ^0.13.1
-        version: 0.13.1(typescript@5.8.3)
+        specifier: ^0.13.2
+        version: 0.13.2(typescript@5.8.3)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -552,8 +552,8 @@ importers:
         specifier: ^5.37.2
         version: 5.37.2
       tsdown:
-        specifier: ^0.13.1
-        version: 0.13.1(typescript@5.8.3)
+        specifier: ^0.13.2
+        version: 0.13.2(typescript@5.8.3)
       tsup:
         specifier: ^8.5.0
         version: 8.5.0(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
@@ -622,8 +622,8 @@ importers:
         specifier: ^19.1.1
         version: 19.1.1(react@19.1.1)
       tsdown:
-        specifier: ^0.13.1
-        version: 0.13.1(typescript@5.8.3)
+        specifier: ^0.13.2
+        version: 0.13.2(typescript@5.8.3)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -659,8 +659,8 @@ importers:
         specifier: ^1.9.7
         version: 1.9.7
       tsdown:
-        specifier: ^0.13.1
-        version: 0.13.1(typescript@5.8.3)
+        specifier: ^0.13.2
+        version: 0.13.2(typescript@5.8.3)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -727,8 +727,8 @@ importers:
         specifier: ^20.17.29
         version: 20.17.57
       tsdown:
-        specifier: ^0.13.1
-        version: 0.13.1(typescript@5.8.3)
+        specifier: ^0.13.2
+        version: 0.13.2(typescript@5.8.3)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -764,8 +764,8 @@ importers:
         specifier: ^2.4.6
         version: 2.4.6
       tsdown:
-        specifier: ^0.13.1
-        version: 0.13.1(typescript@5.8.3)
+        specifier: ^0.13.2
+        version: 0.13.2(typescript@5.8.3)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -831,8 +831,8 @@ importers:
         specifier: workspace:*
         version: link:../config-vitest
       tsdown:
-        specifier: ^0.13.1
-        version: 0.13.1(typescript@5.8.3)
+        specifier: ^0.13.2
+        version: 0.13.2(typescript@5.8.3)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -6151,8 +6151,8 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rolldown-plugin-dts@0.14.3:
-    resolution: {integrity: sha512-LsUPsPV2XpACe5wikxQzYBD0qg4nyxwUkLos5oF8v8qVO9jPpH6GRg2S5ZUELFry04Ab58C9Tibbi7dEbVLp2w==}
+  rolldown-plugin-dts@0.15.1:
+    resolution: {integrity: sha512-X/oIfoqsEWb46aWXvdgKSN/TcF3Z50Mikk30KZcceVBgypEl9Tscvt3+o6pZzyJxZV3m+Kc+ftlHBBVQUGpXtw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
@@ -6676,8 +6676,8 @@ packages:
       typescript:
         optional: true
 
-  tsdown@0.13.1:
-    resolution: {integrity: sha512-+rdxvqZvRKh+OwuupdQmJ2XAM31gLsdqcoo1O3aIlaD+MEXw5OaCRaCalg5wA+0nNk97f0GJliGZyUi0QlcCmQ==}
+  tsdown@0.13.2:
+    resolution: {integrity: sha512-sXZKvkqxxKMBL6I/AzXJnC+/9i6bLO8an+Jg4JSJDkEc99e3Y5bACQMTQyE1IXJE+7F6IRZ1P8AJQu31eQqv8A==}
     engines: {node: '>=20.19.0'}
     hasBin: true
     peerDependencies:
@@ -13845,7 +13845,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.14.3(rolldown@1.0.0-beta.30)(typescript@5.8.3):
+  rolldown-plugin-dts@0.15.1(rolldown@1.0.0-beta.30)(typescript@5.8.3):
     dependencies:
       '@babel/generator': 7.28.0
       '@babel/parser': 7.28.0
@@ -14518,7 +14518,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  tsdown@0.13.1(typescript@5.8.3):
+  tsdown@0.13.2(typescript@5.8.3):
     dependencies:
       ansis: 4.1.0
       cac: 6.7.14
@@ -14528,7 +14528,7 @@ snapshots:
       empathic: 2.0.0
       hookable: 5.5.3
       rolldown: 1.0.0-beta.30
-      rolldown-plugin-dts: 0.14.3(rolldown@1.0.0-beta.30)(typescript@5.8.3)
+      rolldown-plugin-dts: 0.15.1(rolldown@1.0.0-beta.30)(typescript@5.8.3)
       semver: 7.7.2
       tinyexec: 1.0.1
       tinyglobby: 0.2.14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2178,12 +2178,12 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
-  '@oxc-project/runtime@0.78.0':
-    resolution: {integrity: sha512-jOU7sDFMyq5ShGJC21UobalVzqcdtWGfySVp8ELvKoVLzMpLHb4kv1bs9VKxaP8XC7Z9hlAXwEKVhCTN+j21aQ==}
+  '@oxc-project/runtime@0.80.0':
+    resolution: {integrity: sha512-3rzy1bJAZ4s7zV9TKT60x119RwJDCDqEtCwK/Zc2qlm7wGhiIUxLLYUhE/mN91yB0u1kxm5sh4NjU12sPqQTpg==}
     engines: {node: '>=6.9.0'}
 
-  '@oxc-project/types@0.78.0':
-    resolution: {integrity: sha512-8FvExh0WRWN1FoSTjah1xa9RlavZcJQ8/yxRbZ7ElmSa2Ij5f5Em7MvRbSthE6FbwC6Wh8iAw0Gpna7QdoqLGg==}
+  '@oxc-project/types@0.80.0':
+    resolution: {integrity: sha512-xxHQm8wfCv2e8EmtaDwpMeAHOWqgQDAYg+BJouLXSQt5oTKu9TIXrgNMGSrM2fLvKmECsRd9uUFAAD+hPyootA==}
 
   '@pagefind/darwin-arm64@1.3.0':
     resolution: {integrity: sha512-365BEGl6ChOsauRjyVpBjXybflXAOvoMROw3TucAROHIcdBvXk9/2AmEvGFU0r75+vdQI4LJdJdpH4Y6Yqaj4A==}
@@ -2314,78 +2314,78 @@ packages:
     resolution: {integrity: sha512-G0OnZbMWEs5LhDyqy2UL17vGhSVHkQIfVojMtEWVenvj0V5S84VBgy86kJIuNsGDp2p7sTKlpSIpBUWdC35OKg==}
     engines: {node: '>=20.0.0'}
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.30':
-    resolution: {integrity: sha512-4j7QBitb/WMT1fzdJo7BsFvVNaFR5WCQPdf/RPDHEsgQIYwBaHaL47KTZxncGFQDD1UAKN3XScJ0k7LAsZfsvg==}
+  '@rolldown/binding-android-arm64@1.0.0-beta.31':
+    resolution: {integrity: sha512-0mFtKwOG7smn0HkvQ6h8j0m/ohkR7Fp5eMTJ2Pns/HSbePHuDpxMaQ4TjZ6arlVXxpeWZlAHeT5BeNsOA3iWTg==}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.30':
-    resolution: {integrity: sha512-4vWFTe1o5LXeitI2lW8qMGRxxwrH/LhKd2HDLa/QPhdxohvdnfKyDZWN96XUhDyje2bHFCFyhMs3ak2lg2mJFA==}
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.31':
+    resolution: {integrity: sha512-BHfHJ8Nb5G7ZKJl6pimJacupONT4F7w6gmQHw41rouAnJF51ORDwGefWeb6OMLzGmJwzxlIVPERfnJf1EsMM7A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.30':
-    resolution: {integrity: sha512-MxrfodqImbsDFFFU/8LxyFPZjt7s4ht8g2Zb76EmIQ+xlmit46L9IzvWiuMpEaSJ5WbnjO7fCDWwakMGyJJ+Dw==}
+  '@rolldown/binding-darwin-x64@1.0.0-beta.31':
+    resolution: {integrity: sha512-4MiuRtExC08jHbSU/diIL+IuQP+3Ck1FbWAplK+ysQJ7fxT3DMxy5FmnIGfmhaqow8oTjb2GEwZJKgTRjZL1Vw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.30':
-    resolution: {integrity: sha512-c/TQXcATKoO8qE1bCjCOkymZTu7yVUAxBSNLp42Q97XHCb0Cu9v6MjZpB6c7Hq9NQ9NzW44uglak9D/r77JeDw==}
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.31':
+    resolution: {integrity: sha512-nffC1u7ccm12qlAea8ExY3AvqlaHy/o/3L4p5Es8JFJ3zJSs6e3DyuxGZZVdl9EVwsLxPPTvioIl4tEm2afwyw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.30':
-    resolution: {integrity: sha512-Vxci4xylM11zVqvrmezAaRjGBDyOlMRtlt7TDgxaBmSYLuiokXbZpD8aoSuOyjUAeN0/tmWItkxNGQza8UWGNQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.31':
+    resolution: {integrity: sha512-LHmAaB3rB1GOJuHscKcL2Ts/LKLcb3YWTh2uQ/876rg/J9WE9kQ0kZ+3lRSYbth/YL8ln54j4JZmHpqQY3xptQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.30':
-    resolution: {integrity: sha512-iEBEdSs25Ol0lXyVNs763f7YPAIP0t1EAjoXME81oJ94DesJslaLTj71Rn1shoMDVA+dfkYA286w5uYnOs9ZNA==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.31':
+    resolution: {integrity: sha512-oTDZVfqIAjLB2I1yTiLyyhfPPO6dky33sTblxTCpe+ZT55WizN3KDoBKJ4yXG8shI6I4bRShVu29Xg0yAjyQYw==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.30':
-    resolution: {integrity: sha512-Ny684Sn1X8c+gGLuDlxkOuwiEE3C7eEOqp1/YVBzQB4HO7U/b4n7alvHvShboOEY5DP1fFUjq6Z+sBLYlCIZbQ==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.31':
+    resolution: {integrity: sha512-duJ3IkEBj9Xe9NYW1n8Y3483VXHGi8zQ0ZsLbK8464EJUXLF7CXM8Ry+jkkUw+ZvA+Zu1E/+C6p2Y6T9el0C9g==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.30':
-    resolution: {integrity: sha512-6moyULHDPKwt5RDEV72EqYw5n+s46AerTwtEBau5wCsZd1wuHS1L9z6wqhKISXAFTK9sneN0TEjvYKo+sgbbiA==}
+  '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.31':
+    resolution: {integrity: sha512-qdbmU5QSZ0uoLZBYMxiHsMQmizqtzFGTVPU5oyU1n0jU0Mo+mkSzqZuL8VBnjHOHzhVxZsoAGH9JjiRzCnoGVA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.30':
-    resolution: {integrity: sha512-p0yoPdoGg5Ow2YZKKB5Ypbn58i7u4XFk3PvMkriFnEcgtVk40c5u7miaX7jH0JdzahyXVBJ/KT5yEpJrzQn8yg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.31':
+    resolution: {integrity: sha512-H7+r34TSV8udB2gAsebFM/YuEeNCkPGEAGJ1JE7SgI9XML6FflqcdKfrRSneQFsPaom/gCEc1g0WW5MZ0O3blw==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.30':
-    resolution: {integrity: sha512-sM/KhCrsT0YdHX10mFSr0cvbfk1+btG6ftepAfqhbcDfhi0s65J4dTOxGmklJnJL9i1LXZ8WA3N4wmnqsfoK8Q==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.31':
+    resolution: {integrity: sha512-zRm2YmzFVqbsmUsyyZnHfJrOlQUcWS/FJ5ZWL8Q1kZh5PnLBrTVZNpakIWwAxpN5gNEi9MmFd5YHocVJp8ps1Q==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.30':
-    resolution: {integrity: sha512-i3kD5OWs8PQP0V+JW3TFyCLuyjuNzrB45em0g84Jc+gvnDsGVlzVjMNPo7txE/yT8CfE90HC/lDs3ry9FvaUyw==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.31':
+    resolution: {integrity: sha512-fM1eUIuHLsNJXRlWOuIIex1oBJ89I0skFWo5r/D3KSJ5gD9MBd3g4Hp+v1JGohvyFE+7ylnwRxSUyMEeYpA69A==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.30':
-    resolution: {integrity: sha512-q7mrYln30V35VrCqnBVQQvNPQm8Om9HC59I3kMYiOWogvJobzSPyO+HA1MP363+Qgwe39I2I1nqBKPOtWZ33AQ==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.31':
+    resolution: {integrity: sha512-4nftR9V2KHH3zjBwf6leuZZJQZ7v0d70ogjHIqB3SDsbDLvVEZiGSsSn2X6blSZRZeJSFzK0pp4kZ67zdZXwSw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.30':
-    resolution: {integrity: sha512-nUqGBt39XTpbBEREEnyKofdP3uz+SN/x2884BH+N3B2NjSUrP6NXwzltM35C0wKK42hX/nthRrwSgj715m99Jw==}
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.31':
+    resolution: {integrity: sha512-0TQcKu9xZVHYALit+WJsSuADGlTFfOXhnZoIHWWQhTk3OgbwwbYcSoZUXjRdFmR6Wswn4csHtJGN1oYKeQ6/2g==}
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.30':
-    resolution: {integrity: sha512-lbnvUwAXIVWSXAeZrCa4b1KvV/DW0rBnMHuX0T7I6ey1IsXZ90J37dEgt3j48Ex1Cw1E+5H7VDNP2gyOX8iu3w==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.31':
+    resolution: {integrity: sha512-3zMICWwpZh1jrkkKDYIUCx/2wY3PXLICAS0AnbeLlhzfWPhCcpNK9eKhiTlLAZyTp+3kyipoi/ZSVIh+WDnBpQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-beta.30':
-    resolution: {integrity: sha512-whXaSoNUFiyDAjkUF8OBpOm77Szdbk5lGNqFe6CbVbJFrhCCPinCbRA3NjawwlNHla1No7xvXXh+CpSxnPfUEw==}
+  '@rolldown/pluginutils@1.0.0-beta.31':
+    resolution: {integrity: sha512-IaDZ9NhjOIOkYtm+hH0GX33h3iVZ2OeSUnFF0+7Z4+1GuKs4Kj5wK3+I2zNV9IPLfqV4XlwWif8SXrZNutxciQ==}
 
   '@rolldown/pluginutils@1.0.0-beta.9':
     resolution: {integrity: sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==}
@@ -6167,8 +6167,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.0-beta.30:
-    resolution: {integrity: sha512-H/LmDTUPlm65hWOTjXvd1k0qrGinNi8LrG3JsHVm6Oit7STg0upBmgoG5PZUHbAnGTHr0MLoLyzjmH261lIqSg==}
+  rolldown@1.0.0-beta.31:
+    resolution: {integrity: sha512-M2Q+RfG0FMJeSW3RSFTbvtjGVTcQpTQvN247D0EMSsPkpZFoinopR9oAnQiwgogQyzDuvKNnbyCbQQlmNAzSoQ==}
     hasBin: true
 
   rollup@4.41.1:
@@ -8932,9 +8932,9 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
-  '@oxc-project/runtime@0.78.0': {}
+  '@oxc-project/runtime@0.80.0': {}
 
-  '@oxc-project/types@0.78.0': {}
+  '@oxc-project/types@0.80.0': {}
 
   '@pagefind/darwin-arm64@1.3.0':
     optional: true
@@ -9060,51 +9060,51 @@ snapshots:
     dependencies:
       quansync: 0.2.10
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.30':
+  '@rolldown/binding-android-arm64@1.0.0-beta.31':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.30':
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.31':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.30':
+  '@rolldown/binding-darwin-x64@1.0.0-beta.31':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.30':
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.31':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.30':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.31':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.30':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.31':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.30':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.31':
     optional: true
 
-  '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.30':
+  '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.31':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.30':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.31':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.30':
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.31':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.30':
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.31':
     dependencies:
       '@napi-rs/wasm-runtime': 1.0.1
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.30':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.31':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.30':
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.31':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.30':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.31':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-beta.30': {}
+  '@rolldown/pluginutils@1.0.0-beta.31': {}
 
   '@rolldown/pluginutils@1.0.0-beta.9': {}
 
@@ -9858,7 +9858,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.4
       '@babel/plugin-transform-typescript': 7.27.1(@babel/core@7.27.4)
-      '@rolldown/pluginutils': 1.0.0-beta.30
+      '@rolldown/pluginutils': 1.0.0-beta.31
       '@vue/babel-plugin-jsx': 1.4.0(@babel/core@7.27.4)
       vite: 6.3.5(@types/node@20.17.57)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0)
       vue: 3.5.18(typescript@5.8.3)
@@ -13845,7 +13845,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.15.1(rolldown@1.0.0-beta.30)(typescript@5.8.3):
+  rolldown-plugin-dts@0.15.1(rolldown@1.0.0-beta.31)(typescript@5.8.3):
     dependencies:
       '@babel/generator': 7.28.0
       '@babel/parser': 7.28.0
@@ -13855,34 +13855,34 @@ snapshots:
       debug: 4.4.1
       dts-resolver: 2.1.1
       get-tsconfig: 4.10.1
-      rolldown: 1.0.0-beta.30
+      rolldown: 1.0.0-beta.31
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
       - oxc-resolver
       - supports-color
 
-  rolldown@1.0.0-beta.30:
+  rolldown@1.0.0-beta.31:
     dependencies:
-      '@oxc-project/runtime': 0.78.0
-      '@oxc-project/types': 0.78.0
-      '@rolldown/pluginutils': 1.0.0-beta.30
+      '@oxc-project/runtime': 0.80.0
+      '@oxc-project/types': 0.80.0
+      '@rolldown/pluginutils': 1.0.0-beta.31
       ansis: 4.1.0
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-beta.30
-      '@rolldown/binding-darwin-arm64': 1.0.0-beta.30
-      '@rolldown/binding-darwin-x64': 1.0.0-beta.30
-      '@rolldown/binding-freebsd-x64': 1.0.0-beta.30
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.30
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.30
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.30
-      '@rolldown/binding-linux-arm64-ohos': 1.0.0-beta.30
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.30
-      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.30
-      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.30
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.30
-      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.30
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.30
+      '@rolldown/binding-android-arm64': 1.0.0-beta.31
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.31
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.31
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.31
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.31
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.31
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.31
+      '@rolldown/binding-linux-arm64-ohos': 1.0.0-beta.31
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.31
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.31
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.31
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.31
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.31
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.31
 
   rollup@4.41.1:
     dependencies:
@@ -14527,8 +14527,8 @@ snapshots:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.0.0-beta.30
-      rolldown-plugin-dts: 0.15.1(rolldown@1.0.0-beta.30)(typescript@5.8.3)
+      rolldown: 1.0.0-beta.31
+      rolldown-plugin-dts: 0.15.1(rolldown@1.0.0-beta.31)(typescript@5.8.3)
       semver: 7.7.2
       tinyexec: 1.0.1
       tinyglobby: 0.2.14

--- a/website/example.meta.ts
+++ b/website/example.meta.ts
@@ -2701,10 +2701,6 @@ export const exampleMeta = {
           "hidden": false
         },
         {
-          "path": "get-id.ts",
-          "hidden": false
-        },
-        {
           "path": "language-selector.ts",
           "hidden": false
         }

--- a/website/example.meta.yaml
+++ b/website/example.meta.yaml
@@ -1405,8 +1405,6 @@ examples:
         hidden: false
       - path: create-element.ts
         hidden: false
-      - path: get-id.ts
-        hidden: false
       - path: language-selector.ts
         hidden: false
   - name: vanilla-dom

--- a/website/package.json
+++ b/website/package.json
@@ -40,7 +40,7 @@
     "astro": "^5.12.8",
     "astro-minify-html-swc": "^0.1.7",
     "astro-rehype-relative-markdown-links": "^0.18.1",
-    "astrobook": "^0.8.7",
+    "astrobook": "^0.8.8",
     "babel-plugin-react-compiler": "19.1.0-rc.2",
     "bits-ui": "^2.9.0",
     "diffable-html": "^6.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -40,7 +40,7 @@
     "astro": "^5.12.8",
     "astro-minify-html-swc": "^0.1.7",
     "astro-rehype-relative-markdown-links": "^0.18.1",
-    "astrobook": "^0.8.8",
+    "astrobook": "^0.8.9",
     "babel-plugin-react-compiler": "19.1.0-rc.2",
     "bits-ui": "^2.9.0",
     "diffable-html": "^6.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -29,7 +29,7 @@
     "@iconify-json/logos": "^1.2.5",
     "@iconify-json/lucide": "^1.2.59",
     "@iconify-json/tabler": "^1.2.20",
-    "@ocavue/utils": "^0.6.0",
+    "@ocavue/utils": "^0.7.1",
     "@playwright/test": "^1.54.2",
     "@prosekit/config-unocss": "workspace:*",
     "@prosekit/config-vitest": "workspace:*",

--- a/website/src/examples/lit/dom/get-id.ts
+++ b/website/src/examples/lit/dom/get-id.ts
@@ -1,3 +1,0 @@
-export function getId() {
-  return Math.random().toString(36).slice(2)
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions for `tsdown`, `@ocavue/utils`, and `astrobook` across multiple packages.
* **Documentation**
  * Added a deprecation notice to the `getId` function, recommending use from `@ocavue/utils`.
* **Refactor**
  * Simplified TypeScript declaration configuration in one package.
* **Bug Fixes**
  * Removed the `get-id.ts` example and its references from the website examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->