### PR TITLE
fix(vue): add missing DropIndicator component in block-handle example

### DIFF
--- a/website/src/examples/vue/block-handle/editor.vue
+++ b/website/src/examples/vue/block-handle/editor.vue
@@ -11,6 +11,7 @@ import {
 
 import BlockHandle from './block-handle.vue'
 import { DEFAULT_DRAG_AND_DROP_CONTENT } from './default-content-drag-and-drop'
+import DropIndicator from './drop-indicator.vue'
 import { defineExtension } from './extension'
 
 const editor = createEditor({
@@ -35,6 +36,7 @@ watchPostEffect((onCleanup) => {
           class="CSS_EDITOR_CONTENT"
         />
         <BlockHandle />
+        <DropIndicator />
       </div>
     </div>
   </ProseKit>


### PR DESCRIPTION
## Description
This PR fixes a missing component in the Vue block-handle example that prevents the blue drop indicator line from appearing when dragging blocks.

## 问题描述
此 PR 修复了 Vue block-handle 示例中缺失的组件，该问题导致拖拽块时蓝色放置指示线无法显示。

## Problem / 问题
- The Vue version of the block-handle example doesn't show the drop indicator when dragging blocks
- Vue 版本的 block-handle 示例在拖拽块时不显示放置指示线
- The React version works correctly
- React 版本工作正常
- This affects both the local examples and the demos on the official website
- 这影响了本地示例和官方网站上的演示

## Solution / 解决方案
Added the missing `DropIndicator` component to the Vue example, making it consistent with the React implementation.
添加了缺失的 `DropIndicator` 组件到 Vue 示例中，使其与 React 实现保持一致。

## Changes / 更改
- Import `DropIndicator` component in `website/src/examples/vue/block-handle/editor.vue`
- 在 `website/src/examples/vue/block-handle/editor.vue` 中导入 `DropIndicator` 组件
- Add `<DropIndicator />` component to the template
- 在模板中添加 `<DropIndicator />` 组件

## Testing / 测试
- Tested locally with the Vue block-handle example
- 在本地测试了 Vue block-handle 示例
- Verified that the blue drop indicator now appears when dragging blocks
- 确认拖拽块时蓝色放置指示线现在可以正常显示
- Confirmed behavior matches the React version
- 确认行为与 React 版本一致