### PR TITLE
docs: remove redundant extensions in examples

### DIFF
--- a/website/src/examples/lit/dom/extension.ts
+++ b/website/src/examples/lit/dom/extension.ts
@@ -1,16 +1,12 @@
 import { defineBasicExtension } from 'prosekit/basic'
 import { union } from 'prosekit/core'
-import {
-  defineCodeBlock,
-  defineCodeBlockShiki,
-} from 'prosekit/extensions/code-block'
+import { defineCodeBlockShiki } from 'prosekit/extensions/code-block'
 
 import { defineCodeBlockView } from './code-block-view'
 
 export function defineExtension() {
   return union(
     defineBasicExtension(),
-    defineCodeBlock(),
     defineCodeBlockShiki(),
     defineCodeBlockView(),
   )

--- a/website/src/examples/preact/full/extension.ts
+++ b/website/src/examples/preact/full/extension.ts
@@ -1,9 +1,6 @@
 import { defineBasicExtension } from 'prosekit/basic'
 import { union } from 'prosekit/core'
-import {
-  defineCodeBlock,
-  defineCodeBlockShiki,
-} from 'prosekit/extensions/code-block'
+import { defineCodeBlockShiki } from 'prosekit/extensions/code-block'
 import { defineHorizontalRule } from 'prosekit/extensions/horizontal-rule'
 import { defineImageUploadHandler } from 'prosekit/extensions/image'
 import { defineMention } from 'prosekit/extensions/mention'
@@ -22,7 +19,6 @@ export function defineExtension() {
     defineBasicExtension(),
     definePlaceholder({ placeholder: 'Press / for commands...' }),
     defineMention(),
-    defineCodeBlock(),
     defineCodeBlockShiki(),
     defineHorizontalRule(),
     definePreactNodeView({

--- a/website/src/examples/react/code-block/extension.ts
+++ b/website/src/examples/react/code-block/extension.ts
@@ -1,9 +1,6 @@
 import { defineBasicExtension } from 'prosekit/basic'
 import { union } from 'prosekit/core'
-import {
-  defineCodeBlock,
-  defineCodeBlockShiki,
-} from 'prosekit/extensions/code-block'
+import { defineCodeBlockShiki } from 'prosekit/extensions/code-block'
 import {
   defineReactNodeView,
   type ReactNodeViewComponent,
@@ -14,7 +11,6 @@ import CodeBlockView from './code-block-view'
 export function defineExtension() {
   return union(
     defineBasicExtension(),
-    defineCodeBlock(),
     defineCodeBlockShiki(),
     defineReactNodeView({
       name: 'codeBlock',

--- a/website/src/examples/react/full/extension.ts
+++ b/website/src/examples/react/full/extension.ts
@@ -1,9 +1,6 @@
 import { defineBasicExtension } from 'prosekit/basic'
 import { union } from 'prosekit/core'
-import {
-  defineCodeBlock,
-  defineCodeBlockShiki,
-} from 'prosekit/extensions/code-block'
+import { defineCodeBlockShiki } from 'prosekit/extensions/code-block'
 import { defineHorizontalRule } from 'prosekit/extensions/horizontal-rule'
 import { defineImageUploadHandler } from 'prosekit/extensions/image'
 import { defineMention } from 'prosekit/extensions/mention'
@@ -22,7 +19,6 @@ export function defineExtension() {
     defineBasicExtension(),
     definePlaceholder({ placeholder: 'Press / for commands...' }),
     defineMention(),
-    defineCodeBlock(),
     defineCodeBlockShiki(),
     defineHorizontalRule(),
     defineReactNodeView({

--- a/website/src/examples/solid/code-block/extension.ts
+++ b/website/src/examples/solid/code-block/extension.ts
@@ -1,9 +1,6 @@
 import { defineBasicExtension } from 'prosekit/basic'
 import { union } from 'prosekit/core'
-import {
-  defineCodeBlock,
-  defineCodeBlockShiki,
-} from 'prosekit/extensions/code-block'
+import { defineCodeBlockShiki } from 'prosekit/extensions/code-block'
 import {
   defineSolidNodeView,
   type SolidNodeViewComponent,
@@ -14,7 +11,6 @@ import CodeBlockView from './code-block-view'
 export function defineExtension() {
   return union(
     defineBasicExtension(),
-    defineCodeBlock(),
     defineCodeBlockShiki(),
     defineSolidNodeView({
       name: 'codeBlock',

--- a/website/src/examples/solid/full/extension.ts
+++ b/website/src/examples/solid/full/extension.ts
@@ -1,9 +1,6 @@
 import { defineBasicExtension } from 'prosekit/basic'
 import { union } from 'prosekit/core'
-import {
-  defineCodeBlock,
-  defineCodeBlockShiki,
-} from 'prosekit/extensions/code-block'
+import { defineCodeBlockShiki } from 'prosekit/extensions/code-block'
 import { defineHorizontalRule } from 'prosekit/extensions/horizontal-rule'
 import { defineImageUploadHandler } from 'prosekit/extensions/image'
 import { defineMention } from 'prosekit/extensions/mention'
@@ -22,7 +19,6 @@ export function defineExtension() {
     defineBasicExtension(),
     definePlaceholder({ placeholder: 'Press / for commands...' }),
     defineMention(),
-    defineCodeBlock(),
     defineCodeBlockShiki(),
     defineHorizontalRule(),
     defineSolidNodeView({

--- a/website/src/examples/svelte/code-block/extension.ts
+++ b/website/src/examples/svelte/code-block/extension.ts
@@ -1,9 +1,6 @@
 import { defineBasicExtension } from 'prosekit/basic'
 import { union } from 'prosekit/core'
-import {
-  defineCodeBlock,
-  defineCodeBlockShiki,
-} from 'prosekit/extensions/code-block'
+import { defineCodeBlockShiki } from 'prosekit/extensions/code-block'
 import {
   defineSvelteNodeView,
   type SvelteNodeViewComponent,
@@ -14,7 +11,6 @@ import CodeBlockView from './code-block-view.svelte'
 export function defineExtension() {
   return union(
     defineBasicExtension(),
-    defineCodeBlock(),
     defineCodeBlockShiki(),
     defineSvelteNodeView({
       name: 'codeBlock',

--- a/website/src/examples/svelte/full/extension.ts
+++ b/website/src/examples/svelte/full/extension.ts
@@ -1,9 +1,6 @@
 import { defineBasicExtension } from 'prosekit/basic'
 import { union } from 'prosekit/core'
-import {
-  defineCodeBlock,
-  defineCodeBlockShiki,
-} from 'prosekit/extensions/code-block'
+import { defineCodeBlockShiki } from 'prosekit/extensions/code-block'
 import { defineHorizontalRule } from 'prosekit/extensions/horizontal-rule'
 import { defineImageUploadHandler } from 'prosekit/extensions/image'
 import { defineMention } from 'prosekit/extensions/mention'
@@ -22,7 +19,6 @@ export function defineExtension() {
     defineBasicExtension(),
     definePlaceholder({ placeholder: 'Press / for commands...' }),
     defineMention(),
-    defineCodeBlock(),
     defineCodeBlockShiki(),
     defineHorizontalRule(),
     defineSvelteNodeView({

--- a/website/src/examples/vue/code-block/extension.ts
+++ b/website/src/examples/vue/code-block/extension.ts
@@ -1,9 +1,6 @@
 import { defineBasicExtension } from 'prosekit/basic'
 import { union } from 'prosekit/core'
-import {
-  defineCodeBlock,
-  defineCodeBlockShiki,
-} from 'prosekit/extensions/code-block'
+import { defineCodeBlockShiki } from 'prosekit/extensions/code-block'
 import {
   defineVueNodeView,
   type VueNodeViewComponent,
@@ -14,7 +11,6 @@ import CodeBlockView from './code-block-view.vue'
 export function defineExtension() {
   return union(
     defineBasicExtension(),
-    defineCodeBlock(),
     defineCodeBlockShiki(),
     defineVueNodeView({
       name: 'codeBlock',

--- a/website/src/examples/vue/full/extension.ts
+++ b/website/src/examples/vue/full/extension.ts
@@ -1,9 +1,6 @@
 import { defineBasicExtension } from 'prosekit/basic'
 import { union } from 'prosekit/core'
-import {
-  defineCodeBlock,
-  defineCodeBlockShiki,
-} from 'prosekit/extensions/code-block'
+import { defineCodeBlockShiki } from 'prosekit/extensions/code-block'
 import { defineHorizontalRule } from 'prosekit/extensions/horizontal-rule'
 import { defineImageUploadHandler } from 'prosekit/extensions/image'
 import { defineMention } from 'prosekit/extensions/mention'
@@ -22,7 +19,6 @@ export function defineExtension() {
     defineBasicExtension(),
     definePlaceholder({ placeholder: 'Press / for commands...' }),
     defineMention(),
-    defineCodeBlock(),
     defineCodeBlockShiki(),
     defineHorizontalRule(),
     defineVueNodeView({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized code-block rendering across all framework examples (Lit, Preact, React, Solid, Svelte, Vue) to use a unified implementation approach, improving consistency and reducing code duplication across the editor examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->