### PR TITLE
feat(registry): remove tw-animate-css

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1065,9 +1065,6 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
-      tw-animate-css:
-        specifier: ^1.4.0
-        version: 1.4.0
       vite:
         specifier: ^8.0.8
         version: 8.0.8(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1227,9 +1224,6 @@ importers:
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
-      tw-animate-css:
-        specifier: ^1.4.0
-        version: 1.4.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -7062,9 +7056,6 @@ packages:
   turbo@2.9.5:
     resolution: {integrity: sha512-JXNkRe6H6MjSlk5UQRTjyoKX5YN2zlc2632xcSlSFBao5yvbMWTpv9SNolOZlZmUlcDOHuszPLItbKrvcXnnZA==}
     hasBin: true
-
-  tw-animate-css@1.4.0:
-    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
   twoslash-protocol@0.3.7:
     resolution: {integrity: sha512-mwDFdclG7DbFW3aZA/CGATzV2efV2uPai90mmRSblqPbrc1Z1cu+DpI5oKMNciGY4rw8EOXc7QGY8O0iw1hnzg==}
@@ -14736,8 +14727,6 @@ snapshots:
       '@turbo/linux-arm64': 2.9.5
       '@turbo/windows-64': 2.9.5
       '@turbo/windows-arm64': 2.9.5
-
-  tw-animate-css@1.4.0: {}
 
   twoslash-protocol@0.3.7: {}
 

--- a/registry/package.json
+++ b/registry/package.json
@@ -336,7 +336,6 @@
     "temml": "^0.13.2",
     "tinyexec": "^1.1.1",
     "tsx": "^4.21.0",
-    "tw-animate-css": "^1.4.0",
     "vite": "^8.0.8",
     "vite-plugin-solid": "^2.11.12",
     "vite-plugin-wasm": "^3.6.0",

--- a/registry/src/tailwind.css
+++ b/registry/src/tailwind.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@import "tw-animate-css";
 @import "prosekit/basic/style.css";
 @import "prosekit/basic/typography.css";
 

--- a/website/package.json
+++ b/website/package.json
@@ -56,7 +56,6 @@
     "starlight-theme-nova": "^0.11.8",
     "svelte": "^5.55.2",
     "tailwindcss": "^4.2.2",
-    "tw-animate-css": "^1.4.0",
     "typescript": "catalog:",
     "vite": "^7.3.2",
     "vite-plugin-wasm": "^3.6.0",

--- a/website/src/components/ui/demo/dropdown-menu.tsx
+++ b/website/src/components/ui/demo/dropdown-menu.tsx
@@ -44,34 +44,34 @@ export function DropdownMenu({ story, framework }: DropdownMenuProps) {
       </Menu.Trigger>
       <Menu.Portal>
         <Menu.Positioner sideOffset={6}>
-          <Menu.Popup className="w-[220px] rounded-lg border border-border bg-background p-1 shadow-lg outline-none focus-visible:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2">
-            <Menu.Item
-              className="flex h-8 select-none items-center rounded py-3 pl-3 pr-1.5 text-sm outline-none ring-transparent data-highlighted:bg-muted"
-              onClick={handleOpenCodeSandbox}
-            >
-              Open in CodeSandbox
-            </Menu.Item>
-            <Menu.Item
-              className="flex h-8 select-none items-center rounded py-3 pl-3 pr-1.5 text-sm outline-none ring-transparent data-highlighted:bg-muted"
-              onClick={handleOpenStackBlitz}
-            >
-              Open in StackBlitz
-            </Menu.Item>
-            <Menu.Item
-              className="flex h-8 select-none items-center rounded py-3 pl-3 pr-1.5 text-sm outline-none ring-transparent data-highlighted:bg-muted"
-              onClick={handleOpenInNewPage}
-            >
-              Open in New Page
-            </Menu.Item>
-            <Menu.Item
-              className="flex h-8 select-none items-center rounded py-3 pl-3 pr-1.5 text-sm outline-none ring-transparent data-highlighted:bg-muted"
-              onClick={handleDownload}
-            >
-              Download
-            </Menu.Item>
+          <Menu.Popup className="
+            border rounded-lg border-border bg-background p-1 shadow-lg outline-none
+            transition-[transform,scale,opacity]
+            origin-(--transform-origin) 
+            data-ending-style:scale-90 
+            data-ending-style:opacity-0 
+            data-starting-style:scale-90 
+            data-starting-style:opacity-0">
+            <DropdownMenuItem text="Open in CodeSandbox" onClick={handleOpenCodeSandbox} />
+            <DropdownMenuItem text="Open in StackBlitz" onClick={handleOpenStackBlitz} />
+            <DropdownMenuItem text="Open in New Page" onClick={handleOpenInNewPage} />
+            <DropdownMenuItem text="Download" onClick={handleDownload} />
           </Menu.Popup>
         </Menu.Positioner>
       </Menu.Portal>
     </Menu.Root>
+  )
+}
+
+function DropdownMenuItem({ text, onClick }: { text: string; onClick: () => void }) {
+  return (
+    <Menu.Item
+      className="flex items-center cursor-default py-2 pl-3 pr-2 text-sm leading-4 outline-hidden select-none outline-none ring-transparent data-highlighted:bg-muted relative"
+      onClick={onClick}
+    >
+      <span>{text}</span>
+      <span className="flex-1 inline-flex w-3"></span>
+      <span className="size-4 inline-flex opacity-50 i-lucide-square-arrow-out-up-right"></span>
+    </Menu.Item>
   )
 }

