### PR TITLE
ci: detect registry changes and bump version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,3 +100,4 @@ jobs:
           tag: ${{ env.RELEASE_TAG }}
           body: "Please refer to [CHANGELOG.md](https://github.com/ocavue/prosekit/blob/${{ env.RELEASE_TAG }}/packages/prosekit/CHANGELOG.md) for details."
           token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
       registry: ${{ steps.filter.outputs.registry }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
 
       - id: filter
         uses: dorny/paths-filter@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,30 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  detect:
+    name: Detect changes
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      registry: ${{ steps.filter.outputs.registry }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            registry:
+              - 'registry/src/**'
+
   prepare:
     name: Prepare
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -29,8 +51,9 @@ jobs:
 
   publish:
     name: Publish
+    needs: detect
     permissions:
-      contents: write
+      contents: read
       id-token: write
     runs-on: ubuntu-latest
     steps:
@@ -38,26 +61,42 @@ jobs:
 
       - uses: ./.github/actions/setup
 
+      - name: Update registry version
+        if: needs.detect.outputs.registry == 'true'
+        run: |
+          cd registry
+          VERSION="0.0.$(date -u +%Y%m%d%H%M%S)"
+          echo "Setting registry version to ${VERSION}"
+          npm pkg set version="${VERSION}"
+
       - name: Build packages
         run: pnpm build:package
 
       - name: Publish to NPM
         run: |
-          if [ -f .changeset/pre.json ];
-          then pnpm ci:publish:beta;
-          else pnpm ci:publish:latest;
+          if [ -f .changeset/pre.json ]; then
+            pnpm ci:publish:beta
+          else
+            pnpm ci:publish:latest
           fi
 
-      - name: Get package version
-        run: |
-          PROSEKIT_VERSION=$(jq -r ".version" packages/prosekit/package.json)
-          echo "PROSEKIT_RELEASE_TAG=v${PROSEKIT_VERSION}" >> "$GITHUB_ENV"
+  github-release:
+    name: Create GitHub release
+    needs: publish
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Create GitHub release
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+      - name: Read release tag
+        run: |
+          v=$(jq -r .version packages/prosekit/package.json)
+          echo "RELEASE_TAG=v${v}" >> "$GITHUB_ENV"
+
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
-          commit: master
-          tag: "${{ env.PROSEKIT_RELEASE_TAG }}"
-          body: "Please refer to [CHANGELOG.md](https://github.com/ocavue/prosekit/blob/${{ env.PROSEKIT_RELEASE_TAG }}/packages/prosekit/CHANGELOG.md) for details."
+          commit: ${{ github.sha }}
+          tag: ${{ env.RELEASE_TAG }}
+          body: "Please refer to [CHANGELOG.md](https://github.com/ocavue/prosekit/blob/${{ env.RELEASE_TAG }}/packages/prosekit/CHANGELOG.md) for details."
           token: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true

--- a/registry/src/classes.ts
+++ b/registry/src/classes.ts
@@ -8,18 +8,15 @@ function cn(...args: Array<string | undefined | null | false>): string {
 const CSS_BUTTON_BASE = cn(
   'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white dark:ring-offset-gray-950 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-gray-900 dark:focus-visible:ring-gray-300 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-0',
 )
-
 const CSS_BUTTON_VARIANT_PRIMARY = cn(
   'bg-gray-900 dark:bg-gray-50 text-gray-50 dark:text-gray-900 hover:bg-gray-900/90 dark:hover:bg-gray-50/90',
 )
-
 const CSS_BUTTON_VARIANT_SECONDARY = cn(
   'bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-50 hover:bg-gray-100/80 dark:hover:bg-gray-800/80',
 )
 
 const CSS_BUTTON_SIZE_DEFAULT = 'h-10 px-4 py-2'
 const CSS_BUTTON_SIZE_SM = 'h-9 px-3'
-// const CSS_BUTTON_SIZE_LG = 'h-1 px-8'
 const CSS_BUTTON_SIZE_ICON = 'h-10 w-10'
 
 const CSS_INPUT = cn(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD release workflow to detect registry source changes and auto-generate timestamped registry package versions when applicable.
  * Separated and improved GitHub release creation and tagging to use the package-derived release tag and target the current commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->