### PR TITLE
fix(web): fix inline popover overflow

### DIFF
--- a/.changeset/400-inline-popover-floating.md
+++ b/.changeset/400-inline-popover-floating.md
@@ -1,4 +1,5 @@
 ---
+'prosekit': patch
 "@prosekit/web": patch
 ---
 

--- a/.changeset/400-inline-popover-floating.md
+++ b/.changeset/400-inline-popover-floating.md
@@ -1,0 +1,5 @@
+---
+"@prosekit/web": patch
+---
+
+Fix an issue where the inline popover could overflow the clipping area.

--- a/packages/web/src/components/inline-popover/inline-popover-positioner.ts
+++ b/packages/web/src/components/inline-popover/inline-popover-positioner.ts
@@ -14,7 +14,8 @@ import { InlinePopoverStoreContext } from './store.ts'
 /**
  * @public
  */
-export interface InlinePopoverPositionerProps extends OverlayPositionerProps {
+export interface InlinePopoverPositionerProps extends Omit<OverlayPositionerProps, "placement"|"offset"|"hide"|"hoist"|"overlap"|"inline"|"overflowPadding"
+> {
   /**
    * The initial placement of the floating element
    *

--- a/packages/web/src/components/inline-popover/inline-popover-positioner.ts
+++ b/packages/web/src/components/inline-popover/inline-popover-positioner.ts
@@ -38,6 +38,14 @@ export interface InlinePopoverPositionerProps extends OverlayPositionerProps {
   hide: OverlayPositionerProps['hide']
 
   /**
+   * Whether to use the browser [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)
+   * to place the floating element on top of other page content.
+   *
+   * @default false
+   */
+  hoist: boolean
+
+  /**
    * Whether the floating element can overlap the reference element to keep it
    * in view.
    *
@@ -69,6 +77,7 @@ export const InlinePopoverPositionerPropsDeclaration: PropsDeclaration<InlinePop
   placement: { default: 'top', attribute: 'placement', type: 'string' },
   offset: { default: 12, attribute: false, type: 'json' },
   hide: { default: true, attribute: 'hide', type: 'boolean' },
+  hoist: { default: false, attribute: 'hoist', type: 'boolean' },
   overlap: { default: true, attribute: 'overlap', type: 'boolean' },
   inline: { default: true, attribute: 'inline', type: 'boolean' },
   overflowPadding: { default: 8, attribute: 'overflow-padding', type: 'number' },

--- a/packages/web/src/components/inline-popover/inline-popover-positioner.ts
+++ b/packages/web/src/components/inline-popover/inline-popover-positioner.ts
@@ -14,8 +14,9 @@ import { InlinePopoverStoreContext } from './store.ts'
 /**
  * @public
  */
-export interface InlinePopoverPositionerProps extends Omit<OverlayPositionerProps, "placement"|"offset"|"hide"|"hoist"|"overlap"|"inline"|"overflowPadding"
-> {
+export interface InlinePopoverPositionerProps
+  extends Omit<OverlayPositionerProps, 'placement' | 'offset' | 'hide' | 'hoist' | 'overlap' | 'inline' | 'overflowPadding'>
+{
   /**
    * The initial placement of the floating element
    *

--- a/packages/web/src/components/inline-popover/inline-popover-positioner.ts
+++ b/packages/web/src/components/inline-popover/inline-popover-positioner.ts
@@ -14,8 +14,17 @@ import { InlinePopoverStoreContext } from './store.ts'
 /**
  * @public
  */
-export interface InlinePopoverPositionerProps
-  extends Omit<OverlayPositionerProps, 'placement' | 'offset' | 'hide' | 'hoist' | 'overlap' | 'inline' | 'overflowPadding'>
+export interface InlinePopoverPositionerProps extends
+  Omit<
+    OverlayPositionerProps,
+    | 'placement'
+    | 'offset'
+    | 'hide'
+    | 'hoist'
+    | 'overlap'
+    | 'inline'
+    | 'overflowPadding'
+  >
 {
   /**
    * The initial placement of the floating element

--- a/registry/src/preact/examples/link/editor.tsx
+++ b/registry/src/preact/examples/link/editor.tsx
@@ -24,9 +24,9 @@ export default function Editor(props: EditorProps) {
   return (
     <ProseKit editor={editor}>
       <div className="CSS_EDITOR_VIEWPORT">
-        <InlineMenu />
         <div className="CSS_EDITOR_SCROLLING">
           <div ref={editor.mount} className="CSS_EDITOR_CONTENT"></div>
+          <InlineMenu />
         </div>
       </div>
     </ProseKit>

--- a/registry/src/react/examples/link/editor.tsx
+++ b/registry/src/react/examples/link/editor.tsx
@@ -24,9 +24,9 @@ export default function Editor(props: EditorProps) {
   return (
     <ProseKit editor={editor}>
       <div className="CSS_EDITOR_VIEWPORT">
-        <InlineMenu />
         <div className="CSS_EDITOR_SCROLLING">
           <div ref={editor.mount} className="CSS_EDITOR_CONTENT"></div>
+          <InlineMenu />
         </div>
       </div>
     </ProseKit>

--- a/registry/src/solid/examples/link/editor.tsx
+++ b/registry/src/solid/examples/link/editor.tsx
@@ -22,9 +22,9 @@ export default function Editor(props: EditorProps): JSX.Element {
   return (
     <ProseKit editor={editor}>
       <div class="CSS_EDITOR_VIEWPORT">
-        <InlineMenu />
         <div class="CSS_EDITOR_SCROLLING">
           <div ref={editor.mount} class="CSS_EDITOR_CONTENT"></div>
+          <InlineMenu />
         </div>
       </div>
     </ProseKit>

--- a/registry/src/svelte/examples/link/editor.svelte
+++ b/registry/src/svelte/examples/link/editor.svelte
@@ -22,9 +22,9 @@ const editor = createEditor({ extension, defaultContent })
 
 <ProseKit {editor}>
   <div class="CSS_EDITOR_VIEWPORT">
-    <InlineMenu />
     <div class="CSS_EDITOR_SCROLLING">
       <div {@attach editor.mount} class="CSS_EDITOR_CONTENT"></div>
+      <InlineMenu />
     </div>
   </div>
 </ProseKit>

--- a/registry/src/vue/examples/link/editor.vue
+++ b/registry/src/vue/examples/link/editor.vue
@@ -22,9 +22,9 @@ const editor = createEditor({ extension, defaultContent })
 <template>
   <ProseKit :editor="editor">
     <div class="CSS_EDITOR_VIEWPORT">
-      <InlineMenu />
       <div class="CSS_EDITOR_SCROLLING">
         <div :ref="(el) => editor.mount(el as HTMLElement | null)" class="CSS_EDITOR_CONTENT" />
+        <InlineMenu />
       </div>
     </div>
   </ProseKit>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inline popover overflowing clipping areas.

* **New Features**
  * Added a hoist option for inline popovers to improve positioning control.

* **Examples**
  * Adjusted example editors so the inline menu is nested inside the scrolling region for more consistent placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->