--- a/website/src/components/ui/demo/framework-select.tsx
+++ b/website/src/components/ui/demo/framework-select.tsx
@@ -31,11 +31,14 @@ export function FrameworkSelect({
         <Select.Value>
           <FrameworkLabel framework={framework} />
         </Select.Value>
-        <Select.Icon className="i-lucide-chevron-down size-4 min-w-4 text-muted-foreground" />
+        <Select.Icon className="i-lucide-chevron-down size-4 min-w-4 min-h-4 text-muted-foreground" />
       </Select.Trigger>
       <Select.Portal>
         <Select.Positioner sideOffset={6}>
-          <Select.Popup className="z-50 max-h-96 select-none rounded-lg border border-border bg-background p-1 shadow-lg outline-none min-w-(--anchor-width) data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2">
+          <Select.Popup className="
+            z-50 max-h-96 select-none rounded-lg border border-border bg-background p-1 shadow-lg outline-none
+            min-w-(--anchor-width) origin-(--transform-origin)
+          ">
             {frameworks.map((framework) => (
               <Select.Item
                 key={framework}

--- a/website/src/content/docs/components/index.mdx
+++ b/website/src/content/docs/components/index.mdx
@@ -19,9 +19,9 @@ ProseKit provides a set of components that you can copy and paste into your proj
 
 2. **Install recommended plugins**
 
-   You’ll need a few extra Tailwind CSS plugins for these components to work properly. Install the following:
+   We use [`@egoist/tailwindcss-icons`](https://npmx.dev/package/@egoist/tailwindcss-icons) for icons. Install the following:
 
-   <CodePackageManagers packages="tw-animate-css @egoist/tailwindcss-icons @iconify-json/lucide" />
+   <CodePackageManagers packages="@egoist/tailwindcss-icons @iconify-json/lucide" />
 
 3. **Configure Tailwind CSS**
 
@@ -29,7 +29,6 @@ ProseKit provides a set of components that you can copy and paste into your proj
 
    ```css {2,3}
    @import "tailwindcss";
-   @import "tw-animate-css";
    @plugin "@egoist/tailwindcss-icons";
    ```
 

--- a/website/src/styles/tailwind.css
+++ b/website/src/styles/tailwind.css
@@ -1,6 +1,5 @@
 @import "tailwindcss";
 @import "starlight-theme-nova/tailwind.css";
-@import "tw-animate-css";
 @import "./starlight.css";
 
 @source "../../../registry/src/";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed tw-animate-css dependency from registry and website packages.

* **Style**
  * Updated dropdown menu styling with new transition-based animations and improved transform/scale/opacity controls.
  * Enhanced framework select component with refined icon sizing and popup styling.

* **Refactor**
  * Refactored dropdown menu component with reusable DropdownMenuItem elements for consistency.

* **Documentation**
  * Updated installation guide to remove tw-animate-css plugin reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->