### PR TITLE
feat(registry): add lit code-block example

### DIFF
--- a/registry/package.json
+++ b/registry/package.json
@@ -14,6 +14,7 @@
   },
   "exports": {
     "./examples.gen.json": "./src/examples.gen.json",
+    "./lit/examples/code-block": "./src/lit/examples/code-block/index.ts",
     "./lit/examples/minimal": "./src/lit/examples/minimal/index.ts",
     "./lit/examples/slash-menu": "./src/lit/examples/slash-menu/index.ts",
     "./lit/examples/table": "./src/lit/examples/table/index.ts",

--- a/registry/src/examples.gen.json
+++ b/registry/src/examples.gen.json
@@ -60,6 +60,7 @@
         "react",
         "preact",
         "vue",
+        "lit",
         "svelte",
         "solid"
       ],
@@ -2471,6 +2472,25 @@
         "registry/src/vue/ui/image-upload-popover/index.ts",
         "registry/src/vue/ui/toolbar/index.ts",
         "registry/src/vue/ui/toolbar/toolbar.vue"
+      ]
+    },
+    "lit-example-code-block": {
+      "story": "code-block",
+      "files": [
+        "registry/src/lit/examples/code-block/editor.ts",
+        "registry/src/lit/examples/code-block/extension.ts",
+        "registry/src/lit/examples/code-block/index.ts",
+        "registry/src/lit/sample/sample-doc-code-block.ts",
+        "registry/src/lit/sample/sample-uploader.ts",
+        "registry/src/lit/ui/button/button.ts",
+        "registry/src/lit/ui/button/index.ts",
+        "registry/src/lit/ui/code-block-view/code-block-view.ts",
+        "registry/src/lit/ui/code-block-view/index.ts",
+        "registry/src/lit/ui/editor-context.ts",
+        "registry/src/lit/ui/image-upload-popover/image-upload-popover.ts",
+        "registry/src/lit/ui/image-upload-popover/index.ts",
+        "registry/src/lit/ui/toolbar/index.ts",
+        "registry/src/lit/ui/toolbar/toolbar.ts"
       ]
     },
     "lit-example-minimal": {

--- a/registry/src/lit/examples/code-block/editor.ts
+++ b/registry/src/lit/examples/code-block/editor.ts
@@ -1,0 +1,71 @@
+import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
+
+import '../../ui/toolbar/index'
+
+import { ContextProvider } from '@lit/context'
+import { html, LitElement, type PropertyDeclaration, type PropertyValues } from 'lit'
+import { createRef, ref, type Ref } from 'lit/directives/ref.js'
+import type { Editor } from 'prosekit/core'
+import { createEditor } from 'prosekit/core'
+
+import { sampleContent } from '../../sample/sample-doc-code-block'
+import { sampleUploader } from '../../sample/sample-uploader'
+import { editorContext } from '../../ui/editor-context'
+
+import { defineExtension } from './extension'
+
+export class LitEditor extends LitElement {
+  static override properties = {
+    editor: { state: true, attribute: false } satisfies PropertyDeclaration<Editor>,
+  }
+
+  private editor: Editor
+  private ref: Ref<HTMLDivElement>
+
+  constructor() {
+    super()
+
+    const extension = defineExtension()
+    this.editor = createEditor({ extension, defaultContent: sampleContent })
+    this.ref = createRef<HTMLDivElement>()
+    new ContextProvider(this, {
+      context: editorContext,
+      initialValue: this.editor,
+    })
+  }
+
+  override createRenderRoot() {
+    return this
+  }
+
+  override disconnectedCallback() {
+    this.editor.unmount()
+    super.disconnectedCallback()
+  }
+
+  override updated(changedProperties: PropertyValues) {
+    super.updated(changedProperties)
+    this.editor.mount(this.ref.value)
+  }
+
+  override render() {
+    return html`<div class="CSS_EDITOR_VIEWPORT">
+      <lit-editor-toolbar .uploader=${sampleUploader}></lit-editor-toolbar>
+      <div class="CSS_EDITOR_SCROLLING">
+        <div ${ref(this.ref)} class="CSS_EDITOR_CONTENT"></div>
+      </div>
+    </div>`
+  }
+}
+
+export function registerLitEditor() {
+  if (customElements.get('lit-editor-example-code-block')) return
+  customElements.define('lit-editor-example-code-block', LitEditor)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-example-code-block': LitEditor
+  }
+}

