### PR TITLE
fix(registry): remove redundant `canUseRegexLookbehind`

### DIFF
--- a/packages/core/src/utils/can-use-regex-lookbehind.ts
+++ b/packages/core/src/utils/can-use-regex-lookbehind.ts
@@ -2,7 +2,7 @@ import { supportsRegexLookbehind } from '@ocavue/utils'
 
 /**
  * Checks if the browser supports [regex lookbehind assertion](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion).
- * 
+ *
  * @internal
  */
 export const canUseRegexLookbehind: () => boolean = supportsRegexLookbehind

--- a/packages/core/src/utils/can-use-regex-lookbehind.ts
+++ b/packages/core/src/utils/can-use-regex-lookbehind.ts
@@ -2,5 +2,7 @@ import { supportsRegexLookbehind } from '@ocavue/utils'
 
 /**
  * Checks if the browser supports [regex lookbehind assertion](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion).
+ * 
+ * @internal
  */
 export const canUseRegexLookbehind: () => boolean = supportsRegexLookbehind

--- a/packages/extensions/src/autocomplete/autocomplete.spec.ts
+++ b/packages/extensions/src/autocomplete/autocomplete.spec.ts
@@ -1,4 +1,4 @@
-import { union } from '@prosekit/core'
+import { canUseRegexLookbehind, union } from '@prosekit/core'
 import { describe, expect, it, vi } from 'vitest'
 import { keyboard } from 'vitest-browser-commands/playwright'
 
