### PR TITLE
docs: add a link to `defineImageUploadHandler`

### DIFF
--- a/website/src/content/docs/extensions/image.mdx
+++ b/website/src/content/docs/extensions/image.mdx
@@ -56,7 +56,7 @@ editor.commands.uploadImage({
 })
 ```
 
-You can reuse the `uploadImage` command when handling paste or drop uploads. For a convenience wrapper that wires it into the editor automatically, use `defineImageUploadHandler`.
+You can reuse the `uploadImage` command when handling paste or drop uploads. For a convenience wrapper that wires it into the editor automatically, use [`defineImageUploadHandler`].
 
 ## API Reference
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved navigation in the extensions documentation by converting a code reference to a clickable link for easier access to related content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->