### PR TITLE
fix(drag-indicator): set table drag preview size correctly

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -64,6 +64,7 @@
     "@prosekit/config-tsdown": "workspace:*",
     "@prosekit/config-vitest": "workspace:*",
     "tsdown": "^0.13.4",
+    "type-fest": "^4.41.0",
     "typescript": "~5.9.2",
     "vitest": "^3.2.4"
   },

--- a/packages/web/src/components/block-handle/block-handle-draggable/set-drag-preview.ts
+++ b/packages/web/src/components/block-handle/block-handle-draggable/set-drag-preview.ts
@@ -66,13 +66,15 @@ export function setDragPreview(event: DragEvent, element: HTMLElement): void {
     height: `${height + borderY}px`,
   })
 
-  const [clonedElement, styleText] = deepCloneElement(element)
+  const [clonedElement, styleText] = deepCloneElement(element, true)
 
-  // A hardcoded opacity.
-  clonedElement.style.setProperty('opacity', '0.5', 'important')
-  // The bounding client rect doesn't include the margin, so we need to remove
-  // the margin too from the cloned element so that it can fit the container.
-  clonedElement.style.setProperty('margin', '0', 'important')
+  assignStyles(clonedElement, {
+    // A hardcoded opacity.
+    opacity: '0.5',
+    // The bounding client rect doesn't include the margin, so we need to remove
+    // the margin too from the cloned element so that it can fit the container.
+    margin: '0',
+  }, true)
 
   document.body.appendChild(container)
   container.appendChild(clonedElement)

--- a/packages/web/src/utils/assign-styles.ts
+++ b/packages/web/src/utils/assign-styles.ts
@@ -1,6 +1,23 @@
+import type { ConditionalPick } from 'type-fest'
+
+// Only include CSS properties whose value type is `string`
+type StringStyleDeclaration = Partial<ConditionalPick<CSSStyleDeclaration, string>>
+
 /**
  * A type-safe version of `Object.assign` for `element.style`.
  */
-export function assignStyles(element: HTMLElement | SVGElement | MathMLElement, styles: Partial<CSSStyleDeclaration>): void {
-  Object.assign(element.style, styles)
+export function assignStyles(
+  element: HTMLElement | SVGElement | MathMLElement,
+  styles: StringStyleDeclaration,
+  important = false,
+): void {
+  if (important) {
+    for (const [key, value] of Object.entries(styles)) {
+      if (value != null) {
+        element.style.setProperty(key, value, 'important')
+      }
+    }
+  } else {
+    Object.assign(element.style, styles)
+  }
 }

--- a/packages/web/src/utils/clone-element.ts
+++ b/packages/web/src/utils/clone-element.ts
@@ -4,9 +4,9 @@ import { getId } from '@ocavue/utils'
  * Creates a deep clone of an Element, including all computed styles so that
  * it looks almost exactly the same as the original element.
  */
-export function deepCloneElement<T extends Element>(element: T): [T, string] {
+export function deepCloneElement<T extends Element>(element: T, important = false): [T, string] {
   const clonedElement = element.cloneNode(true) as T
-  const style = deepCopyStyles(element, clonedElement)
+  const style = deepCopyStyles(element, clonedElement, important)
   return [clonedElement, style]
 }
 
@@ -14,13 +14,13 @@ export function deepCloneElement<T extends Element>(element: T): [T, string] {
  * Creates a clone of an Element, including all computed styles so that
  * it looks similar enough to the original element.
  */
-export function cloneElement<T extends Element>(element: T): [T, string] {
+export function cloneElement<T extends Element>(element: T, important = false): [T, string] {
   const clonedElement = element.cloneNode() as T
-  const style = copyStyles(element, clonedElement)
+  const style = copyStyles(element, clonedElement, important)
   return [clonedElement, style]
 }
 
-function deepCopyStyles(source: Element, target: Element): string {
+function deepCopyStyles(source: Element, target: Element, important: boolean): string {
   const sources = [source]
   const targets = [target]
   const styles: string[] = []
@@ -33,7 +33,7 @@ function deepCopyStyles(source: Element, target: Element): string {
       break
     }
 
-    const style = copyStyles(source, target)
+    const style = copyStyles(source, target, important)
     if (style) {
       styles.push(style)
     }
@@ -45,7 +45,7 @@ function deepCopyStyles(source: Element, target: Element): string {
   return styles.join('\n')
 }
 
-function copyStyles(source: Element, target: Element): string {
+function copyStyles(source: Element, target: Element, important: boolean): string {
   if (!source || !target) {
     return ''
   }
@@ -70,7 +70,7 @@ function copyStyles(source: Element, target: Element): string {
       // Enforce important to avoid the style being overridden when the element
       // is connected to the page.
       // See https://github.com/prosekit/prosekit/issues/1185 for more details.
-      'important',
+      important ? 'important' : (sourceStyle.getPropertyPriority(key) || ''),
     )
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -833,6 +833,9 @@ importers:
       tsdown:
         specifier: ^0.13.4
         version: 0.13.4(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))
+      type-fest:
+        specifier: ^4.41.0
+        version: 4.41.0
       typescript:
         specifier: ~5.9.2
         version: 5.9.2


### PR DESCRIPTION
Before and after:


https://github.com/user-attachments/assets/c7d9972b-1423-4746-9171-4139e476f22f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More reliable styling during interactions by enforcing important styles when needed, improving visual consistency.
- Bug Fixes
  - Drag preview now displays more consistently with clearer opacity and spacing, reducing flicker during drag operations.
- Refactor
  - Consolidated style application to ensure consistent behavior across components.
- Chores
  - Added a development dependency to improve type safety for styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->