### PR TITLE
docs: add inline examples for `defineNodeSpec` and `defineMarkSpec`

### DIFF
--- a/packages/core/src/extensions/mark-spec.ts
+++ b/packages/core/src/extensions/mark-spec.ts
@@ -75,7 +75,24 @@ export interface MarkAttrOptions<
 }
 
 /**
+ * Defines a mark type into the editor schema.
+ *
  * @public
+ *
+ * @example
+ *
+ * ```ts
+ * const extension = defineMarkSpec({
+ *   name: 'bold',
+ *   parseDOM: [
+ *     { tag: 'strong' },
+ *     { tag: 'b' },
+ *   ],
+ *   toDOM() {
+ *     return ['strong', 0]
+ *   },
+ * })
+ * ```
  */
 export function defineMarkSpec<
   Mark extends string,

--- a/packages/core/src/extensions/node-spec.ts
+++ b/packages/core/src/extensions/node-spec.ts
@@ -92,9 +92,23 @@ export interface NodeAttrOptions<
 }
 
 /**
- * Defines a node type.
+ * Defines a node type into the editor schema.
  *
  * @public
+ *
+ * @example
+ *
+ * ```ts
+ * const extension = defineNodeSpec({
+ *   name: 'fancyParagraph',
+ *   content: 'inline*',
+ *   group: 'block',
+ *   parseDOM: [{ tag: 'p.fancy' }],
+ *   toDOM() {
+ *     return ['p', { 'class': 'fancy' }, 0]
+ *   },
+ * })
+ * ```
  */
 export function defineNodeSpec<
   Node extends string,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Enhanced developer documentation for core specification functions with improved descriptions and comprehensive usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->