### PR TITLE
fix(website): restore Markdown link underline decoration

### DIFF
--- a/website/src/styles/starlight.css
+++ b/website/src/styles/starlight.css
@@ -50,8 +50,6 @@
   */
   a {
     color: inherit;
-    -webkit-text-decoration: inherit;
-    text-decoration: inherit;
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated link styling to rely on default browser text-decoration rather than inheriting from parent elements.
  * Links may now display underlines (or other default styles) more consistently across pages and browsers.
  * Improves link visibility and readability while preserving inherited color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->