### PR TITLE
test: add test for example tweet

### DIFF
--- a/registry/test/tweet.test.ts
+++ b/registry/test/tweet.test.ts
@@ -13,52 +13,36 @@ import {
 testStoryConsistency('tweet')
 
 testStory('tweet', () => {
-  const setup = async () => {
+  it('can switch between iframe and react mode', async () => {
     const editor = await waitForEditor()
     const iframe = editor.locate('iframe[src^="https://platform.twitter.com/embed/Tweet.html"]')
     const nodeViewRoot = editor.locate('[data-node-view-root="true"]')
     const reactRadio = page.getByRole('radio', { name: 'react-tweet' })
     const iframeRadio = page.getByRole('radio', { name: 'iframe' })
 
-    return {
-      iframe,
-      nodeViewRoot,
-      reactRadio,
-      iframeRadio,
+    const expectIframe = async () => {
+      await expect.element(iframe).toBeVisible()
+      await expect.element(nodeViewRoot).not.toBeInTheDocument()
     }
-  }
 
-  it('renders tweet in iframe mode by default', async () => {
-    const { iframe, nodeViewRoot } = await setup()
+    const expectNodeViewRoot = async () => {
+      await expect.element(nodeViewRoot).toBeVisible()
+      await expect.element(iframe).not.toBeInTheDocument()
+    }
 
-    await expect.element(iframe).toBeVisible()
-    await expect.element(nodeViewRoot).not.toBeInTheDocument()
-  })
-
-  it('switches to react mode', async () => {
-    const { iframe, nodeViewRoot, reactRadio } = await setup()
-
-    await expect.element(iframe).toBeVisible()
-    await expect.element(nodeViewRoot).not.toBeInTheDocument()
+    // Render the tweet in iframe mode by default
+    await expectIframe()
 
     // Switch to react mode
     await reactRadio.click()
 
-    await expect.element(nodeViewRoot).toBeVisible()
-    await expect.element(iframe).not.toBeInTheDocument()
-  })
-
-  it('switches back to iframe mode', async () => {
-    const { iframe, nodeViewRoot, reactRadio, iframeRadio } = await setup()
-
-    // Switch to react mode first
-    await reactRadio.click()
+    // Verify the tweet is rendered in react mode
+    await expectNodeViewRoot()
 
     // Switch back to iframe mode
     await iframeRadio.click()
 
-    // Verify iframe is rendered again
-    await expect.element(iframe).toBeVisible()
-    await expect.element(nodeViewRoot).not.toBeInTheDocument()
+    // Verify the tweet is rendered in iframe mode
+    await expectIframe()
   })
 })


### PR DESCRIPTION
I found the following console error when switching between two render methods in http://localhost:4321/playground/react/tweet

```
flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.
```

This error can slow be seen from tests:

```
$ pnpm run test:run registry/test/tweet.test.ts

stderr | test/tweet.test.ts > react/tweet > switches to react mode
flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  16:59:31
   Duration  2.52s (transform 0ms, setup 0ms, import 700ms, tests 807ms, environment 0ms)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for embedded tweet rendering that verify the default iframe view, switch to the React-rendered view, and switching back to iframe. Tests exercise UI controls to change render modes and assert the correct view is visible at each step, improving coverage for render-mode consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->