@@ -9,7 +9,7 @@ import { AutocompleteRule, type MatchHandler, type MatchHandlerOptions } from '.
 import { defineAutocomplete } from './autocomplete.ts'
 
 function setupSlashMenu() {
-  const regex = /(?<!\S)\/(\S.*)?$/u
+  const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
 
   let matching: MatchHandlerOptions | null = null
 

--- a/packages/extensions/src/autocomplete/autocomplete.spec.ts
+++ b/packages/extensions/src/autocomplete/autocomplete.spec.ts
@@ -9,7 +9,7 @@ import { AutocompleteRule, type MatchHandler, type MatchHandlerOptions } from '.
 import { defineAutocomplete } from './autocomplete.ts'
 
 function setupSlashMenu() {
-  const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+  const regex =   /(?<!\S)\/(\S.*)?$/u  
 
   let matching: MatchHandlerOptions | null = null
 

--- a/packages/extensions/src/autocomplete/autocomplete.spec.ts
+++ b/packages/extensions/src/autocomplete/autocomplete.spec.ts
@@ -1,4 +1,4 @@
-import { canUseRegexLookbehind, union } from '@prosekit/core'
+import {  union } from '@prosekit/core'
 import { describe, expect, it, vi } from 'vitest'
 import { keyboard } from 'vitest-browser-commands/playwright'
 

--- a/packages/extensions/src/autocomplete/autocomplete.spec.ts
+++ b/packages/extensions/src/autocomplete/autocomplete.spec.ts
@@ -9,7 +9,7 @@ import { AutocompleteRule, type MatchHandler, type MatchHandlerOptions } from '.
 import { defineAutocomplete } from './autocomplete.ts'
 
 function setupSlashMenu() {
-  const regex =   /(?<!\S)\/(\S.*)?$/u  
+  const regex = /(?<!\S)\/(\S.*)?$/u
 
   let matching: MatchHandlerOptions | null = null
 

--- a/packages/extensions/src/autocomplete/autocomplete.spec.ts
+++ b/packages/extensions/src/autocomplete/autocomplete.spec.ts
@@ -1,4 +1,4 @@
-import {  union } from '@prosekit/core'
+import { union } from '@prosekit/core'
 import { describe, expect, it, vi } from 'vitest'
 import { keyboard } from 'vitest-browser-commands/playwright'
 

--- a/registry/src/lit/ui/slash-menu/slash-menu.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu.ts
@@ -4,7 +4,6 @@ import { ContextConsumer } from '@lit/context'
 import { html, LitElement } from 'lit'
 import type { BasicExtension } from 'prosekit/basic'
 import type { Editor } from 'prosekit/core'
-import { canUseRegexLookbehind } from 'prosekit/core'
 
 import { editorContext } from '../editor-context'
 

--- a/registry/src/lit/ui/slash-menu/slash-menu.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu.ts
@@ -9,7 +9,7 @@ import { canUseRegexLookbehind } from 'prosekit/core'
 import { editorContext } from '../editor-context'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex =   /(?<!\S)\/(\S.*)?$/u  
+const regex = /(?<!\S)\/(\S.*)?$/u
 
 class SlashMenuElement extends LitElement {
   private editorConsumer = new ContextConsumer(this, {

--- a/registry/src/lit/ui/slash-menu/slash-menu.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu.ts
@@ -9,7 +9,7 @@ import { canUseRegexLookbehind } from 'prosekit/core'
 import { editorContext } from '../editor-context'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+const regex =   /(?<!\S)\/(\S.*)?$/u  
 
 class SlashMenuElement extends LitElement {
   private editorConsumer = new ContextConsumer(this, {

--- a/registry/src/preact/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/preact/ui/slash-menu/slash-menu.tsx
@@ -7,7 +7,7 @@ import SlashMenuEmpty from './slash-menu-empty'
 import SlashMenuItem from './slash-menu-item'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex =  /(?<!\S)\/(\S.*)?$/u 
+const regex = /(?<!\S)\/(\S.*)?$/u
 
 export default function SlashMenu() {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/preact/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/preact/ui/slash-menu/slash-menu.tsx
@@ -1,5 +1,4 @@
 import type { BasicExtension } from 'prosekit/basic'
-import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/preact'
 import { AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'prosekit/preact/autocomplete'
 

--- a/registry/src/preact/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/preact/ui/slash-menu/slash-menu.tsx
@@ -7,7 +7,7 @@ import SlashMenuEmpty from './slash-menu-empty'
 import SlashMenuItem from './slash-menu-item'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+const regex =  /(?<!\S)\/(\S.*)?$/u 
 
 export default function SlashMenu() {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/preact/ui/user-menu/user-menu.tsx
+++ b/registry/src/preact/ui/user-menu/user-menu.tsx
@@ -1,5 +1,5 @@
 import type { BasicExtension } from 'prosekit/basic'
-import { canUseRegexLookbehind, type Union } from 'prosekit/core'
+import type {  Union } from 'prosekit/core'
 import type { MentionExtension } from 'prosekit/extensions/mention'
 import { useEditor } from 'prosekit/preact'
 import {

--- a/registry/src/preact/ui/user-menu/user-menu.tsx
+++ b/registry/src/preact/ui/user-menu/user-menu.tsx
@@ -11,7 +11,7 @@ import {
 } from 'prosekit/preact/autocomplete'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex =   /(?<!\S)@(\S.*)?$/u  
+const regex = /(?<!\S)@(\S.*)?$/u
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/preact/ui/user-menu/user-menu.tsx
+++ b/registry/src/preact/ui/user-menu/user-menu.tsx
@@ -1,5 +1,5 @@
 import type { BasicExtension } from 'prosekit/basic'
-import type {  Union } from 'prosekit/core'
+import type { Union } from 'prosekit/core'
 import type { MentionExtension } from 'prosekit/extensions/mention'
 import { useEditor } from 'prosekit/preact'
 import {

--- a/registry/src/preact/ui/user-menu/user-menu.tsx
+++ b/registry/src/preact/ui/user-menu/user-menu.tsx
@@ -11,7 +11,7 @@ import {
 } from 'prosekit/preact/autocomplete'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = canUseRegexLookbehind() ? /(?<!\S)@(\S.*)?$/u : /@(\S.*)?$/u
+const regex =   /(?<!\S)@(\S.*)?$/u  
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/react/examples/notion/slash-menu/slash-menu.tsx
+++ b/registry/src/react/examples/notion/slash-menu/slash-menu.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import type { BasicExtension } from 'prosekit/basic'
-import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/react'
 import { AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'prosekit/react/autocomplete'
 

--- a/registry/src/react/examples/notion/slash-menu/slash-menu.tsx
+++ b/registry/src/react/examples/notion/slash-menu/slash-menu.tsx
@@ -9,7 +9,7 @@ import SlashMenuEmpty from './slash-menu-empty'
 import SlashMenuItem from './slash-menu-item'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex =  /(?<!\S)\/(\S.*)?$/u  
+const regex = /(?<!\S)\/(\S.*)?$/u
 
 interface Props {
   onOpenChange: (open: boolean) => void

--- a/registry/src/react/examples/notion/slash-menu/slash-menu.tsx
+++ b/registry/src/react/examples/notion/slash-menu/slash-menu.tsx
@@ -9,7 +9,7 @@ import SlashMenuEmpty from './slash-menu-empty'
 import SlashMenuItem from './slash-menu-item'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+const regex =  /(?<!\S)\/(\S.*)?$/u  
 
 interface Props {
   onOpenChange: (open: boolean) => void

--- a/registry/src/react/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/react/ui/slash-menu/slash-menu.tsx
@@ -9,7 +9,7 @@ import SlashMenuEmpty from './slash-menu-empty'
 import SlashMenuItem from './slash-menu-item'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+const regex =   /(?<!\S)\/(\S.*)?$/u 
 
 export default function SlashMenu() {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/react/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/react/ui/slash-menu/slash-menu.tsx
@@ -9,7 +9,7 @@ import SlashMenuEmpty from './slash-menu-empty'
 import SlashMenuItem from './slash-menu-item'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex =   /(?<!\S)\/(\S.*)?$/u 
+const regex = /(?<!\S)\/(\S.*)?$/u
 
 export default function SlashMenu() {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/react/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/react/ui/slash-menu/slash-menu.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import type { BasicExtension } from 'prosekit/basic'
-import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/react'
 import { AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'prosekit/react/autocomplete'
 

--- a/registry/src/react/ui/user-menu/user-menu.tsx
+++ b/registry/src/react/ui/user-menu/user-menu.tsx
@@ -13,7 +13,7 @@ import {
 } from 'prosekit/react/autocomplete'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = canUseRegexLookbehind() ? /(?<!\S)@(\S.*)?$/u : /@(\S.*)?$/u
+const regex =  /(?<!\S)@(\S.*)?$/u  
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/react/ui/user-menu/user-menu.tsx
+++ b/registry/src/react/ui/user-menu/user-menu.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { BasicExtension } from 'prosekit/basic'
-import type {  Union } from 'prosekit/core'
+import type { Union } from 'prosekit/core'
 import type { MentionExtension } from 'prosekit/extensions/mention'
 import { useEditor } from 'prosekit/react'
 import {

--- a/registry/src/react/ui/user-menu/user-menu.tsx
+++ b/registry/src/react/ui/user-menu/user-menu.tsx
@@ -13,7 +13,7 @@ import {
 } from 'prosekit/react/autocomplete'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex =  /(?<!\S)@(\S.*)?$/u  
+const regex = /(?<!\S)@(\S.*)?$/u
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/react/ui/user-menu/user-menu.tsx
+++ b/registry/src/react/ui/user-menu/user-menu.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { BasicExtension } from 'prosekit/basic'
-import { canUseRegexLookbehind, type Union } from 'prosekit/core'
+import type {  Union } from 'prosekit/core'
 import type { MentionExtension } from 'prosekit/extensions/mention'
 import { useEditor } from 'prosekit/react'
 import {

--- a/registry/src/solid/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/solid/ui/slash-menu/slash-menu.tsx
@@ -8,7 +8,7 @@ import SlashMenuEmpty from './slash-menu-empty'
 import SlashMenuItem from './slash-menu-item'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex =   /(?<!\S)\/(\S.*)?$/u 
+const regex = /(?<!\S)\/(\S.*)?$/u
 
 export default function SlashMenu(): JSX.Element {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/solid/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/solid/ui/slash-menu/slash-menu.tsx
@@ -1,5 +1,4 @@
 import type { BasicExtension } from 'prosekit/basic'
-import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/solid'
 import { AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'prosekit/solid/autocomplete'
 import type { JSX } from 'solid-js'

--- a/registry/src/solid/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/solid/ui/slash-menu/slash-menu.tsx
@@ -8,7 +8,7 @@ import SlashMenuEmpty from './slash-menu-empty'
 import SlashMenuItem from './slash-menu-item'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+const regex =   /(?<!\S)\/(\S.*)?$/u 
 
 export default function SlashMenu(): JSX.Element {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/solid/ui/user-menu/user-menu.tsx
+++ b/registry/src/solid/ui/user-menu/user-menu.tsx
@@ -1,5 +1,5 @@
 import type { BasicExtension } from 'prosekit/basic'
-import { canUseRegexLookbehind, type Union } from 'prosekit/core'
+import type {  Union } from 'prosekit/core'
 import type { MentionExtension } from 'prosekit/extensions/mention'
 import { useEditor } from 'prosekit/solid'
 import {

--- a/registry/src/solid/ui/user-menu/user-menu.tsx
+++ b/registry/src/solid/ui/user-menu/user-menu.tsx
@@ -12,7 +12,7 @@ import {
 import { For, type JSX } from 'solid-js'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex =   /(?<!\S)@(\S.*)?$/u  
+const regex = /(?<!\S)@(\S.*)?$/u
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/solid/ui/user-menu/user-menu.tsx
+++ b/registry/src/solid/ui/user-menu/user-menu.tsx
@@ -1,5 +1,5 @@
 import type { BasicExtension } from 'prosekit/basic'
-import type {  Union } from 'prosekit/core'
+import type { Union } from 'prosekit/core'
 import type { MentionExtension } from 'prosekit/extensions/mention'
 import { useEditor } from 'prosekit/solid'
 import {

--- a/registry/src/solid/ui/user-menu/user-menu.tsx
+++ b/registry/src/solid/ui/user-menu/user-menu.tsx
@@ -12,7 +12,7 @@ import {
 import { For, type JSX } from 'solid-js'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = canUseRegexLookbehind() ? /(?<!\S)@(\S.*)?$/u : /@(\S.*)?$/u
+const regex =   /(?<!\S)@(\S.*)?$/u  
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/svelte/ui/slash-menu/slash-menu.svelte
+++ b/registry/src/svelte/ui/slash-menu/slash-menu.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import type { BasicExtension } from 'prosekit/basic'
-import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/svelte'
 import { AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'prosekit/svelte/autocomplete'
 

--- a/registry/src/svelte/ui/slash-menu/slash-menu.svelte
+++ b/registry/src/svelte/ui/slash-menu/slash-menu.svelte
@@ -10,7 +10,7 @@ import SlashMenuItem from './slash-menu-item.svelte'
 const editor = useEditor<BasicExtension>()
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex =   /(?<!\S)\/(\S.*)?$/u 
+const regex = /(?<!\S)\/(\S.*)?$/u
 </script>
 
 <AutocompleteRoot {regex}>

--- a/registry/src/svelte/ui/slash-menu/slash-menu.svelte
+++ b/registry/src/svelte/ui/slash-menu/slash-menu.svelte
@@ -10,7 +10,7 @@ import SlashMenuItem from './slash-menu-item.svelte'
 const editor = useEditor<BasicExtension>()
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+const regex =   /(?<!\S)\/(\S.*)?$/u 
 </script>
 
 <AutocompleteRoot {regex}>

--- a/registry/src/svelte/ui/user-menu/user-menu.svelte
+++ b/registry/src/svelte/ui/user-menu/user-menu.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { BasicExtension } from 'prosekit/basic'
-import { canUseRegexLookbehind, type Union } from 'prosekit/core'
+import { type Union } from 'prosekit/core'
 import type { MentionExtension } from 'prosekit/extensions/mention'
 import { useEditor } from 'prosekit/svelte'
 import {

--- a/registry/src/svelte/ui/user-menu/user-menu.svelte
+++ b/registry/src/svelte/ui/user-menu/user-menu.svelte
@@ -33,7 +33,7 @@ function handleUserInsert(id: number, username: string) {
 }
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = canUseRegexLookbehind() ? /(?<!\S)@(\S.*)?$/u : /@(\S.*)?$/u
+const regex =   /(?<!\S)@(\S.*)?$/u  
 </script>
 
 <AutocompleteRoot

--- a/registry/src/svelte/ui/user-menu/user-menu.svelte
+++ b/registry/src/svelte/ui/user-menu/user-menu.svelte
@@ -33,7 +33,7 @@ function handleUserInsert(id: number, username: string) {
 }
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex =   /(?<!\S)@(\S.*)?$/u  
+const regex = /(?<!\S)@(\S.*)?$/u
 </script>
 
 <AutocompleteRoot

--- a/registry/src/vanilla/ui/slash-menu/slash-menu.ts
+++ b/registry/src/vanilla/ui/slash-menu/slash-menu.ts
@@ -9,7 +9,7 @@ import { renderSlashMenuEmpty } from './slash-menu-empty'
 import { renderSlashMenuItem } from './slash-menu-item'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+const regex =   /(?<!\S)\/(\S.*)?$/u  
 
 export function renderSlashMenu(
   editor: Editor<BasicExtension>,

--- a/registry/src/vanilla/ui/slash-menu/slash-menu.ts
+++ b/registry/src/vanilla/ui/slash-menu/slash-menu.ts
@@ -2,7 +2,6 @@ import 'prosekit/web/autocomplete'
 
 import type { BasicExtension } from 'prosekit/basic'
 import type { Editor } from 'prosekit/core'
-import { canUseRegexLookbehind } from 'prosekit/core'
 import type { AutocompletePopupElement, AutocompletePositionerElement, AutocompleteRootElement } from 'prosekit/web/autocomplete'
 
 import { renderSlashMenuEmpty } from './slash-menu-empty'

--- a/registry/src/vanilla/ui/slash-menu/slash-menu.ts
+++ b/registry/src/vanilla/ui/slash-menu/slash-menu.ts
@@ -9,7 +9,7 @@ import { renderSlashMenuEmpty } from './slash-menu-empty'
 import { renderSlashMenuItem } from './slash-menu-item'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex =   /(?<!\S)\/(\S.*)?$/u  
+const regex = /(?<!\S)\/(\S.*)?$/u
 
 export function renderSlashMenu(
   editor: Editor<BasicExtension>,

--- a/registry/src/vue/ui/slash-menu/slash-menu.vue
+++ b/registry/src/vue/ui/slash-menu/slash-menu.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { BasicExtension } from 'prosekit/basic'
-import { canUseRegexLookbehind } from 'prosekit/core'
 import { useEditor } from 'prosekit/vue'
 import { AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'prosekit/vue/autocomplete'
 
@@ -10,7 +9,7 @@ import SlashMenuItem from './slash-menu-item.vue'
 const editor = useEditor<BasicExtension>()
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+const regex =  /(?<!\S)\/(\S.*)?$/u  
 </script>
 
 <template>

--- a/registry/src/vue/ui/slash-menu/slash-menu.vue
+++ b/registry/src/vue/ui/slash-menu/slash-menu.vue
@@ -9,7 +9,7 @@ import SlashMenuItem from './slash-menu-item.vue'
 const editor = useEditor<BasicExtension>()
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex =  /(?<!\S)\/(\S.*)?$/u  
+const regex = /(?<!\S)\/(\S.*)?$/u
 </script>
 
 <template>

--- a/registry/src/vue/ui/user-menu/user-menu.vue
+++ b/registry/src/vue/ui/user-menu/user-menu.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { BasicExtension } from 'prosekit/basic'
-import { type Union } from 'prosekit/core'
+import type { Union } from 'prosekit/core'
 import type { MentionExtension } from 'prosekit/extensions/mention'
 import { useEditor } from 'prosekit/vue'
 import { AutocompleteEmpty, AutocompleteItem, AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'prosekit/vue/autocomplete'

--- a/registry/src/vue/ui/user-menu/user-menu.vue
+++ b/registry/src/vue/ui/user-menu/user-menu.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { BasicExtension } from 'prosekit/basic'
-import { canUseRegexLookbehind, type Union } from 'prosekit/core'
+import {   type Union } from 'prosekit/core'
 import type { MentionExtension } from 'prosekit/extensions/mention'
 import { useEditor } from 'prosekit/vue'
 import { AutocompleteEmpty, AutocompleteItem, AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'prosekit/vue/autocomplete'
@@ -24,7 +24,7 @@ function handleUserInsert(id: number, username: string) {
 }
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = canUseRegexLookbehind() ? /(?<!\S)@(\S.*)?$/u : /@(\S.*)?$/u
+const regex =   /(?<!\S)@(\S.*)?$/u  
 </script>
 
 <template>

--- a/registry/src/vue/ui/user-menu/user-menu.vue
+++ b/registry/src/vue/ui/user-menu/user-menu.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { BasicExtension } from 'prosekit/basic'
-import {   type Union } from 'prosekit/core'
+import { type Union } from 'prosekit/core'
 import type { MentionExtension } from 'prosekit/extensions/mention'
 import { useEditor } from 'prosekit/vue'
 import { AutocompleteEmpty, AutocompleteItem, AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'prosekit/vue/autocomplete'
@@ -24,7 +24,7 @@ function handleUserInsert(id: number, username: string) {
 }
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex =   /(?<!\S)@(\S.*)?$/u  
+const regex = /(?<!\S)@(\S.*)?$/u
 </script>
 
 <template>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Menu autocomplete (slash and mention triggers) now requires modern regex pattern support; legacy fallbacks for older engines have been removed. This may affect behavior in unsupported environments.

* **Refactor**
  * Consolidated pattern matching across menu components by removing runtime feature detection, providing consistent trigger matching behavior across frameworks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->