### PR TITLE
fix(website): prevent stale slot DOM when switching frameworks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,10 @@ jobs:
 
     needs: [build]
 
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master' && contains(github.event.head_commit.message || '', 'version packages'))
+    if: >-
+      github.event_name == 'pull_request' ||
+      contains(github.event.head_commit.message || '', 'version packages') ||
+      contains(github.event.head_commit.message || '', '(website)')
 
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/website/src/components/ui/demo/framework-content.ts
+++ b/website/src/components/ui/demo/framework-content.ts
@@ -1,6 +1,4 @@
-/** @jsxImportSource react */
-
-import type { FC, ReactNode } from 'react'
+import { createElement, Fragment, type FC, type ReactNode } from 'react'
 
 export interface ReactFrameworkContents {
   lit?: ReactNode
@@ -16,22 +14,27 @@ interface FrameworkContentProps extends ReactFrameworkContents {
   framework: string
 }
 
+// Each slot is wrapped in a keyed Fragment to force React to unmount and
+// remount when the framework changes.  Astro's StaticHtml component is
+// wrapped in React.memo(() => true) which prevents any prop-driven
+// re-render, so without distinct keys React would reuse the old slot DOM.
+// https://github.com/withastro/astro/blob/a8a926eecc2fb9a2e48a63afcf444d3ca2921a9c/packages/integrations/react/src/static-html.ts#L36
 export const FrameworkContent: FC<FrameworkContentProps> = (props) => {
   switch (props.framework) {
     case 'lit':
-      return props.lit
+      return createElement(Fragment, { key: 1 }, props.lit)
     case 'preact':
-      return props.preact
+      return createElement(Fragment, { key: 2 }, props.preact)
     case 'react':
-      return props.react
+      return createElement(Fragment, { key: 3 }, props.react)
     case 'solid':
-      return props.solid
+      return createElement(Fragment, { key: 4 }, props.solid)
     case 'svelte':
-      return props.svelte
+      return createElement(Fragment, { key: 5 }, props.svelte)
     case 'vanilla':
-      return props.vanilla
+      return createElement(Fragment, { key: 6 }, props.vanilla)
     case 'vue':
-      return props.vue
+      return createElement(Fragment, { key: 7 }, props.vue)
     default:
       throw new Error(`Unknown framework: ${props.framework}`)
   }

--- a/website/src/components/ui/demo/framework-content.ts
+++ b/website/src/components/ui/demo/framework-content.ts
@@ -19,23 +19,10 @@ interface FrameworkContentProps extends ReactFrameworkContents {
 // wrapped in React.memo(() => true) which prevents any prop-driven
 // re-render, so without distinct keys React would reuse the old slot DOM.
 // https://github.com/withastro/astro/blob/a8a926eecc2fb9a2e48a63afcf444d3ca2921a9c/packages/integrations/react/src/static-html.ts#L36
-export const FrameworkContent: FC<FrameworkContentProps> = (props) => {
-  switch (props.framework) {
-    case 'lit':
-      return createElement(Fragment, { key: 1 }, props.lit)
-    case 'preact':
-      return createElement(Fragment, { key: 2 }, props.preact)
-    case 'react':
-      return createElement(Fragment, { key: 3 }, props.react)
-    case 'solid':
-      return createElement(Fragment, { key: 4 }, props.solid)
-    case 'svelte':
-      return createElement(Fragment, { key: 5 }, props.svelte)
-    case 'vanilla':
-      return createElement(Fragment, { key: 6 }, props.vanilla)
-    case 'vue':
-      return createElement(Fragment, { key: 7 }, props.vue)
-    default:
-      throw new Error(`Unknown framework: ${props.framework}`)
+export const FrameworkContent: FC<FrameworkContentProps> = ({ framework, ...slots }) => {
+  const child = slots[framework as keyof typeof slots]
+  if (!child) {
+    throw new Error(`no content for framework ${framework}`)
   }
+  return createElement(Fragment, { key: framework }, child)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced continuous integration workflow to automatically deploy website updates when website-specific changes are committed.

* **Refactor**
  * Optimized framework switching mechanism in demo components to improve state management and user experience when selecting between different framework implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->