### PR TITLE
docs: add sponsors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Detailed changes for each release are documented in the [CHANGELOG.md](https://g
 
 See [CONTRIBUTING.md](https://github.com/ocavue/prosekit/blob/master/CONTRIBUTING.md) for details.
 
+## Sponsors
+
+<p align="center">
+	<a href="https://github.com/sponsors/ocavue">
+		<img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors">
+	</a>
+</p>
+
 ## License
 
-MIT
+[MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Sponsors section with GitHub Sponsors link and sponsor banner image
  * Updated the License section with a clickable MIT license link

<!-- end of auto-generated comment: release notes by coderabbit.ai -->