### PR TITLE
fix(website): select framework via icon clicks

### DIFF
--- a/website/src/components/ui/use-framework.svelte.ts
+++ b/website/src/components/ui/use-framework.svelte.ts
@@ -4,7 +4,7 @@ function consumeFrameworkFromQuery(): string | undefined | null {
   if (typeof window === 'undefined') return undefined
   try {
     const url = new URL(window.location.href)
-    if (!url.searchParams.has('framework')) return
+    if (!url.searchParams.has('framework')) return undefined
     const value = url.searchParams.get('framework')
     url.searchParams.delete('framework')
     window.history.replaceState(window.history.state, '', url.toString())

--- a/website/src/pages/examples/index.astro
+++ b/website/src/pages/examples/index.astro
@@ -25,7 +25,7 @@ import { frameworkIcons } from '@/components/ui/framework-icons'
                 class:list={[
                   'size-6 p-1 transition-all inline-flex items-center justify-center',
                   'saturate-100 group-hover/framework-icons:saturate-0 hover:saturate-100',
-                  'scale-100 hover:scale-160',
+                  'scale-100 hover:scale-150',
                   'opacity-100 group-hover/framework-icons:opacity-70 hover:opacity-100',
                 ]}
                 href={item.link + '?framework=' + framework}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Framework selection via URL query now pre-selects and overrides stored preferences; URLs are consumed so shared links apply immediately.
  * Examples now use clickable framework icons that link to the corresponding example with the framework selected.

* **Accessibility**
  * Clickable icons include screen-reader labels and improved hover/interaction styling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->