### PR TITLE
feat(preact): add node/mark view support

### DIFF
--- a/.changeset/preact-node-mark-views.md
+++ b/.changeset/preact-node-mark-views.md
@@ -1,0 +1,10 @@
+---
+"prosekit": patch
+"@prosekit/preact": minor
+---
+
+Add complete Preact support with node/mark views and useEditorDerivedValue hook. Preact now has feature parity with React, including:
+
+- `definePreactNodeView` for custom node views
+- `definePreactMarkView` for custom mark views
+- `useEditorDerivedValue` hook for reactive state derivation

--- a/packages/dev/src/gen-example-symlinks.ts
+++ b/packages/dev/src/gen-example-symlinks.ts
@@ -35,6 +35,7 @@ const mapping: Record<string, string[]> = {
   ],
   'shared/common/sample-doc-image.ts': [
     /// keep-sorted
+    'examples/preact/image-view/',
     'examples/react/image-view/',
     'examples/solid/image-view/',
     'examples/svelte/image-view/',
@@ -42,6 +43,7 @@ const mapping: Record<string, string[]> = {
   ],
   'shared/common/sample-uploader.ts': [
     /// keep-sorted
+    'examples/preact/image-view/',
     'examples/react/full/',
     'examples/react/image-view/',
     'examples/react/toolbar/',
@@ -97,6 +99,10 @@ const mapping: Record<string, string[]> = {
   'shared/preact/drop-indicator.tsx': [
     /// keep-sorted
     'examples/preact/block-handle/',
+  ],
+  'shared/preact/image-view.tsx': [
+    /// keep-sorted
+    'examples/preact/image-view/',
   ],
   'shared/preact/slash-menu-empty.tsx': [
     /// keep-sorted

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -47,7 +47,9 @@
   "dependencies": {
     "@prosekit/core": "workspace:^",
     "@prosekit/pm": "workspace:^",
-    "@prosekit/web": "workspace:^"
+    "@prosekit/web": "workspace:^",
+    "@prosemirror-adapter/core": "^0.4.5",
+    "@prosemirror-adapter/preact": "^0.4.5"
   },
   "peerDependencies": {
     "preact": ">= 10.11.0"

--- a/packages/preact/src/components/prosekit.ts
+++ b/packages/preact/src/components/prosekit.ts
@@ -1,4 +1,5 @@
 import type { Editor } from '@prosekit/core'
+import { ProsemirrorAdapterProvider } from '@prosemirror-adapter/preact'
 import {
   h,
   type ComponentChildren,
@@ -6,6 +7,8 @@ import {
 } from 'preact'
 
 import { EditorContextProvider } from '../contexts/editor-context'
+import { PreactMarkViewConsumer } from '../extensions/preact-mark-view'
+import { PreactNodeViewConsumer } from '../extensions/preact-node-view'
 
 export interface ProseKitProps {
   editor: Editor
@@ -20,5 +23,15 @@ export interface ProseKitProps {
 export const ProseKit: ComponentType<ProseKitProps> = (props) => {
   const { editor, children } = props
 
-  return h(EditorContextProvider, { value: editor, children })
+  return h(
+    ProsemirrorAdapterProvider,
+    null,
+    h(
+      EditorContextProvider,
+      { value: editor },
+      h(PreactNodeViewConsumer, null),
+      h(PreactMarkViewConsumer, null),
+      children,
+    ),
+  )
 }

--- a/packages/preact/src/extensions/preact-mark-view.ts
+++ b/packages/preact/src/extensions/preact-mark-view.ts
@@ -1,0 +1,93 @@
+import {
+  defineMarkViewComponent,
+  defineMarkViewFactory,
+  type Extension,
+} from '@prosekit/core'
+import type { MarkViewConstructor } from '@prosekit/pm/view'
+import type { CoreMarkViewUserOptions } from '@prosemirror-adapter/core'
+import {
+  useMarkViewContext,
+  useMarkViewFactory,
+  type MarkViewContext,
+  type PreactMarkViewUserOptions,
+} from '@prosemirror-adapter/preact'
+import {
+  h,
+  type ComponentType,
+  type FunctionComponent,
+} from 'preact'
+import { useMemo } from 'preact/hooks'
+
+import { useExtension } from '../hooks/use-extension'
+
+/**
+ * @public
+ */
+export interface PreactMarkViewProps extends MarkViewContext {}
+
+/**
+ * @public
+ */
+export type PreactMarkViewComponent = ComponentType<PreactMarkViewProps>
+
+/**
+ * Options for {@link definePreactMarkView}.
+ *
+ * @public
+ */
+export interface PreactMarkViewOptions extends CoreMarkViewUserOptions<PreactMarkViewComponent> {
+  /**
+   * The name of the mark type.
+   */
+  name: string
+}
+
+function withMarkViewProps(component: PreactMarkViewComponent) {
+  return function MarkViewPropsWrapper() {
+    const props: PreactMarkViewProps = useMarkViewContext()
+    return h(component, props)
+  }
+}
+
+/**
+ * @internal
+ */
+export const PreactMarkViewConsumer: FunctionComponent = () => {
+  const markViewFactory = useMarkViewFactory()
+  const extension = useMemo(
+    () => definePreactMarkViewFactory(markViewFactory),
+    [markViewFactory],
+  )
+  useExtension(extension)
+
+  return null
+}
+
+/**
+ * Defines a mark view using a Preact component.
+ *
+ * @public
+ */
+export function definePreactMarkView(options: PreactMarkViewOptions): Extension {
+  const { name, component, ...userOptions } = options
+
+  const args: PreactMarkViewUserOptions = {
+    ...userOptions,
+    component: withMarkViewProps(component),
+  }
+
+  return defineMarkViewComponent<PreactMarkViewUserOptions>({
+    group: 'preact',
+    name,
+    args,
+  })
+}
+
+function definePreactMarkViewFactory(
+  factory: (options: PreactMarkViewUserOptions) => MarkViewConstructor,
+) {
+  return defineMarkViewFactory<PreactMarkViewUserOptions>({
+    group: 'preact',
+    factory,
+  })
+}

--- a/packages/preact/src/extensions/preact-node-view.ts
+++ b/packages/preact/src/extensions/preact-node-view.ts
@@ -1,0 +1,93 @@
+import {
+  defineNodeViewComponent,
+  defineNodeViewFactory,
+  type Extension,
+} from '@prosekit/core'
+import type { NodeViewConstructor } from '@prosekit/pm/view'
+import type { CoreNodeViewUserOptions } from '@prosemirror-adapter/core'
+import {
+  useNodeViewContext,
+  useNodeViewFactory,
+  type NodeViewContext,
+  type PreactNodeViewUserOptions,
+} from '@prosemirror-adapter/preact'
+import {
+  h,
+  type ComponentType,
+  type FunctionComponent,
+} from 'preact'
+import { useMemo } from 'preact/hooks'
+
+import { useExtension } from '../hooks/use-extension'
+
+/**
+ * @public
+ */
+export interface PreactNodeViewProps extends NodeViewContext {}
+
+/**
+ * @public
+ */
+export type PreactNodeViewComponent = ComponentType<PreactNodeViewProps>
+
+/**
+ * Options for {@link definePreactNodeView}.
+ *
+ * @public
+ */
+export interface PreactNodeViewOptions extends CoreNodeViewUserOptions<PreactNodeViewComponent> {
+  /**
+   * The name of the node type.
+   */
+  name: string
+}
+
+function withNodeViewProps(component: PreactNodeViewComponent) {
+  return function NodeViewPropsWrapper() {
+    const props: PreactNodeViewProps = useNodeViewContext()
+    return h(component, props)
+  }
+}
+
+/**
+ * @internal
+ */
+export const PreactNodeViewConsumer: FunctionComponent = () => {
+  const nodeViewFactory = useNodeViewFactory()
+  const extension = useMemo(
+    () => definePreactNodeViewFactory(nodeViewFactory),
+    [nodeViewFactory],
+  )
+  useExtension(extension)
+
+  return null
+}
+
+/**
+ * Defines a node view using a Preact component.
+ *
+ * @public
+ */
+export function definePreactNodeView(options: PreactNodeViewOptions): Extension {
+  const { name, component, ...userOptions } = options
+
+  const args: PreactNodeViewUserOptions = {
+    ...userOptions,
+    component: withNodeViewProps(component),
+  }
+
+  return defineNodeViewComponent<PreactNodeViewUserOptions>({
+    group: 'preact',
+    name,
+    args,
+  })
+}
+
+function definePreactNodeViewFactory(
+  factory: (options: PreactNodeViewUserOptions) => NodeViewConstructor,
+) {
+  return defineNodeViewFactory<PreactNodeViewUserOptions>({
+    group: 'preact',
+    factory,
+  })
+}

--- a/packages/preact/src/hooks/use-editor-derived-value.ts
+++ b/packages/preact/src/hooks/use-editor-derived-value.ts
@@ -1,0 +1,81 @@
+import {
+  defineMountHandler,
+  defineUpdateHandler,
+  EditorNotFoundError,
+  union,
+  type Editor,
+  type Extension,
+} from '@prosekit/core'
+import { useSyncExternalStore } from 'preact/compat'
+import { useMemo } from 'preact/hooks'
+
+import { useEditorContext } from '../contexts/editor-context'
+
+export interface UseEditorDerivedOptions<E extends Extension = any> {
+  /**
+   * The editor to add the extension to. If not provided, it will use the
+   * editor from the nearest `ProseKit` component.
+   */
+  editor?: Editor<E>
+}
+
+/**
+ * A hook that runs a function to derive a value from the editor instance after
+ * editor state changes.
+ *
+ * This is useful when you need to render something based on the editor state,
+ * for example, whether the selected text is wrapped in an italic mark.
+ *
+ * @public
+ */
+export function useEditorDerivedValue<E extends Extension, Derived>(
+  /**
+   * A function that receives the editor instance and returns a derived value.
+   *
+   * It will be called whenever the editor's document state changes, or when it
+   * mounts.
+   *
+   * This function should be memoized.
+   */
+  derive: (editor: Editor<E>) => Derived,
+  options?: UseEditorDerivedOptions<E>,
+): Derived {
+  const editorContext = useEditorContext<E>()
+  const editor = options?.editor ?? editorContext
+  if (!editor) {
+    throw new EditorNotFoundError()
+  }
+
+  const [subscribe, getSnapshot] = useMemo(() => {
+    return createEditorStore(editor, derive)
+  }, [editor, derive])
+
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+function createEditorStore<Derived, E extends Extension = any>(editor: Editor<E>, derive: (editor: Editor<E>) => Derived) {
+  let dirty = true
+  let derived: Derived
+
+  const subscribe = (onChange: VoidFunction): VoidFunction => {
+    const handleChange = () => {
+      dirty = true
+      onChange()
+    }
+    const extension = union(
+      defineUpdateHandler(handleChange),
+      defineMountHandler(handleChange),
+    )
+    return editor.use(extension)
+  }
+
+  const getSnapshot = () => {
+    if (dirty) {
+      dirty = false
+      derived = derive(editor)
+    }
+    return derived
+  }
+
+  return [subscribe, getSnapshot] as const
+}

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -2,8 +2,24 @@ export {
   ProseKit,
   type ProseKitProps,
 } from './components/prosekit'
+export {
+  definePreactMarkView,
+  type PreactMarkViewComponent,
+  type PreactMarkViewOptions,
+  type PreactMarkViewProps,
+} from './extensions/preact-mark-view'
+export {
+  definePreactNodeView,
+  type PreactNodeViewComponent,
+  type PreactNodeViewOptions,
+  type PreactNodeViewProps,
+} from './extensions/preact-node-view'
 export { useDocChange } from './hooks/use-doc-change'
 export { useEditor } from './hooks/use-editor'
+export {
+  useEditorDerivedValue,
+  type UseEditorDerivedOptions,
+} from './hooks/use-editor-derived-value'
 export {
   useExtension,
   type UseExtensionOptions,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,12 @@ importers:
       '@prosekit/web':
         specifier: workspace:^
         version: link:../web
+      '@prosemirror-adapter/core':
+        specifier: ^0.4.5
+        version: 0.4.5
+      '@prosemirror-adapter/preact':
+        specifier: ^0.4.5
+        version: 0.4.5(preact@10.27.2)
     devDependencies:
       '@prosekit/config-tsdown':
         specifier: workspace:*
@@ -2059,6 +2065,9 @@ packages:
   '@napi-rs/wasm-runtime@1.0.5':
     resolution: {integrity: sha512-TBr9Cf9onSAS2LQ2+QHx6XcC6h9+RIzJgbqG3++9TUZSH204AwEy5jg3BTQ0VATsyoGj4ee49tN/y6rvaOOtcg==}
 
+  '@napi-rs/wasm-runtime@1.0.6':
+    resolution: {integrity: sha512-DXj75ewm11LIWUk198QSKUTxjyRjsBwk09MuMk5DGK+GDUtyPhhEHOGP/Xwwj3DjQXXkivoBirmOnKrLfc0+9g==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2142,8 +2151,8 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
-  '@oxc-project/types@0.93.0':
-    resolution: {integrity: sha512-yNtwmWZIBtJsMr5TEfoZFDxIWV6OdScOpza/f5YxbqUMJk+j6QX3Cf3jgZShGEFYWQJ5j9mJ6jM0tZHu2J9Yrg==}
+  '@oxc-project/types@0.94.0':
+    resolution: {integrity: sha512-+UgQT/4o59cZfH6Cp7G0hwmqEQ0wE+AdIwhikdwnhWI9Dp8CgSY081+Q3O67/wq3VJu8mgUEB93J9EHHn70fOw==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.8.3':
     resolution: {integrity: sha512-er6onTUX8NMF5kBNGHCF8S6vxWVJS5BKO6SmLRW5nfZgHDHWsESH1YgyKpO6n6HBd/x58+7r9/1fxF3N8z911A==}
@@ -2335,6 +2344,14 @@ packages:
   '@prosemirror-adapter/core@0.4.5':
     resolution: {integrity: sha512-22uU2dWD2VDw2fVM1vzFlhFpp8Cow3LiWh2kltUFwzkCTHTvkn9AsuI7YF5QvYyzMXzwFIixfG11WZRDj3oZgw==}
 
+  '@prosemirror-adapter/preact@0.4.5':
+    resolution: {integrity: sha512-O5YZFrpJjIJ3ckmT1pxuUt1wyE4h9MR6ouV2B8YVZh74hsQSuDG+CQt3ILZUtHxbKyWvcKw5hoHe3dlPWtNqfw==}
+    peerDependencies:
+      preact: ^10.0.0
+    peerDependenciesMeta:
+      preact:
+        optional: true
+
   '@prosemirror-adapter/react@0.4.5':
     resolution: {integrity: sha512-z+A6IRJwn17F0VUiPDDD/DkJuwVxo51uxsFfE4aubEcTcvbFvlqqcn4g4P7nGSvPjqLojqZHP4BBOd6ArMrXAg==}
     peerDependencies:
@@ -2373,85 +2390,85 @@ packages:
   '@quansync/fs@0.1.5':
     resolution: {integrity: sha512-lNS9hL2aS2NZgNW7BBj+6EBl4rOf8l+tQ0eRY6JWCI8jI2kc53gSoqbjojU0OnAWhzoXiOjFyGsHcDGePB3lhA==}
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.41':
-    resolution: {integrity: sha512-Edflndd9lU7JVhVIvJlZhdCj5DkhYDJPIRn4Dx0RUdfc8asP9xHOI5gMd8MesDDx+BJpdIT/uAmVTearteU/mQ==}
+  '@rolldown/binding-android-arm64@1.0.0-beta.42':
+    resolution: {integrity: sha512-W5ZKF3TP3bOWuBfotAGp+UGjxOkGV7jRmIRbBA7NFjggx7Oi6vOmGDqpHEIX7kDCiry1cnIsWQaxNvWbMdkvzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.41':
-    resolution: {integrity: sha512-XGCzqfjdk7550PlyZRTBKbypXrB7ATtXhw/+bjtxnklLQs0mKP/XkQVOKyn9qGKSlvH8I56JLYryVxl0PCvSNw==}
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.42':
+    resolution: {integrity: sha512-abw/wtgJA8OCgaTlL+xJxnN/Z01BwV1rfzIp5Hh9x+IIO6xOBfPsQ0nzi0+rWx3TyZ9FZXyC7bbC+5NpQ9EaXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.41':
-    resolution: {integrity: sha512-Ho6lIwGJed98zub7n0xcRKuEtnZgbxevAmO4x3zn3C3N4GVXZD5xvCvTVxSMoeBJwTcIYzkVDRTIhylQNsTgLQ==}
+  '@rolldown/binding-darwin-x64@1.0.0-beta.42':
+    resolution: {integrity: sha512-Y/UrZIRVr8CvXVEB88t6PeC46r1K9/QdPEo2ASE/b/KBEyXIx+QbM6kv9QfQVWU2Atly2+SVsQzxQsIvuk3lZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.41':
-    resolution: {integrity: sha512-ijAZETywvL+gACjbT4zBnCp5ez1JhTRs6OxRN4J+D6AzDRbU2zb01Esl51RP5/8ZOlvB37xxsRQ3X4YRVyYb3g==}
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.42':
+    resolution: {integrity: sha512-zRM0oOk7BZiy6DoWBvdV4hyEg+j6+WcBZIMHVirMEZRu8hd18kZdJkg+bjVMfCEhwpWeFUfBfZ1qcaZ5UdYzlQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.41':
-    resolution: {integrity: sha512-EgIOZt7UildXKFEFvaiLNBXm+4ggQyGe3E5Z1QP9uRcJJs9omihOnm897FwOBQdCuMvI49iBgjFrkhH+wMJ2MA==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.42':
+    resolution: {integrity: sha512-6RjFaC52QNwo7ilU8C5H7swbGlgfTkG9pudXwzr3VYyT18s0C9gLg3mvc7OMPIGqNxnQ0M5lU8j6aQCk2DTRVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.41':
-    resolution: {integrity: sha512-F8bUwJq8v/JAU8HSwgF4dztoqJ+FjdyjuvX4//3+Fbe2we9UktFeZ27U4lRMXF1vxWtdV4ey6oCSqI7yUrSEeg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.42':
+    resolution: {integrity: sha512-LMYHM5Sf6ROq+VUwHMDVX2IAuEsWTv4SnlFEedBnMGpvRuQ14lCmD4m5Q8sjyAQCgyha9oghdGoK8AEg1sXZKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.41':
-    resolution: {integrity: sha512-MioXcCIX/wB1pBnBoJx8q4OGucUAfC1+/X1ilKFsjDK05VwbLZGRgOVD5OJJpUQPK86DhQciNBrfOKDiatxNmg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.42':
+    resolution: {integrity: sha512-/bNTYb9aKNhzdbPn3O4MK2aLv55AlrkUKPE4KNfBYjkoZUfDr4jWp7gsSlvTc5A/99V1RCm9axvt616ZzeXGyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.41':
-    resolution: {integrity: sha512-m66M61fizvRCwt5pOEiZQMiwBL9/y0bwU/+Kc4Ce/Pef6YfoEkR28y+DzN9rMdjo8Z28NXjsDPq9nH4mXnAP0g==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.42':
+    resolution: {integrity: sha512-n/SLa4h342oyeGykZdch7Y3GNCNliRPL4k5wkeZ/5eQZs+c6/ZG1SHCJQoy7bZcmxiMyaXs9HoFmv1PEKrZgWg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.41':
-    resolution: {integrity: sha512-yRxlSfBvWnnfrdtJfvi9lg8xfG5mPuyoSHm0X01oiE8ArmLRvoJGHUTJydCYz+wbK2esbq5J4B4Tq9WAsOlP1Q==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.42':
+    resolution: {integrity: sha512-4PSd46sFzqpLHSGdaSViAb1mk55sCUMpJg+X8ittXaVocQsV3QLG/uydSH8RyL0ngHX5fy3D70LcCzlB15AgHw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-beta.41':
-    resolution: {integrity: sha512-PHVxYhBpi8UViS3/hcvQQb9RFqCtvFmFU1PvUoTRiUdBtgHA6fONNHU4x796lgzNlVSD3DO/MZNk1s5/ozSMQg==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.42':
+    resolution: {integrity: sha512-BmWoeJJyeZXmZBcfoxG6J9+rl2G7eO47qdTkAzEegj4n3aC6CBIHOuDcbE8BvhZaEjQR0nh0nJrtEDlt65Q7Sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.41':
-    resolution: {integrity: sha512-OAfcO37ME6GGWmj9qTaDT7jY4rM0T2z0/8ujdQIJQ2x2nl+ztO32EIwURfmXOK0U1tzkyuaKYvE34Pug/ucXlQ==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.42':
+    resolution: {integrity: sha512-2Ft32F7uiDTrGZUKws6CLNTlvTWHC33l4vpXrzUucf9rYtUThAdPCOt89Pmn13tNX6AulxjGEP2R0nZjTSW3eQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.41':
-    resolution: {integrity: sha512-NIYGuCcuXaq5BC4Q3upbiMBvmZsTsEPG9k/8QKQdmrch+ocSy5Jv9tdpdmXJyighKqm182nh/zBt+tSJkYoNlg==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.42':
+    resolution: {integrity: sha512-hC1kShXW/z221eG+WzQMN06KepvPbMBknF0iGR3VMYJLOe9gwnSTfGxFT5hf8XrPv7CEZqTWRd0GQpkSHRbGsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.41':
-    resolution: {integrity: sha512-kANdsDbE5FkEOb5NrCGBJBCaZ2Sabp3D7d4PRqMYJqyLljwh9mDyYyYSv5+QNvdAmifj+f3lviNEUUuUZPEFPw==}
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.42':
+    resolution: {integrity: sha512-AICBYromawouGjj+GS33369E8Vwhy6UwhQEhQ5evfS8jPCsyVvoICJatbDGDGH01dwtVGLD5eDFzPicUOVpe4g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.41':
-    resolution: {integrity: sha512-UlpxKmFdik0Y2VjZrgUCgoYArZJiZllXgIipdBRV1hw6uK45UbQabSTW6Kp6enuOu7vouYWftwhuxfpE8J2JAg==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.42':
+    resolution: {integrity: sha512-XpZ0M+tjoEiSc9c+uZR7FCnOI0uxDRNs1elGOMjeB0pUP1QmvVbZGYNsyLbLoP4u7e3VQN8rie1OQ8/mB6rcJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2464,6 +2481,9 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-beta.41':
     resolution: {integrity: sha512-ycMEPrS3StOIeb87BT3/+bu+blEtyvwQ4zmo2IcJQy0Rd1DAAhKksA0iUZ3MYSpJtjlPhg0Eo6mvVS6ggPhRbw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.42':
+    resolution: {integrity: sha512-N7pQzk9CyE7q0bBN/q0J8s6Db279r5kUZc6d7/wWRe9/zXqC52HQovVyu6iXPIDY4BEzzgbVLhVFXrOuGJ22ZQ==}
 
   '@rollup/pluginutils@4.2.1':
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
@@ -6275,8 +6295,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.0-beta.41:
-    resolution: {integrity: sha512-U+NPR0Bkg3wm61dteD2L4nAM1U9dtaqVrpDXwC36IKRHpEO/Ubpid4Nijpa2imPchcVNHfxVFwSSMJdwdGFUbg==}
+  rolldown@1.0.0-beta.42:
+    resolution: {integrity: sha512-xaPcckj+BbJhYLsv8gOqezc8EdMcKKe/gk8v47B0KPvgABDrQ0qmNPAiT/gh9n9Foe0bUkEv2qzj42uU5q1WRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -9032,6 +9052,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.0.6':
+    dependencies:
+      '@emnapi/core': 1.5.0
+      '@emnapi/runtime': 1.5.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -9156,7 +9183,7 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
-  '@oxc-project/types@0.93.0': {}
+  '@oxc-project/types@0.94.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.8.3':
     optional: true
@@ -9309,6 +9336,16 @@ snapshots:
       prosemirror-state: 1.4.3
       prosemirror-view: 1.41.2
 
+  '@prosemirror-adapter/preact@0.4.5(preact@10.27.2)':
+    dependencies:
+      '@prosemirror-adapter/core': 0.4.5
+      nanoid: 5.1.6
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.2
+    optionalDependencies:
+      preact: 10.27.2
+
   '@prosemirror-adapter/react@0.4.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@prosemirror-adapter/core': 0.4.5
@@ -9355,48 +9392,48 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.41':
+  '@rolldown/binding-android-arm64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.41':
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.41':
+  '@rolldown/binding-darwin-x64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.41':
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.41':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.41':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.41':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.41':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.41':
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-beta.41':
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.41':
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.42':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.5
+      '@napi-rs/wasm-runtime': 1.0.6
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.41':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.41':
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.41':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.42':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
@@ -9404,6 +9441,8 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-beta.29': {}
 
   '@rolldown/pluginutils@1.0.0-beta.41': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.42': {}
 
   '@rollup/pluginutils@4.2.1':
     dependencies:
@@ -14130,7 +14169,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.16.8(oxc-resolver@11.8.3)(rolldown@1.0.0-beta.41)(typescript@5.9.2)(vue-tsc@3.0.8(typescript@5.9.2)):
+  rolldown-plugin-dts@0.16.8(oxc-resolver@11.8.3)(rolldown@1.0.0-beta.42)(typescript@5.9.2)(vue-tsc@3.0.8(typescript@5.9.2)):
     dependencies:
       '@babel/generator': 7.28.3
       '@babel/parser': 7.28.4
@@ -14141,7 +14180,7 @@ snapshots:
       dts-resolver: 2.1.2(oxc-resolver@11.8.3)
       get-tsconfig: 4.10.1
       magic-string: 0.30.19
-      rolldown: 1.0.0-beta.41
+      rolldown: 1.0.0-beta.42
     optionalDependencies:
       typescript: 5.9.2
       vue-tsc: 3.0.8(typescript@5.9.2)
@@ -14149,26 +14188,26 @@ snapshots:
       - oxc-resolver
       - supports-color
 
-  rolldown@1.0.0-beta.41:
+  rolldown@1.0.0-beta.42:
     dependencies:
-      '@oxc-project/types': 0.93.0
-      '@rolldown/pluginutils': 1.0.0-beta.41
+      '@oxc-project/types': 0.94.0
+      '@rolldown/pluginutils': 1.0.0-beta.42
       ansis: 4.2.0
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-beta.41
-      '@rolldown/binding-darwin-arm64': 1.0.0-beta.41
-      '@rolldown/binding-darwin-x64': 1.0.0-beta.41
-      '@rolldown/binding-freebsd-x64': 1.0.0-beta.41
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.41
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.41
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.41
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.41
-      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.41
-      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.41
-      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.41
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.41
-      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.41
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.41
+      '@rolldown/binding-android-arm64': 1.0.0-beta.42
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.42
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.42
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.42
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.42
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.42
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.42
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.42
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.42
+      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.42
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.42
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.42
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.42
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.42
 
   rollup@4.50.2:
     dependencies:
@@ -14772,8 +14811,8 @@ snapshots:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.0.0-beta.41
-      rolldown-plugin-dts: 0.16.8(oxc-resolver@11.8.3)(rolldown@1.0.0-beta.41)(typescript@5.9.2)(vue-tsc@3.0.8(typescript@5.9.2))
+      rolldown: 1.0.0-beta.42
+      rolldown-plugin-dts: 0.16.8(oxc-resolver@11.8.3)(rolldown@1.0.0-beta.42)(typescript@5.9.2)(vue-tsc@3.0.8(typescript@5.9.2))
       semver: 7.7.2
       tinyexec: 1.0.1
       tinyglobby: 0.2.15

--- a/website/example.meta.json
+++ b/website/example.meta.json
@@ -1714,6 +1714,33 @@
       ]
     },
     {
+      "name": "preact-image-view",
+      "framework": "preact",
+      "story": "image-view",
+      "files": [
+        {
+          "path": "editor.tsx",
+          "hidden": false
+        },
+        {
+          "path": "extension.ts",
+          "hidden": false
+        },
+        {
+          "path": "image-view.tsx",
+          "hidden": false
+        },
+        {
+          "path": "sample-doc-image.ts",
+          "hidden": false
+        },
+        {
+          "path": "sample-uploader.ts",
+          "hidden": false
+        }
+      ]
+    },
+    {
       "name": "preact-keymap",
       "framework": "preact",
       "story": "keymap",
@@ -1736,6 +1763,25 @@
         },
         {
           "path": "button.tsx",
+          "hidden": false
+        }
+      ]
+    },
+    {
+      "name": "preact-link-mark-view",
+      "framework": "preact",
+      "story": "link-mark-view",
+      "files": [
+        {
+          "path": "editor.tsx",
+          "hidden": false
+        },
+        {
+          "path": "extension.ts",
+          "hidden": false
+        },
+        {
+          "path": "link-view.tsx",
           "hidden": false
         }
       ]

--- a/website/src/examples/preact/image-view/editor.tsx
+++ b/website/src/examples/preact/image-view/editor.tsx
@@ -1,0 +1,26 @@
+import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
+
+import { useMemo } from 'preact/hooks'
+import { createEditor } from 'prosekit/core'
+import { ProseKit } from 'prosekit/preact'
+
+import { defineExtension } from './extension'
+import { defaultContent } from './sample-doc-image'
+
+export default function Editor() {
+  const editor = useMemo(() => {
+    const extension = defineExtension()
+    return createEditor({ extension, defaultContent })
+  }, [])
+
+  return (
+    <ProseKit editor={editor}>
+      <div className="CSS_EDITOR_VIEWPORT">
+        <div className="CSS_EDITOR_SCROLLING">
+          <div ref={editor.mount} className="CSS_EDITOR_CONTENT"></div>
+        </div>
+      </div>
+    </ProseKit>
+  )
+}

--- a/website/src/examples/preact/image-view/extension.ts
+++ b/website/src/examples/preact/image-view/extension.ts
@@ -1,0 +1,27 @@
+import { defineBasicExtension } from 'prosekit/basic'
+import { union } from 'prosekit/core'
+import { defineImageUploadHandler } from 'prosekit/extensions/image'
+import {
+  definePreactNodeView,
+  type PreactNodeViewComponent,
+} from 'prosekit/preact'
+
+import ImageView from './image-view'
+import { sampleUploader } from './sample-uploader'
+
+export function defineExtension() {
+  return union(
+    defineBasicExtension(),
+    definePreactNodeView({
+      name: 'image',
+      component: ImageView satisfies PreactNodeViewComponent,
+    }),
+    defineImageUploadHandler(
+      {
+        uploader: sampleUploader,
+      },
+    ),
+  )
+}
+
+export type EditorExtension = ReturnType<typeof defineExtension>

--- a/website/src/examples/preact/image-view/image-view.tsx
+++ b/website/src/examples/preact/image-view/image-view.tsx
@@ -1,0 +1,1 @@
+../../../shared/preact/image-view.tsx

--- a/website/src/examples/preact/image-view/sample-doc-image.ts
+++ b/website/src/examples/preact/image-view/sample-doc-image.ts
@@ -1,0 +1,1 @@
+../../../shared/common/sample-doc-image.ts

--- a/website/src/examples/preact/image-view/sample-uploader.ts
+++ b/website/src/examples/preact/image-view/sample-uploader.ts
@@ -1,0 +1,1 @@
+../../../shared/common/sample-uploader.ts

--- a/website/src/examples/preact/link-mark-view/editor.tsx
+++ b/website/src/examples/preact/link-mark-view/editor.tsx
@@ -1,0 +1,28 @@
+import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
+
+import { useMemo } from 'preact/hooks'
+import { createEditor } from 'prosekit/core'
+import { ProseKit } from 'prosekit/preact'
+
+import { defineExtension } from './extension'
+
+export default function Editor() {
+  const editor = useMemo(() => {
+    return createEditor({ extension: defineExtension(), defaultContent })
+  }, [])
+
+  return (
+    <ProseKit editor={editor}>
+      <div className="CSS_EDITOR_VIEWPORT">
+        <div className="CSS_EDITOR_SCROLLING">
+          <div ref={editor.mount} className="CSS_EDITOR_CONTENT"></div>
+        </div>
+      </div>
+    </ProseKit>
+  )
+}
+
+const defaultContent = `
+  <p>Here is a link that changes color every second: <a href="https://www.example.com">example link</a>
+`

--- a/website/src/examples/preact/link-mark-view/extension.ts
+++ b/website/src/examples/preact/link-mark-view/extension.ts
@@ -1,0 +1,17 @@
+import { defineBasicExtension } from 'prosekit/basic'
+import { union } from 'prosekit/core'
+import { definePreactMarkView } from 'prosekit/preact'
+
+import LinkView from './link-view'
+
+export function defineExtension() {
+  return union(
+    defineBasicExtension(),
+    definePreactMarkView({
+      name: 'link',
+      component: LinkView,
+    }),
+  )
+}
+
+export type EditorExtension = ReturnType<typeof defineExtension>

--- a/website/src/examples/preact/link-mark-view/link-view.tsx
+++ b/website/src/examples/preact/link-mark-view/link-view.tsx
@@ -1,0 +1,50 @@
+import {
+  useEffect,
+  useState,
+} from 'preact/hooks'
+import type { PreactMarkViewProps } from 'prosekit/preact'
+
+const colors = [
+  '#f06292',
+  '#ba68c8',
+  '#9575cd',
+  '#7986cb',
+  '#64b5f6',
+  '#4fc3f7',
+  '#4dd0e1',
+  '#4db6ac',
+  '#81c784',
+  '#aed581',
+  '#ffb74d',
+  '#ffa726',
+  '#ff8a65',
+  '#d4e157',
+  '#ffd54f',
+  '#ffecb3',
+]
+
+function pickRandomColor() {
+  return colors[Math.floor(Math.random() * colors.length)]
+}
+
+export default function Link(props: PreactMarkViewProps) {
+  const [color, setColor] = useState(colors[0])
+  const { mark, contentRef } = props
+  const href = mark.attrs.href as string
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setColor(pickRandomColor())
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <a
+      href={href}
+      ref={contentRef}
+      style={{ color, transition: 'color 1s ease-in-out' }}
+    >
+    </a>
+  )
+}

--- a/website/src/examples/preact/loaders.gen.ts
+++ b/website/src/examples/preact/loaders.gen.ts
@@ -4,7 +4,9 @@ import { lazy } from 'preact/compat'
 export const loaders = {
   'minimal': lazy(() => import('./minimal/editor')),
   'block-handle': lazy(() => import('./block-handle/editor')),
+  'image-view': lazy(() => import('./image-view/editor')),
   'keymap': lazy(() => import('./keymap/editor')),
+  'link-mark-view': lazy(() => import('./link-mark-view/editor')),
   'readonly': lazy(() => import('./readonly/editor')),
   'slash-menu': lazy(() => import('./slash-menu/editor')),
   'table': lazy(() => import('./table/editor')),

--- a/website/src/shared/preact/image-view.tsx
+++ b/website/src/shared/preact/image-view.tsx
@@ -1,0 +1,97 @@
+import type { JSX } from 'preact'
+import {
+  useEffect,
+  useState,
+} from 'preact/hooks'
+import { UploadTask } from 'prosekit/extensions/file'
+import type { ImageAttrs } from 'prosekit/extensions/image'
+import type { PreactNodeViewProps } from 'prosekit/preact'
+import {
+  ResizableHandle,
+  ResizableRoot,
+} from 'prosekit/preact/resizable'
+
+export default function ImageView(props: PreactNodeViewProps) {
+  const { setAttrs, node } = props
+  const attrs = node.attrs as ImageAttrs
+  const url = attrs.src || ''
+  const uploading = url.startsWith('blob:')
+
+  const [aspectRatio, setAspectRatio] = useState<number | undefined>()
+  const [error, setError] = useState<string | undefined>()
+  const [progress, setProgress] = useState(0)
+
+  useEffect(() => {
+    if (!uploading) return
+
+    const uploadTask = UploadTask.get<string>(url)
+    if (!uploadTask) return
+
+    let canceled = false
+
+    uploadTask.finished.catch((error) => {
+      if (canceled) return
+      setError(String(error))
+    })
+    const unsubscribeProgress = uploadTask.subscribeProgress(({ loaded, total }) => {
+      if (canceled) return
+      setProgress(total ? loaded / total : 0)
+    })
+
+    return () => {
+      canceled = true
+      unsubscribeProgress()
+    }
+  }, [url, uploading, setAttrs])
+
+  const handleImageLoad = (event: JSX.TargetedEvent<HTMLImageElement>) => {
+    const img = event.target as HTMLImageElement
+    const { naturalWidth, naturalHeight } = img
+    const ratio = naturalWidth / naturalHeight
+    if (ratio && Number.isFinite(ratio)) {
+      setAspectRatio(ratio)
+    }
+    if (naturalWidth && naturalHeight && (!attrs.width || !attrs.height)) {
+      setAttrs({ width: naturalWidth, height: naturalHeight })
+    }
+  }
+
+  return (
+    <ResizableRoot
+      width={attrs.width ?? undefined}
+      height={attrs.height ?? undefined}
+      aspectRatio={aspectRatio}
+      onResizeEnd={(event) => setAttrs(event.detail)}
+      data-selected={props.selected ? '' : undefined}
+      className="CSS_IMAGE_RESIZABLE"
+    >
+      {url && !error && (
+        <img
+          src={url}
+          onLoad={handleImageLoad}
+          className="CSS_IMAGE_RESIZABLE_IMAGE"
+        />
+      )}
+      {uploading && !error && (
+        <div className="CSS_IMAGE_UPLOAD_PROGRESS">
+          <div className="CSS_ICON_LOADER"></div>
+          <div>{Math.round(progress * 100)}%</div>
+        </div>
+      )}
+      {error && (
+        <div className="CSS_IMAGE_UPLOAD_ERROR">
+          <div className="CSS_ICON_IMAGE_ERROR"></div>
+          <div className="CSS_IMAGE_UPLOAD_ERROR_MESSAGE">
+            Failed to upload image
+          </div>
+        </div>
+      )}
+      <ResizableHandle
+        className="CSS_IMAGE_RESIZABLE_HANDLE"
+        position="bottom-right"
+      >
+        <div className="CSS_ICON_CORNER_HANDLE"></div>
+      </ResizableHandle>
+    </ResizableRoot>
+  )
+}

--- a/website/src/stories/preact.stories.ts
+++ b/website/src/stories/preact.stories.ts
@@ -5,7 +5,9 @@ export default { component }
 
 export const Minimal = { args: { story: 'minimal' } }
 export const BlockHandle = { args: { story: 'block-handle' } }
+export const ImageView = { args: { story: 'image-view' } }
 export const Keymap = { args: { story: 'keymap' } }
+export const LinkMarkView = { args: { story: 'link-mark-view' } }
 export const Readonly = { args: { story: 'readonly' } }
 export const SlashMenu = { args: { story: 'slash-menu' } }
 export const Table = { args: { story: 'table' } }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added full Preact support for custom node and mark views.
  - Introduced a hook to derive reactive editor state from the editor.
  - Added Preact examples: Image View and Link Mark View, with new lazy-loaded routes.
- Documentation
  - New Preact example pages and stories for Image View and Link Mark View.
- Chores
  - Added Preact adapter dependencies.
  - Updated development symlink mappings for new examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->