### PR TITLE
fix(table): hide the drop indicator when dragging table handle

### DIFF
--- a/.changeset/fix-table-drop-indicator.md
+++ b/.changeset/fix-table-drop-indicator.md
@@ -1,0 +1,7 @@
+---
+"prosekit": patch
+"@prosekit/extensions": patch
+"@prosekit/web": patch
+---
+
+Hide the extra drop indicator when moving a table column or row by dragging the table handle.

--- a/packages/extensions/src/drop-indicator/drop-target.ts
+++ b/packages/extensions/src/drop-indicator/drop-target.ts
@@ -86,7 +86,6 @@ export function buildGetTarget(
       return
     }
 
-    // TODO: better performance method?
     const compare = (p1: DropTarget, p2: DropTarget): number => {
       const [pos1, line1] = p1
       const [pos2, line2] = p2
@@ -96,8 +95,11 @@ export function buildGetTarget(
       return (p1Distance - p2Distance) || (pos1 - pos2)
     }
 
-    const targets = getTargets()
+    let targets = getTargets()
     targets.sort(compare)
+
+    // Only consider the first few targets for performance reasons.
+    targets = targets.slice(0, 8)
 
     // Find the closest valid target.
     const target = targets.find(target => onDrag({ view, pos: target[0], event }) !== false)

--- a/packages/extensions/src/table/index.ts
+++ b/packages/extensions/src/table/index.ts
@@ -25,6 +25,7 @@ export {
   moveTableRow,
   type MoveTableRowOptions,
 } from './table-commands/move-table-row'
+export { defineTableDropIndicator } from './table-drop-indicator'
 export { defineTablePlugins } from './table-plugins'
 export {
   defineTableCellSpec,

--- a/packages/extensions/src/table/table-drop-indicator.ts
+++ b/packages/extensions/src/table/table-drop-indicator.ts
@@ -1,0 +1,24 @@
+import type { PlainExtension } from '@prosekit/core'
+
+import type { DragEventHandler } from '../drop-indicator'
+import { defineDropIndicator } from '../drop-indicator'
+
+/**
+ * Hides the drop indicator when dragging a table column or row by using the
+ * table handle.
+ *
+ * @internal
+ */
+export function defineTableDropIndicator(): PlainExtension {
+  return defineDropIndicator({
+    onDrag,
+  })
+}
+
+const onDrag: DragEventHandler = ({ event }): boolean => {
+  if (event.dataTransfer?.types.includes('application/x-prosekit-table-handle-drag')) {
+    return false
+  }
+
+  return true
+}

--- a/packages/extensions/src/table/table-drop-indicator.ts
+++ b/packages/extensions/src/table/table-drop-indicator.ts
@@ -15,9 +15,26 @@ export function defineTableDropIndicator(): PlainExtension {
   })
 }
 
+const matchMap = new WeakMap<DataTransfer, boolean>()
+
 const onDrag: DragEventHandler = ({ event }): boolean => {
+  const dataTransfer = event.dataTransfer
+  if (!dataTransfer) return true
+
+  let match: boolean
+
+  if (matchMap.has(dataTransfer)) {
+    match = matchMap.get(dataTransfer)!
+  } else {
+    // On Safari, accessing `dataTransfer.types` is more than 10x slower than in
+    // Chrome. This becomes a bottleneck when `onDrag` is called frequently, so
+    // we cache the result in a WeakMap.
+    const types = dataTransfer.types
+    match = types.includes('application/x-prosekit-table-handle-drag')
+    matchMap.set(dataTransfer, match)
+  }
+
   // Don't show the drop indicator when the drag event has
   // "application/x-prosekit-table-handle-drag" type.
-  const types = event.dataTransfer?.types ?? []
-  return !types.includes('application/x-prosekit-table-handle-drag')
+  return !match
 }

--- a/packages/extensions/src/table/table-drop-indicator.ts
+++ b/packages/extensions/src/table/table-drop-indicator.ts
@@ -16,9 +16,8 @@ export function defineTableDropIndicator(): PlainExtension {
 }
 
 const onDrag: DragEventHandler = ({ event }): boolean => {
-  if (event.dataTransfer?.types.includes('application/x-prosekit-table-handle-drag')) {
-    return false
-  }
-
-  return true
+  // Don't show the drop indicator when the drag event has
+  // "application/x-prosekit-table-handle-drag" type.
+  const types = event.dataTransfer?.types ?? []
+  return !types.includes('application/x-prosekit-table-handle-drag')
 }

--- a/packages/extensions/src/table/table.ts
+++ b/packages/extensions/src/table/table.ts
@@ -7,6 +7,7 @@ import {
   defineTableCommands,
   type TableCommandsExtension,
 } from './table-commands'
+import { defineTableDropIndicator } from './table-drop-indicator'
 import { defineTablePlugins } from './table-plugins'
 import {
   defineTableCellSpec,
@@ -43,5 +44,6 @@ export function defineTable(): TableExtension {
     defineTableHeaderCellSpec(),
     defineTablePlugins(),
     defineTableCommands(),
+    defineTableDropIndicator(),
   )
 }

--- a/packages/web/src/components/table-handle/table-handle-column-trigger/setup.ts
+++ b/packages/web/src/components/table-handle/table-handle-column-trigger/setup.ts
@@ -52,6 +52,7 @@ export function useTableHandleColumnTrigger(
       if (emptyImage) {
         dataTransfer.setDragImage(emptyImage, 0, 0)
       }
+      dataTransfer.setData('application/x-prosekit-table-handle-drag', '')
     }
     const prev = dndContext.peek()
     const index = context.peek()?.colIndex


### PR DESCRIPTION

https://github.com/user-attachments/assets/ca504fad-169f-44d6-8ee2-341d70144e20


https://github.com/user-attachments/assets/784f6bb7-651c-49a3-adf8-d4674a679105


Closes https://github.com/prosekit/prosekit/issues/1182 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Hidden redundant drop indicator when dragging table rows or columns using table handles, reducing visual clutter and confusion.
  - Improved drag-and-drop responsiveness in tables by limiting unnecessary drop-target calculations.
- Chores
  - Bumped patch versions of related packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->