### PR TITLE
ci: skip some workflows from a fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,10 +150,7 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
-        # Only run this step if the CLOUDFLARE_PAGES_API_TOKEN is set (i.e. it's
-        # not from a fork). Notice that secrets cannot be directly referenced in
-        # `if:` conditionals.
-        if: ${{ env.CLOUDFLARE_PAGES_API_TOKEN != '' }}
+        if: ${{ !github.event.repository.fork }}
         with:
           apiToken: ${{ env.CLOUDFLARE_PAGES_API_TOKEN }}
           accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/hide-bot-comment.yml
+++ b/.github/workflows/hide-bot-comment.yml
@@ -9,6 +9,7 @@ jobs:
 
     steps:
       - id: hide-comment
+        if: ${{ !github.event.repository.fork }}
         uses: int128/hide-comment-action@v1.47.0
         with:
           authors: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment and automation workflows to restrict certain operations to non-fork repositories only, preventing unintended deployments and bot activity from forked repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->