### PR TITLE
refactor(core): clear `afterMounted` array after mounting

### DIFF
--- a/packages/core/src/editor/editor.ts
+++ b/packages/core/src/editor/editor.ts
@@ -297,6 +297,7 @@ export class EditorInstance {
     }
     this.view = new EditorView({ mount: place }, this.directEditorProps)
     this.afterMounted.forEach((callback) => callback())
+    this.afterMounted.length = 0
   }
 
   public unmount(): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where editor callbacks were executing multiple times during remounting operations, ensuring they run only once as intended.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->