--- a/registry/src/lit/examples/code-block/extension.ts
+++ b/registry/src/lit/examples/code-block/extension.ts
@@ -1,0 +1,21 @@
+import { defineBaseKeymap, union } from 'prosekit/core'
+import { defineCodeBlock, defineCodeBlockShiki } from 'prosekit/extensions/code-block'
+import { defineDoc } from 'prosekit/extensions/doc'
+import { defineParagraph } from 'prosekit/extensions/paragraph'
+import { defineText } from 'prosekit/extensions/text'
+
+import { defineCodeBlockView } from '../../ui/code-block-view'
+
+export function defineExtension() {
+  return union(
+    defineBaseKeymap(),
+    defineDoc(),
+    defineText(),
+    defineParagraph(),
+    defineCodeBlock(),
+    defineCodeBlockShiki(),
+    defineCodeBlockView(),
+  )
+}
+
+export type EditorExtension = ReturnType<typeof defineExtension>

--- a/registry/src/lit/examples/code-block/index.ts
+++ b/registry/src/lit/examples/code-block/index.ts
@@ -1,0 +1,1 @@
+export { LitEditor as ExampleEditor, registerLitEditor } from './editor'

--- a/registry/src/lit/loaders.gen.ts
+++ b/registry/src/lit/loaders.gen.ts
@@ -1,6 +1,7 @@
 // This file is generated from update-loader.ts
 
 export const loaders = {
+  'code-block': () => import('./examples/code-block').then((m) => m.registerLitEditor()),
   'minimal': () => import('./examples/minimal').then((m) => m.registerLitEditor()),
   'slash-menu': () => import('./examples/slash-menu').then((m) => m.registerLitEditor()),
   'table': () => import('./examples/table').then((m) => m.registerLitEditor()),

--- a/registry/src/lit/sample/sample-doc-code-block.ts
+++ b/registry/src/lit/sample/sample-doc-code-block.ts
@@ -1,0 +1,50 @@
+import type { NodeJSON } from 'prosekit/core'
+
+const js = `
+async function start() {
+  while (true) {
+    await sleep()
+    await eat()
+    await code('JavaScript!')
+  }
+}
+`.trim()
+
+const py = `
+async def start():
+    while True:
+        await sleep()
+        await eat()
+        await code('Python!')
+`.trim()
+
+const go = `
+func start() {
+	for {
+		sleep()
+		eat()
+		code('Go!')
+	}
+}
+`.trim()
+
+export const sampleContent: NodeJSON = {
+  type: 'doc',
+  content: [
+    {
+      type: 'codeBlock',
+      attrs: { language: 'javascript' },
+      content: [{ type: 'text', text: js }],
+    },
+    {
+      type: 'codeBlock',
+      attrs: { language: 'python' },
+      content: [{ type: 'text', text: py }],
+    },
+    {
+      type: 'codeBlock',
+      attrs: { language: 'go' },
+      content: [{ type: 'text', text: go }],
+    },
+  ],
+}

--- a/registry/src/lit/ui/code-block-view/code-block-view.ts
+++ b/registry/src/lit/ui/code-block-view/code-block-view.ts
@@ -1,0 +1,96 @@
+import type { Extension } from 'prosekit/core'
+import { defineNodeView } from 'prosekit/core'
+import type { CodeBlockAttrs } from 'prosekit/extensions/code-block'
+import { shikiBundledLanguagesInfo } from 'prosekit/extensions/code-block'
+import type { ProseMirrorNode } from 'prosekit/pm/model'
+import type { EditorView } from 'prosekit/pm/view'
+
+class CodeBlockNodeView {
+  dom: HTMLElement
+  contentDOM: HTMLElement
+  private node: ProseMirrorNode
+  private view: EditorView
+  private getPos: () => number | undefined
+  private select: HTMLSelectElement
+  private pre: HTMLPreElement
+
+  constructor(node: ProseMirrorNode, view: EditorView, getPos: () => number | undefined) {
+    this.node = node
+    this.view = view
+    this.getPos = getPos
+
+    const root = document.createElement('div')
+    root.setAttribute('data-node-view-root', 'true')
+
+    const wrapper = document.createElement('div')
+    wrapper.className = 'CSS_LANGUAGE_WRAPPER'
+    wrapper.setAttribute('contenteditable', 'false')
+
+    this.select = document.createElement('select')
+    this.select.setAttribute('aria-label', 'Code block language')
+    this.select.className = 'CSS_LANGUAGE_SELECT'
+
+    const plain = document.createElement('option')
+    plain.value = ''
+    plain.textContent = 'Plain Text'
+    this.select.appendChild(plain)
+
+    for (const info of shikiBundledLanguagesInfo) {
+      const option = document.createElement('option')
+      option.value = info.id
+      option.textContent = info.name
+      this.select.appendChild(option)
+    }
+
+    this.select.addEventListener('change', this.handleChange)
+    wrapper.appendChild(this.select)
+
+    this.pre = document.createElement('pre')
+    this.contentDOM = document.createElement('code')
+    this.contentDOM.setAttribute('data-node-view-content', 'true')
+    this.contentDOM.style.whiteSpace = 'inherit'
+    this.pre.appendChild(this.contentDOM)
+
+    root.appendChild(wrapper)
+    root.appendChild(this.pre)
+
+    this.dom = root
+    this.syncAttrs()
+  }
+
+  private handleChange = (event: Event) => {
+    const language = (event.target as HTMLSelectElement).value
+    const pos = this.getPos()
+    if (typeof pos !== 'number') return
+    const attrs: CodeBlockAttrs = { ...(this.node.attrs as CodeBlockAttrs), language }
+    this.view.dispatch(this.view.state.tr.setNodeMarkup(pos, undefined, attrs))
+  }
+
+  private syncAttrs() {
+    const language = (this.node.attrs as CodeBlockAttrs).language || ''
+    this.select.value = language
+    if (language) {
+      this.pre.setAttribute('data-language', language)
+    } else {
+      this.pre.removeAttribute('data-language')
+    }
+  }
+
+  update(node: ProseMirrorNode) {
+    if (node.type !== this.node.type) return false
+    this.node = node
+    this.syncAttrs()
+    return true
+  }
+
+  destroy() {
+    this.select.removeEventListener('change', this.handleChange)
+  }
+}
+
+export function defineCodeBlockView(): Extension {
+  return defineNodeView({
+    name: 'codeBlock',
+    constructor: (node, view, getPos) => new CodeBlockNodeView(node, view, getPos),
+  })
+}

--- a/registry/src/lit/ui/code-block-view/index.ts
+++ b/registry/src/lit/ui/code-block-view/index.ts
@@ -1,0 +1,1 @@
+export { defineCodeBlockView } from './code-block-view'

--- a/website/src/stories/lit.stories.ts
+++ b/website/src/stories/lit.stories.ts
@@ -3,6 +3,7 @@ import component from './lit.astro'
 
 export default { component }
 
+export const CodeBlock = { args: { story: 'code-block' } }
 export const Minimal = { args: { story: 'minimal' } }
 export const SlashMenu = { args: { story: 'slash-menu' } }
 export const Table = { args: { story: 'table' } }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new code-block example for the Lit framework with multi-language support (JavaScript, Python, Go), language selection dropdown, and an integrated editor interface with toolbar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->