### PR TITLE
fix(drag-indicator): prevent background capture on Safari

### DIFF
--- a/.changeset/kind-teachers-repair.md
+++ b/.changeset/kind-teachers-repair.md
@@ -1,4 +1,5 @@
 ---
+'prosekit': patch
 "@prosekit/web": patch
 ---
 

--- a/.changeset/kind-teachers-repair.md
+++ b/.changeset/kind-teachers-repair.md
@@ -1,0 +1,6 @@
+---
+"@prosekit/web": patch
+---
+
+
+Fix an issue where the drag preview includes unexpected background content on Safari.

--- a/packages/web/src/components/block-handle/block-handle-draggable/set-drag-preview.ts
+++ b/packages/web/src/components/block-handle/block-handle-draggable/set-drag-preview.ts
@@ -42,8 +42,17 @@ export function setDragPreview(event: DragEvent, element: HTMLElement): void {
     // context, so we don't need to do that here.
     // https://github.com/atlassian/pragmatic-drag-and-drop/blob/56276552/packages/core/src/public-utils/element/custom-native-drag-preview/set-custom-native-drag-preview.ts#L60
     position: 'fixed',
-    top: '0',
-    left: '0',
+
+    // The element is positioned off-screen to avoid capturing the content of
+    // the page on Safari when the dragging element has a transparent background
+    // on Safari. See https://github.com/prosekit/prosekit/issues/1153 for more
+    // details.
+    top: '-1000vh',
+    left: '-1000vw',
+
+    // The element should not be interactive.
+    pointerEvents: 'none',
+
     zIndex: maxZIndex,
 
     // Only reliable cross browser technique found to push a drag preview away


### PR DESCRIPTION
Close https://github.com/prosekit/prosekit/issues/1153 


https://github.com/user-attachments/assets/41e5ec79-aed1-4199-bb3f-fe72b30029d4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Fixed a Safari-specific issue where the drag preview could display unexpected background content during drag operations.
  - Made the drag preview non-interactive to prevent unintended interactions while dragging.
  - Ensured consistent drag preview appearance across browsers.

- Chores
  - Added a patch-level changeset entry for prosekit and @prosekit/web documenting the Safari drag preview fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->