### PR TITLE
fix(lit): add Lit entry points to the side effect list

### DIFF
--- a/.changeset/full-eggs-watch.md
+++ b/.changeset/full-eggs-watch.md
@@ -1,0 +1,6 @@
+---
+"prosekit": patch
+"@prosekit/lit": patch
+---
+
+Add Lit entry points to the side effect list to prevent tree shaking from removing them.

--- a/packages/prosekit/package.json
+++ b/packages/prosekit/package.json
@@ -22,7 +22,10 @@
   "keywords": [
     "ProseMirror"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./**/*.css",
+    "./dist/lit/**/*"
+  ],
   "main": "./src/index.ts",
   "module": "./src/index.ts",
   "exports": {

--- a/packages/prosekit/package.json
+++ b/packages/prosekit/package.json
@@ -24,8 +24,7 @@
   ],
   "sideEffects": [
     "./**/*.css",
-    "./src/lit/**/*",
-    "./dist/lit/**/*"
+    "./*/lit/**/*"
   ],
   "main": "./src/index.ts",
   "module": "./src/index.ts",

--- a/packages/prosekit/package.json
+++ b/packages/prosekit/package.json
@@ -24,6 +24,7 @@
   ],
   "sideEffects": [
     "./**/*.css",
+    "./src/lit/**/*",
     "./dist/lit/**/*"
   ],
   "main": "./src/index.ts",

--- a/registry/src/lit/examples/block-handle/editor.ts
+++ b/registry/src/lit/examples/block-handle/editor.ts
@@ -1,7 +1,7 @@
 import 'prosekit/basic/style.css'
 import 'prosekit/basic/typography.css'
 
-import '../../ui/block-handle'
+import { registryLitEditorBlockHandle } from '../../ui/block-handle'
 import '../../ui/drop-indicator'
 
 import { ContextProvider } from '@lit/context'
@@ -74,6 +74,8 @@ export class LitEditor extends LitElement {
 }
 
 export function registerLitEditor() {
+  registryLitEditorBlockHandle()
+
   if (customElements.get('lit-editor-example-block-handle')) return
   customElements.define('lit-editor-example-block-handle', LitEditor)
 }

--- a/registry/src/lit/examples/block-handle/editor.ts
+++ b/registry/src/lit/examples/block-handle/editor.ts
@@ -8,8 +8,8 @@ import type { Editor, NodeJSON } from 'prosekit/core'
 import { createEditor } from 'prosekit/core'
 
 import { sampleContent } from '../../sample/sample-doc-block-handle'
-import { registryLitEditorBlockHandle } from '../../ui/block-handle'
-import { registryLitEditorDropIndicator } from '../../ui/drop-indicator'
+import { registerLitEditorBlockHandle } from '../../ui/block-handle'
+import { registerLitEditorDropIndicator } from '../../ui/drop-indicator'
 import { editorContext } from '../../ui/editor-context'
 
 import { defineExtension } from './extension'
@@ -73,8 +73,8 @@ export class LitEditor extends LitElement {
 }
 
 export function registerLitEditor() {
-  registryLitEditorBlockHandle()
-  registryLitEditorDropIndicator()
+  registerLitEditorBlockHandle()
+  registerLitEditorDropIndicator()
 
   if (customElements.get('lit-editor-example-block-handle')) return
   customElements.define('lit-editor-example-block-handle', LitEditor)

--- a/registry/src/lit/examples/block-handle/editor.ts
+++ b/registry/src/lit/examples/block-handle/editor.ts
@@ -1,9 +1,6 @@
 import 'prosekit/basic/style.css'
 import 'prosekit/basic/typography.css'
 
-import { registryLitEditorBlockHandle } from '../../ui/block-handle'
-import '../../ui/drop-indicator'
-
 import { ContextProvider } from '@lit/context'
 import { html, LitElement, type PropertyDeclaration, type PropertyValues } from 'lit'
 import { createRef, ref, type Ref } from 'lit/directives/ref.js'
@@ -11,6 +8,8 @@ import type { Editor, NodeJSON } from 'prosekit/core'
 import { createEditor } from 'prosekit/core'
 
 import { sampleContent } from '../../sample/sample-doc-block-handle'
+import { registryLitEditorBlockHandle } from '../../ui/block-handle'
+import { registryLitEditorDropIndicator } from '../../ui/drop-indicator'
 import { editorContext } from '../../ui/editor-context'
 
 import { defineExtension } from './extension'
@@ -75,6 +74,7 @@ export class LitEditor extends LitElement {
 
 export function registerLitEditor() {
   registryLitEditorBlockHandle()
+  registryLitEditorDropIndicator()
 
   if (customElements.get('lit-editor-example-block-handle')) return
   customElements.define('lit-editor-example-block-handle', LitEditor)

--- a/registry/src/lit/examples/code-block/editor.ts
+++ b/registry/src/lit/examples/code-block/editor.ts
@@ -10,7 +10,7 @@ import { createEditor } from 'prosekit/core'
 import { sampleContent } from '../../sample/sample-doc-code-block'
 import { sampleUploader } from '../../sample/sample-uploader'
 import { editorContext } from '../../ui/editor-context'
-import { registryLitEditorToolbar } from '../../ui/toolbar'
+import { registerLitEditorToolbar } from '../../ui/toolbar'
 
 import { defineExtension } from './extension'
 
@@ -59,7 +59,7 @@ export class LitEditor extends LitElement {
 }
 
 export function registerLitEditor() {
-  registryLitEditorToolbar()
+  registerLitEditorToolbar()
 
   if (customElements.get('lit-editor-example-code-block')) return
   customElements.define('lit-editor-example-code-block', LitEditor)

--- a/registry/src/lit/examples/code-block/editor.ts
+++ b/registry/src/lit/examples/code-block/editor.ts
@@ -1,8 +1,6 @@
 import 'prosekit/basic/style.css'
 import 'prosekit/basic/typography.css'
 
-import '../../ui/toolbar/index'
-
 import { ContextProvider } from '@lit/context'
 import { html, LitElement, type PropertyDeclaration, type PropertyValues } from 'lit'
 import { createRef, ref, type Ref } from 'lit/directives/ref.js'
@@ -12,6 +10,7 @@ import { createEditor } from 'prosekit/core'
 import { sampleContent } from '../../sample/sample-doc-code-block'
 import { sampleUploader } from '../../sample/sample-uploader'
 import { editorContext } from '../../ui/editor-context'
+import { registryLitEditorToolbar } from '../../ui/toolbar'
 
 import { defineExtension } from './extension'
 
@@ -60,6 +59,8 @@ export class LitEditor extends LitElement {
 }
 
 export function registerLitEditor() {
+  registryLitEditorToolbar()
+
   if (customElements.get('lit-editor-example-code-block')) return
   customElements.define('lit-editor-example-code-block', LitEditor)
 }

--- a/registry/src/lit/examples/slash-menu/editor.ts
+++ b/registry/src/lit/examples/slash-menu/editor.ts
@@ -1,8 +1,6 @@
 import 'prosekit/basic/style.css'
 import 'prosekit/basic/typography.css'
 
-import '../../ui/slash-menu/index'
-
 import { ContextProvider } from '@lit/context'
 import { html, LitElement, type PropertyDeclaration, type PropertyValues } from 'lit'
 import { createRef, ref, type Ref } from 'lit/directives/ref.js'
@@ -10,6 +8,7 @@ import type { Editor } from 'prosekit/core'
 import { createEditor } from 'prosekit/core'
 
 import { editorContext } from '../../ui/editor-context'
+import { registryLitEditorSlashMenu } from '../../ui/slash-menu'
 
 import { defineExtension } from './extension'
 
@@ -60,6 +59,8 @@ export class LitEditor extends LitElement {
 }
 
 export function registerLitEditor() {
+  registryLitEditorSlashMenu()
+
   if (customElements.get('lit-editor-example-slash-menu')) return
   customElements.define('lit-editor-example-slash-menu', LitEditor)
 }

--- a/registry/src/lit/examples/slash-menu/editor.ts
+++ b/registry/src/lit/examples/slash-menu/editor.ts
@@ -8,7 +8,7 @@ import type { Editor } from 'prosekit/core'
 import { createEditor } from 'prosekit/core'
 
 import { editorContext } from '../../ui/editor-context'
-import { registryLitEditorSlashMenu } from '../../ui/slash-menu'
+import { registerLitEditorSlashMenu } from '../../ui/slash-menu'
 
 import { defineExtension } from './extension'
 
@@ -59,7 +59,7 @@ export class LitEditor extends LitElement {
 }
 
 export function registerLitEditor() {
-  registryLitEditorSlashMenu()
+  registerLitEditorSlashMenu()
 
   if (customElements.get('lit-editor-example-slash-menu')) return
   customElements.define('lit-editor-example-slash-menu', LitEditor)

--- a/registry/src/lit/examples/table/editor.ts
+++ b/registry/src/lit/examples/table/editor.ts
@@ -9,7 +9,7 @@ import { createEditor } from 'prosekit/core'
 
 import { sampleContent } from '../../sample/sample-doc-table'
 import { editorContext } from '../../ui/editor-context'
-import { registryLitEditorTableHandle } from '../../ui/table-handle'
+import { registerLitEditorTableHandle } from '../../ui/table-handle'
 
 import { defineExtension } from './extension'
 
@@ -69,7 +69,7 @@ export class LitEditor extends LitElement {
 }
 
 export function registerLitEditor() {
-  registryLitEditorTableHandle()
+  registerLitEditorTableHandle()
 
   if (customElements.get('lit-editor-example-table')) return
   customElements.define('lit-editor-example-table', LitEditor)

--- a/registry/src/lit/examples/table/editor.ts
+++ b/registry/src/lit/examples/table/editor.ts
@@ -1,8 +1,6 @@
 import 'prosekit/basic/style.css'
 import 'prosekit/basic/typography.css'
 
-import '../../ui/table-handle/index'
-
 import { ContextProvider } from '@lit/context'
 import { html, LitElement, type PropertyDeclaration, type PropertyValues } from 'lit'
 import { createRef, ref, type Ref } from 'lit/directives/ref.js'
@@ -11,6 +9,7 @@ import { createEditor } from 'prosekit/core'
 
 import { sampleContent } from '../../sample/sample-doc-table'
 import { editorContext } from '../../ui/editor-context'
+import { registryLitEditorTableHandle } from '../../ui/table-handle'
 
 import { defineExtension } from './extension'
 
@@ -70,6 +69,8 @@ export class LitEditor extends LitElement {
 }
 
 export function registerLitEditor() {
+  registryLitEditorTableHandle()
+
   if (customElements.get('lit-editor-example-table')) return
   customElements.define('lit-editor-example-table', LitEditor)
 }

--- a/registry/src/lit/examples/toolbar/editor.ts
+++ b/registry/src/lit/examples/toolbar/editor.ts
@@ -9,7 +9,7 @@ import { createEditor } from 'prosekit/core'
 
 import { sampleUploader } from '../../sample/sample-uploader'
 import { editorContext } from '../../ui/editor-context'
-import { registryLitEditorToolbar } from '../../ui/toolbar'
+import { registerLitEditorToolbar } from '../../ui/toolbar'
 
 import { defineExtension } from './extension'
 
@@ -60,7 +60,7 @@ export class LitEditor extends LitElement {
 }
 
 export function registerLitEditor() {
-  registryLitEditorToolbar()
+  registerLitEditorToolbar()
 
   if (customElements.get('lit-editor-example-toolbar')) return
   customElements.define('lit-editor-example-toolbar', LitEditor)

--- a/registry/src/lit/examples/toolbar/editor.ts
+++ b/registry/src/lit/examples/toolbar/editor.ts
@@ -1,8 +1,6 @@
 import 'prosekit/basic/style.css'
 import 'prosekit/basic/typography.css'
 
-import '../../ui/toolbar/index'
-
 import { ContextProvider } from '@lit/context'
 import { html, LitElement, type PropertyDeclaration, type PropertyValues } from 'lit'
 import { createRef, ref, type Ref } from 'lit/directives/ref.js'
@@ -11,6 +9,7 @@ import { createEditor } from 'prosekit/core'
 
 import { sampleUploader } from '../../sample/sample-uploader'
 import { editorContext } from '../../ui/editor-context'
+import { registryLitEditorToolbar } from '../../ui/toolbar'
 
 import { defineExtension } from './extension'
 
@@ -61,6 +60,8 @@ export class LitEditor extends LitElement {
 }
 
 export function registerLitEditor() {
+  registryLitEditorToolbar()
+
   if (customElements.get('lit-editor-example-toolbar')) return
   customElements.define('lit-editor-example-toolbar', LitEditor)
 }

--- a/registry/src/lit/ui/block-handle/block-handle.ts
+++ b/registry/src/lit/ui/block-handle/block-handle.ts
@@ -40,3 +40,14 @@ export class LitBlockHandle extends LitElement {
     </prosekit-block-handle-root>`
   }
 }
+
+export function registryLitEditorBlockHandle() {
+  if (customElements.get('lit-editor-block-handle')) return
+  customElements.define('lit-editor-block-handle', LitBlockHandle)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-block-handle': LitBlockHandle
+  }
+}

--- a/registry/src/lit/ui/block-handle/block-handle.ts
+++ b/registry/src/lit/ui/block-handle/block-handle.ts
@@ -1,4 +1,10 @@
-import 'prosekit/lit/block-handle'
+import {
+registerBlockHandleAddElement,
+registerBlockHandleDraggableElement,
+registerBlockHandlePopupElement,
+registerBlockHandlePositionerElement,
+registerBlockHandleRootElement  ,
+} from  'prosekit/lit/block-handle'
 
 import { ContextConsumer } from '@lit/context'
 import { html, LitElement } from 'lit'
@@ -42,6 +48,12 @@ class LitBlockHandle extends LitElement {
 }
 
 export function registerLitEditorBlockHandle() {
+  registerBlockHandleAddElement()
+  registerBlockHandleDraggableElement()
+  registerBlockHandlePopupElement()
+  registerBlockHandlePositionerElement()
+  registerBlockHandleRootElement()
+
   if (customElements.get('lit-editor-block-handle')) return
   customElements.define('lit-editor-block-handle', LitBlockHandle)
 }

--- a/registry/src/lit/ui/block-handle/block-handle.ts
+++ b/registry/src/lit/ui/block-handle/block-handle.ts
@@ -5,7 +5,7 @@ import { html, LitElement } from 'lit'
 
 import { editorContext } from '../editor-context'
 
-export class LitBlockHandle extends LitElement {
+class LitBlockHandle extends LitElement {
   declare dir: 'ltr' | 'rtl' | 'auto'
 
   private _editorConsumer = new ContextConsumer(this, {

--- a/registry/src/lit/ui/block-handle/block-handle.ts
+++ b/registry/src/lit/ui/block-handle/block-handle.ts
@@ -5,7 +5,6 @@ import { html, LitElement } from 'lit'
 
 import { editorContext } from '../editor-context'
 
-/** @public */
 export class LitBlockHandle extends LitElement {
   declare dir: 'ltr' | 'rtl' | 'auto'
 
@@ -39,13 +38,5 @@ export class LitBlockHandle extends LitElement {
         </prosekit-block-handle-popup>
       </prosekit-block-handle-positioner>
     </prosekit-block-handle-root>`
-  }
-}
-
-customElements.define('lit-editor-block-handle', LitBlockHandle)
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'lit-editor-block-handle': LitBlockHandle
   }
 }

--- a/registry/src/lit/ui/block-handle/block-handle.ts
+++ b/registry/src/lit/ui/block-handle/block-handle.ts
@@ -1,13 +1,12 @@
-import {
-registerBlockHandleAddElement,
-registerBlockHandleDraggableElement,
-registerBlockHandlePopupElement,
-registerBlockHandlePositionerElement,
-registerBlockHandleRootElement  ,
-} from  'prosekit/lit/block-handle'
-
 import { ContextConsumer } from '@lit/context'
 import { html, LitElement } from 'lit'
+import {
+  registerBlockHandleAddElement,
+  registerBlockHandleDraggableElement,
+  registerBlockHandlePopupElement,
+  registerBlockHandlePositionerElement,
+  registerBlockHandleRootElement,
+} from 'prosekit/lit/block-handle'
 
 import { editorContext } from '../editor-context'
 

--- a/registry/src/lit/ui/block-handle/block-handle.ts
+++ b/registry/src/lit/ui/block-handle/block-handle.ts
@@ -41,7 +41,7 @@ export class LitBlockHandle extends LitElement {
   }
 }
 
-export function registryLitEditorBlockHandle() {
+export function registerLitEditorBlockHandle() {
   if (customElements.get('lit-editor-block-handle')) return
   customElements.define('lit-editor-block-handle', LitBlockHandle)
 }

--- a/registry/src/lit/ui/block-handle/index.ts
+++ b/registry/src/lit/ui/block-handle/index.ts
@@ -1,12 +1,1 @@
-import { LitBlockHandle } from './block-handle'
-
-export function registryLitEditorBlockHandle() {
-  if (customElements.get('lit-editor-block-handle')) return
-  customElements.define('lit-editor-block-handle', LitBlockHandle)
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'lit-editor-block-handle': LitBlockHandle
-  }
-}
+export { registryLitEditorBlockHandle } from './block-handle'

--- a/registry/src/lit/ui/block-handle/index.ts
+++ b/registry/src/lit/ui/block-handle/index.ts
@@ -1,1 +1,1 @@
-export { registryLitEditorBlockHandle } from './block-handle'
+export { registerLitEditorBlockHandle } from './block-handle'

--- a/registry/src/lit/ui/block-handle/index.ts
+++ b/registry/src/lit/ui/block-handle/index.ts
@@ -1,4 +1,4 @@
-import { LitBlockHandle } from "./block-handle"
+import { LitBlockHandle } from './block-handle'
 
 export function registryLitEditorBlockHandle() {
   if (customElements.get('lit-editor-block-handle')) return

--- a/registry/src/lit/ui/block-handle/index.ts
+++ b/registry/src/lit/ui/block-handle/index.ts
@@ -1,1 +1,12 @@
-import './block-handle'
+import { LitBlockHandle } from "./block-handle"
+
+export function registryLitEditorBlockHandle() {
+  if (customElements.get('lit-editor-block-handle')) return
+  customElements.define('lit-editor-block-handle', LitBlockHandle)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-block-handle': LitBlockHandle
+  }
+}

--- a/registry/src/lit/ui/button/button.ts
+++ b/registry/src/lit/ui/button/button.ts
@@ -58,3 +58,14 @@ export class LitButton extends LitElement {
     `
   }
 }
+
+export function registryLitEditorButton() {
+  if (customElements.get('lit-editor-button')) return
+  customElements.define('lit-editor-button', LitButton)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-button': LitButton
+  }
+}

--- a/registry/src/lit/ui/button/button.ts
+++ b/registry/src/lit/ui/button/button.ts
@@ -2,7 +2,7 @@ import 'prosekit/lit/tooltip'
 
 import { html, LitElement, nothing, type PropertyDeclaration } from 'lit'
 
-class LitButton extends LitElement {
+export class LitButton extends LitElement {
   static override properties = {
     pressed: { type: Boolean },
     disabled: { type: Boolean },
@@ -56,13 +56,5 @@ class LitButton extends LitElement {
           : nothing}
       </prosekit-tooltip-root>
     `
-  }
-}
-
-customElements.define('lit-editor-button', LitButton)
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'lit-editor-button': LitButton
   }
 }

--- a/registry/src/lit/ui/button/button.ts
+++ b/registry/src/lit/ui/button/button.ts
@@ -1,11 +1,10 @@
+import { html, LitElement, nothing, type PropertyDeclaration } from 'lit'
 import {
   registerTooltipPopupElement,
   registerTooltipPositionerElement,
   registerTooltipRootElement,
   registerTooltipTriggerElement,
 } from 'prosekit/lit/tooltip'
-
-import { html, LitElement, nothing, type PropertyDeclaration } from 'lit'
 
 class LitButton extends LitElement {
   static override properties = {

--- a/registry/src/lit/ui/button/button.ts
+++ b/registry/src/lit/ui/button/button.ts
@@ -59,7 +59,7 @@ export class LitButton extends LitElement {
   }
 }
 
-export function registryLitEditorButton() {
+export function registerLitEditorButton() {
   if (customElements.get('lit-editor-button')) return
   customElements.define('lit-editor-button', LitButton)
 }

--- a/registry/src/lit/ui/button/button.ts
+++ b/registry/src/lit/ui/button/button.ts
@@ -2,7 +2,7 @@ import 'prosekit/lit/tooltip'
 
 import { html, LitElement, nothing, type PropertyDeclaration } from 'lit'
 
-export class LitButton extends LitElement {
+class LitButton extends LitElement {
   static override properties = {
     pressed: { type: Boolean },
     disabled: { type: Boolean },

--- a/registry/src/lit/ui/button/button.ts
+++ b/registry/src/lit/ui/button/button.ts
@@ -1,4 +1,9 @@
-import 'prosekit/lit/tooltip'
+import {
+  registerTooltipPopupElement,
+  registerTooltipPositionerElement,
+  registerTooltipRootElement,
+  registerTooltipTriggerElement,
+} from 'prosekit/lit/tooltip'
 
 import { html, LitElement, nothing, type PropertyDeclaration } from 'lit'
 
@@ -60,6 +65,11 @@ class LitButton extends LitElement {
 }
 
 export function registerLitEditorButton() {
+  registerTooltipPopupElement()
+  registerTooltipPositionerElement()
+  registerTooltipRootElement()
+  registerTooltipTriggerElement()
+
   if (customElements.get('lit-editor-button')) return
   customElements.define('lit-editor-button', LitButton)
 }

--- a/registry/src/lit/ui/button/index.ts
+++ b/registry/src/lit/ui/button/index.ts
@@ -1,1 +1,12 @@
-import './button'
+import { LitButton } from './button'
+
+export function registryLitEditorButton() {
+  if (customElements.get('lit-editor-button')) return
+  customElements.define('lit-editor-button', LitButton)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-button': LitButton
+  }
+}

--- a/registry/src/lit/ui/button/index.ts
+++ b/registry/src/lit/ui/button/index.ts
@@ -1,12 +1,1 @@
-import { LitButton } from './button'
-
-export function registryLitEditorButton() {
-  if (customElements.get('lit-editor-button')) return
-  customElements.define('lit-editor-button', LitButton)
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'lit-editor-button': LitButton
-  }
-}
+export { registryLitEditorButton } from './button'

--- a/registry/src/lit/ui/button/index.ts
+++ b/registry/src/lit/ui/button/index.ts
@@ -1,1 +1,1 @@
-export { registryLitEditorButton } from './button'
+export { registerLitEditorButton } from './button'

--- a/registry/src/lit/ui/drop-indicator/drop-indicator.ts
+++ b/registry/src/lit/ui/drop-indicator/drop-indicator.ts
@@ -5,7 +5,6 @@ import { html, LitElement } from 'lit'
 
 import { editorContext } from '../editor-context'
 
-/** @public */
 export class LitDropIndicator extends LitElement {
   private _editorConsumer = new ContextConsumer(this, {
     context: editorContext,
@@ -26,13 +25,5 @@ export class LitDropIndicator extends LitElement {
       .editor=${this._editorConsumer.value ?? null}
       class="CSS_DROP_INDICATOR"
     ></prosekit-drop-indicator>`
-  }
-}
-
-customElements.define('lit-editor-drop-indicator', LitDropIndicator)
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'lit-editor-drop-indicator': LitDropIndicator
   }
 }

--- a/registry/src/lit/ui/drop-indicator/drop-indicator.ts
+++ b/registry/src/lit/ui/drop-indicator/drop-indicator.ts
@@ -28,7 +28,7 @@ export class LitDropIndicator extends LitElement {
   }
 }
 
-export function registryLitEditorDropIndicator() {
+export function registerLitEditorDropIndicator() {
   if (customElements.get('lit-editor-drop-indicator')) return
   customElements.define('lit-editor-drop-indicator', LitDropIndicator)
 }

--- a/registry/src/lit/ui/drop-indicator/drop-indicator.ts
+++ b/registry/src/lit/ui/drop-indicator/drop-indicator.ts
@@ -5,7 +5,7 @@ import { html, LitElement } from 'lit'
 
 import { editorContext } from '../editor-context'
 
-export class LitDropIndicator extends LitElement {
+class LitDropIndicator extends LitElement {
   private _editorConsumer = new ContextConsumer(this, {
     context: editorContext,
     subscribe: true,

--- a/registry/src/lit/ui/drop-indicator/drop-indicator.ts
+++ b/registry/src/lit/ui/drop-indicator/drop-indicator.ts
@@ -1,4 +1,4 @@
-import 'prosekit/lit/drop-indicator'
+import { registerDropIndicatorElement } from 'prosekit/lit/drop-indicator'
 
 import { ContextConsumer } from '@lit/context'
 import { html, LitElement } from 'lit'
@@ -29,6 +29,8 @@ class LitDropIndicator extends LitElement {
 }
 
 export function registerLitEditorDropIndicator() {
+  registerDropIndicatorElement()
+
   if (customElements.get('lit-editor-drop-indicator')) return
   customElements.define('lit-editor-drop-indicator', LitDropIndicator)
 }

--- a/registry/src/lit/ui/drop-indicator/drop-indicator.ts
+++ b/registry/src/lit/ui/drop-indicator/drop-indicator.ts
@@ -1,7 +1,6 @@
-import { registerDropIndicatorElement } from 'prosekit/lit/drop-indicator'
-
 import { ContextConsumer } from '@lit/context'
 import { html, LitElement } from 'lit'
+import { registerDropIndicatorElement } from 'prosekit/lit/drop-indicator'
 
 import { editorContext } from '../editor-context'
 

--- a/registry/src/lit/ui/drop-indicator/drop-indicator.ts
+++ b/registry/src/lit/ui/drop-indicator/drop-indicator.ts
@@ -27,3 +27,14 @@ export class LitDropIndicator extends LitElement {
     ></prosekit-drop-indicator>`
   }
 }
+
+export function registryLitEditorDropIndicator() {
+  if (customElements.get('lit-editor-drop-indicator')) return
+  customElements.define('lit-editor-drop-indicator', LitDropIndicator)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-drop-indicator': LitDropIndicator
+  }
+}

--- a/registry/src/lit/ui/drop-indicator/index.ts
+++ b/registry/src/lit/ui/drop-indicator/index.ts
@@ -1,12 +1,1 @@
-import { LitDropIndicator } from './drop-indicator'
-
-export function registryLitEditorDropIndicator() {
-  if (customElements.get('lit-editor-drop-indicator')) return
-  customElements.define('lit-editor-drop-indicator', LitDropIndicator)
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'lit-editor-drop-indicator': LitDropIndicator
-  }
-}
+export { registryLitEditorDropIndicator } from './drop-indicator'

--- a/registry/src/lit/ui/drop-indicator/index.ts
+++ b/registry/src/lit/ui/drop-indicator/index.ts
@@ -1,1 +1,12 @@
-import './drop-indicator'
+import { LitDropIndicator } from './drop-indicator'
+
+export function registryLitEditorDropIndicator() {
+  if (customElements.get('lit-editor-drop-indicator')) return
+  customElements.define('lit-editor-drop-indicator', LitDropIndicator)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-drop-indicator': LitDropIndicator
+  }
+}

--- a/registry/src/lit/ui/drop-indicator/index.ts
+++ b/registry/src/lit/ui/drop-indicator/index.ts
@@ -1,1 +1,1 @@
-export { registryLitEditorDropIndicator } from './drop-indicator'
+export { registerLitEditorDropIndicator } from './drop-indicator'

--- a/registry/src/lit/ui/image-upload-popover/image-upload-popover.ts
+++ b/registry/src/lit/ui/image-upload-popover/image-upload-popover.ts
@@ -3,6 +3,7 @@ import type { Editor } from 'prosekit/core'
 import type { Uploader } from 'prosekit/extensions/file'
 import type { ImageExtension } from 'prosekit/extensions/image'
 import type { OpenChangeEvent } from 'prosekit/lit/popover'
+
 import { registryLitEditorButton } from '../button'
 
 let imageUploadId = 0

--- a/registry/src/lit/ui/image-upload-popover/image-upload-popover.ts
+++ b/registry/src/lit/ui/image-upload-popover/image-upload-popover.ts
@@ -8,7 +8,7 @@ import { registerLitEditorButton } from '../button'
 
 let imageUploadId = 0
 
-export class LitImageUploadPopover extends LitElement {
+class LitImageUploadPopover extends LitElement {
   static override properties = {
     editor: { attribute: false } satisfies PropertyDeclaration<Editor>,
     uploader: { attribute: false } satisfies PropertyDeclaration<Uploader<string>>,

--- a/registry/src/lit/ui/image-upload-popover/image-upload-popover.ts
+++ b/registry/src/lit/ui/image-upload-popover/image-upload-popover.ts
@@ -1,5 +1,3 @@
-import '../button/index'
-
 import { html, LitElement, nothing, type PropertyDeclaration } from 'lit'
 import type { Editor } from 'prosekit/core'
 import type { Uploader } from 'prosekit/extensions/file'
@@ -8,7 +6,7 @@ import type { OpenChangeEvent } from 'prosekit/lit/popover'
 
 let imageUploadId = 0
 
-class LitImageUploadPopover extends LitElement {
+export class LitImageUploadPopover extends LitElement {
   static override properties = {
     editor: { attribute: false } satisfies PropertyDeclaration<Editor>,
     uploader: { attribute: false } satisfies PropertyDeclaration<Uploader<string>>,
@@ -154,13 +152,5 @@ class LitImageUploadPopover extends LitElement {
         </prosekit-popover-positioner>
       </prosekit-popover-root>
     `
-  }
-}
-
-customElements.define('lit-editor-image-upload-popover', LitImageUploadPopover)
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'lit-editor-image-upload-popover': LitImageUploadPopover
   }
 }

--- a/registry/src/lit/ui/image-upload-popover/image-upload-popover.ts
+++ b/registry/src/lit/ui/image-upload-popover/image-upload-popover.ts
@@ -4,7 +4,7 @@ import type { Uploader } from 'prosekit/extensions/file'
 import type { ImageExtension } from 'prosekit/extensions/image'
 import type { OpenChangeEvent } from 'prosekit/lit/popover'
 
-import { registryLitEditorButton } from '../button'
+import { registerLitEditorButton } from '../button'
 
 let imageUploadId = 0
 
@@ -157,8 +157,8 @@ export class LitImageUploadPopover extends LitElement {
   }
 }
 
-export function registryLitEditorImageUploadPopover() {
-  registryLitEditorButton()
+export function registerLitEditorImageUploadPopover() {
+  registerLitEditorButton()
 
   if (customElements.get('lit-editor-image-upload-popover')) return
   customElements.define('lit-editor-image-upload-popover', LitImageUploadPopover)

--- a/registry/src/lit/ui/image-upload-popover/image-upload-popover.ts
+++ b/registry/src/lit/ui/image-upload-popover/image-upload-popover.ts
@@ -2,7 +2,13 @@ import { html, LitElement, nothing, type PropertyDeclaration } from 'lit'
 import type { Editor } from 'prosekit/core'
 import type { Uploader } from 'prosekit/extensions/file'
 import type { ImageExtension } from 'prosekit/extensions/image'
-import type { OpenChangeEvent } from 'prosekit/lit/popover'
+import {
+  registerPopoverPopupElement,
+  registerPopoverPositionerElement,
+  registerPopoverRootElement,
+  registerPopoverTriggerElement,
+  type OpenChangeEvent,
+} from 'prosekit/lit/popover'
 
 import { registerLitEditorButton } from '../button'
 
@@ -159,6 +165,10 @@ class LitImageUploadPopover extends LitElement {
 
 export function registerLitEditorImageUploadPopover() {
   registerLitEditorButton()
+  registerPopoverPopupElement()
+  registerPopoverPositionerElement()
+  registerPopoverRootElement()
+  registerPopoverTriggerElement()
 
   if (customElements.get('lit-editor-image-upload-popover')) return
   customElements.define('lit-editor-image-upload-popover', LitImageUploadPopover)

--- a/registry/src/lit/ui/image-upload-popover/image-upload-popover.ts
+++ b/registry/src/lit/ui/image-upload-popover/image-upload-popover.ts
@@ -3,6 +3,7 @@ import type { Editor } from 'prosekit/core'
 import type { Uploader } from 'prosekit/extensions/file'
 import type { ImageExtension } from 'prosekit/extensions/image'
 import type { OpenChangeEvent } from 'prosekit/lit/popover'
+import { registryLitEditorButton } from '../button'
 
 let imageUploadId = 0
 
@@ -152,5 +153,18 @@ export class LitImageUploadPopover extends LitElement {
         </prosekit-popover-positioner>
       </prosekit-popover-root>
     `
+  }
+}
+
+export function registryLitEditorImageUploadPopover() {
+  registryLitEditorButton()
+
+  if (customElements.get('lit-editor-image-upload-popover')) return
+  customElements.define('lit-editor-image-upload-popover', LitImageUploadPopover)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-image-upload-popover': LitImageUploadPopover
   }
 }

--- a/registry/src/lit/ui/image-upload-popover/index.ts
+++ b/registry/src/lit/ui/image-upload-popover/index.ts
@@ -1,1 +1,1 @@
-export {registryLitEditorImageUploadPopover}from './image-upload-popover'
+export { registryLitEditorImageUploadPopover } from './image-upload-popover'

--- a/registry/src/lit/ui/image-upload-popover/index.ts
+++ b/registry/src/lit/ui/image-upload-popover/index.ts
@@ -1,1 +1,1 @@
-export { registryLitEditorImageUploadPopover } from './image-upload-popover'
+export { registerLitEditorImageUploadPopover } from './image-upload-popover'

--- a/registry/src/lit/ui/image-upload-popover/index.ts
+++ b/registry/src/lit/ui/image-upload-popover/index.ts
@@ -1,1 +1,16 @@
-import './image-upload-popover'
+import { registryLitEditorButton } from '../button'
+
+import { LitImageUploadPopover } from './image-upload-popover'
+
+export function registryLitEditorImageUploadPopover() {
+  registryLitEditorButton()
+
+  if (customElements.get('lit-editor-image-upload-popover')) return
+  customElements.define('lit-editor-image-upload-popover', LitImageUploadPopover)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-image-upload-popover': LitImageUploadPopover
+  }
+}

--- a/registry/src/lit/ui/image-upload-popover/index.ts
+++ b/registry/src/lit/ui/image-upload-popover/index.ts
@@ -1,16 +1,1 @@
-import { registryLitEditorButton } from '../button'
-
-import { LitImageUploadPopover } from './image-upload-popover'
-
-export function registryLitEditorImageUploadPopover() {
-  registryLitEditorButton()
-
-  if (customElements.get('lit-editor-image-upload-popover')) return
-  customElements.define('lit-editor-image-upload-popover', LitImageUploadPopover)
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'lit-editor-image-upload-popover': LitImageUploadPopover
-  }
-}
+export {registryLitEditorImageUploadPopover}from './image-upload-popover'

--- a/registry/src/lit/ui/slash-menu/index.ts
+++ b/registry/src/lit/ui/slash-menu/index.ts
@@ -1,1 +1,1 @@
-export { registryLitEditorSlashMenu } from './slash-menu'
+export { registerLitEditorSlashMenu } from './slash-menu'

--- a/registry/src/lit/ui/slash-menu/index.ts
+++ b/registry/src/lit/ui/slash-menu/index.ts
@@ -1,3 +1,14 @@
-import './slash-menu'
-import './slash-menu-item'
-import './slash-menu-empty'
+import { SlashMenuElement } from './slash-menu'
+import { SlashMenuEmptyElement } from './slash-menu-empty'
+import { SlashMenuItemElement } from './slash-menu-item'
+
+export function registryLitEditorSlashMenu() {
+  if (!customElements.get('lit-editor-slash-menu-item')) {
+    customElements.define('lit-editor-slash-menu-item', SlashMenuItemElement)
+  }
+  if (!customElements.get('lit-editor-slash-menu-empty')) {
+    customElements.define('lit-editor-slash-menu-empty', SlashMenuEmptyElement)
+  }
+  if (customElements.get('lit-editor-slash-menu')) return
+  customElements.define('lit-editor-slash-menu', SlashMenuElement)
+}

--- a/registry/src/lit/ui/slash-menu/index.ts
+++ b/registry/src/lit/ui/slash-menu/index.ts
@@ -1,14 +1,1 @@
-import { SlashMenuElement } from './slash-menu'
-import { SlashMenuEmptyElement } from './slash-menu-empty'
-import { SlashMenuItemElement } from './slash-menu-item'
-
-export function registryLitEditorSlashMenu() {
-  if (!customElements.get('lit-editor-slash-menu-item')) {
-    customElements.define('lit-editor-slash-menu-item', SlashMenuItemElement)
-  }
-  if (!customElements.get('lit-editor-slash-menu-empty')) {
-    customElements.define('lit-editor-slash-menu-empty', SlashMenuEmptyElement)
-  }
-  if (customElements.get('lit-editor-slash-menu')) return
-  customElements.define('lit-editor-slash-menu', SlashMenuElement)
-}
+export { registryLitEditorSlashMenu } from './slash-menu'

--- a/registry/src/lit/ui/slash-menu/slash-menu-empty.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu-empty.ts
@@ -1,5 +1,3 @@
-import 'prosekit/lit/autocomplete'
-
 import { html, LitElement } from 'lit'
 
 export class SlashMenuEmptyElement extends LitElement {

--- a/registry/src/lit/ui/slash-menu/slash-menu-empty.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu-empty.ts
@@ -2,7 +2,7 @@ import 'prosekit/lit/autocomplete'
 
 import { html, LitElement } from 'lit'
 
-class SlashMenuEmptyElement extends LitElement {
+export class SlashMenuEmptyElement extends LitElement {
   override createRenderRoot() {
     return this
   }
@@ -15,5 +15,3 @@ class SlashMenuEmptyElement extends LitElement {
     `
   }
 }
-
-customElements.define('lit-editor-slash-menu-empty', SlashMenuEmptyElement)

--- a/registry/src/lit/ui/slash-menu/slash-menu-item.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu-item.ts
@@ -1,5 +1,3 @@
-import 'prosekit/lit/autocomplete'
-
 import { html, LitElement } from 'lit'
 
 export class SlashMenuItemElement extends LitElement {

--- a/registry/src/lit/ui/slash-menu/slash-menu-item.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu-item.ts
@@ -2,7 +2,7 @@ import 'prosekit/lit/autocomplete'
 
 import { html, LitElement } from 'lit'
 
-class SlashMenuItemElement extends LitElement {
+export class SlashMenuItemElement extends LitElement {
   static override properties = {
     label: { type: String },
     kbd: { type: String },
@@ -37,5 +37,3 @@ class SlashMenuItemElement extends LitElement {
     </prosekit-autocomplete-item>`
   }
 }
-
-customElements.define('lit-editor-slash-menu-item', SlashMenuItemElement)

--- a/registry/src/lit/ui/slash-menu/slash-menu.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu.ts
@@ -1,3 +1,8 @@
+import { ContextConsumer } from '@lit/context'
+import { html, LitElement } from 'lit'
+import type { BasicExtension } from 'prosekit/basic'
+import type { Editor } from 'prosekit/core'
+import { canUseRegexLookbehind } from 'prosekit/core'
 import {
   registerAutocompleteEmptyElement,
   registerAutocompleteItemElement,
@@ -5,12 +10,6 @@ import {
   registerAutocompletePositionerElement,
   registerAutocompleteRootElement,
 } from 'prosekit/lit/autocomplete'
-
-import { ContextConsumer } from '@lit/context'
-import { html, LitElement } from 'lit'
-import type { BasicExtension } from 'prosekit/basic'
-import type { Editor } from 'prosekit/core'
-import { canUseRegexLookbehind } from 'prosekit/core'
 
 import { editorContext } from '../editor-context'
 

--- a/registry/src/lit/ui/slash-menu/slash-menu.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu.ts
@@ -112,7 +112,7 @@ export class SlashMenuElement extends LitElement {
   }
 }
 
-export function registryLitEditorSlashMenu() {
+export function registerLitEditorSlashMenu() {
   if (!customElements.get('lit-editor-slash-menu-item')) {
     customElements.define('lit-editor-slash-menu-item', SlashMenuItemElement)
   }

--- a/registry/src/lit/ui/slash-menu/slash-menu.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu.ts
@@ -1,4 +1,10 @@
-import 'prosekit/lit/autocomplete'
+import {
+  registerAutocompleteEmptyElement,
+  registerAutocompleteItemElement,
+  registerAutocompletePopupElement,
+  registerAutocompletePositionerElement,
+  registerAutocompleteRootElement,
+} from 'prosekit/lit/autocomplete'
 
 import { ContextConsumer } from '@lit/context'
 import { html, LitElement } from 'lit'
@@ -113,6 +119,12 @@ class SlashMenuElement extends LitElement {
 }
 
 export function registerLitEditorSlashMenu() {
+  registerAutocompleteEmptyElement()
+  registerAutocompleteItemElement()
+  registerAutocompletePopupElement()
+  registerAutocompletePositionerElement()
+  registerAutocompleteRootElement()
+
   if (!customElements.get('lit-editor-slash-menu-item')) {
     customElements.define('lit-editor-slash-menu-item', SlashMenuItemElement)
   }

--- a/registry/src/lit/ui/slash-menu/slash-menu.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu.ts
@@ -8,6 +8,9 @@ import { canUseRegexLookbehind } from 'prosekit/core'
 
 import { editorContext } from '../editor-context'
 
+import { SlashMenuEmptyElement } from './slash-menu-empty'
+import { SlashMenuItemElement } from './slash-menu-item'
+
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
 const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
 
@@ -107,4 +110,15 @@ export class SlashMenuElement extends LitElement {
       </prosekit-autocomplete-positioner>
     </prosekit-autocomplete-root>`
   }
+}
+
+export function registryLitEditorSlashMenu() {
+  if (!customElements.get('lit-editor-slash-menu-item')) {
+    customElements.define('lit-editor-slash-menu-item', SlashMenuItemElement)
+  }
+  if (!customElements.get('lit-editor-slash-menu-empty')) {
+    customElements.define('lit-editor-slash-menu-empty', SlashMenuEmptyElement)
+  }
+  if (customElements.get('lit-editor-slash-menu')) return
+  customElements.define('lit-editor-slash-menu', SlashMenuElement)
 }

--- a/registry/src/lit/ui/slash-menu/slash-menu.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu.ts
@@ -11,7 +11,7 @@ import { editorContext } from '../editor-context'
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
 const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
 
-class SlashMenuElement extends LitElement {
+export class SlashMenuElement extends LitElement {
   private editorConsumer = new ContextConsumer(this, {
     context: editorContext,
     subscribe: true,
@@ -108,5 +108,3 @@ class SlashMenuElement extends LitElement {
     </prosekit-autocomplete-root>`
   }
 }
-
-customElements.define('lit-editor-slash-menu', SlashMenuElement)

--- a/registry/src/lit/ui/slash-menu/slash-menu.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu.ts
@@ -14,7 +14,7 @@ import { SlashMenuItemElement } from './slash-menu-item'
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
 const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
 
-export class SlashMenuElement extends LitElement {
+class SlashMenuElement extends LitElement {
   private editorConsumer = new ContextConsumer(this, {
     context: editorContext,
     subscribe: true,

--- a/registry/src/lit/ui/table-handle/index.ts
+++ b/registry/src/lit/ui/table-handle/index.ts
@@ -1,1 +1,1 @@
-export { registryLitEditorTableHandle } from './table-handle'
+export { registerLitEditorTableHandle } from './table-handle'

--- a/registry/src/lit/ui/table-handle/index.ts
+++ b/registry/src/lit/ui/table-handle/index.ts
@@ -1,1 +1,12 @@
-import './table-handle'
+import { LitTableHandle } from './table-handle'
+
+export function registryLitEditorTableHandle() {
+  if (customElements.get('lit-editor-table-handle')) return
+  customElements.define('lit-editor-table-handle', LitTableHandle)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-table-handle': LitTableHandle
+  }
+}

--- a/registry/src/lit/ui/table-handle/index.ts
+++ b/registry/src/lit/ui/table-handle/index.ts
@@ -1,12 +1,1 @@
-import { LitTableHandle } from './table-handle'
-
-export function registryLitEditorTableHandle() {
-  if (customElements.get('lit-editor-table-handle')) return
-  customElements.define('lit-editor-table-handle', LitTableHandle)
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'lit-editor-table-handle': LitTableHandle
-  }
-}
+export { registryLitEditorTableHandle } from './table-handle'

--- a/registry/src/lit/ui/table-handle/table-handle.ts
+++ b/registry/src/lit/ui/table-handle/table-handle.ts
@@ -234,3 +234,14 @@ export class LitTableHandle extends LitElement {
     </prosekit-table-handle-root>`
   }
 }
+
+export function registryLitEditorTableHandle() {
+  if (customElements.get('lit-editor-table-handle')) return
+  customElements.define('lit-editor-table-handle', LitTableHandle)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-table-handle': LitTableHandle
+  }
+}

--- a/registry/src/lit/ui/table-handle/table-handle.ts
+++ b/registry/src/lit/ui/table-handle/table-handle.ts
@@ -235,7 +235,7 @@ export class LitTableHandle extends LitElement {
   }
 }
 
-export function registryLitEditorTableHandle() {
+export function registerLitEditorTableHandle() {
   if (customElements.get('lit-editor-table-handle')) return
   customElements.define('lit-editor-table-handle', LitTableHandle)
 }

--- a/registry/src/lit/ui/table-handle/table-handle.ts
+++ b/registry/src/lit/ui/table-handle/table-handle.ts
@@ -1,3 +1,8 @@
+import { ContextConsumer } from '@lit/context'
+import { html, LitElement, nothing, type PropertyDeclaration, type PropertyValues } from 'lit'
+import type { Editor } from 'prosekit/core'
+import { defineUpdateHandler } from 'prosekit/core'
+import type { TableExtension } from 'prosekit/extensions/table'
 import {
   registerMenuItemElement,
   registerMenuPopupElement,
@@ -16,12 +21,6 @@ import {
   registerTableHandleRowPopupElement,
   registerTableHandleRowPositionerElement,
 } from 'prosekit/lit/table-handle'
-
-import { ContextConsumer } from '@lit/context'
-import { html, LitElement, nothing, type PropertyDeclaration, type PropertyValues } from 'lit'
-import type { Editor } from 'prosekit/core'
-import { defineUpdateHandler } from 'prosekit/core'
-import type { TableExtension } from 'prosekit/extensions/table'
 
 import { editorContext } from '../editor-context'
 

--- a/registry/src/lit/ui/table-handle/table-handle.ts
+++ b/registry/src/lit/ui/table-handle/table-handle.ts
@@ -1,5 +1,21 @@
-import 'prosekit/lit/table-handle'
-import 'prosekit/web/menu'
+import {
+  registerMenuItemElement,
+  registerMenuPopupElement,
+  registerMenuPositionerElement,
+} from 'prosekit/lit/menu'
+import {
+  registerTableHandleColumnMenuRootElement,
+  registerTableHandleColumnMenuTriggerElement,
+  registerTableHandleColumnPopupElement,
+  registerTableHandleColumnPositionerElement,
+  registerTableHandleDragPreviewElement,
+  registerTableHandleDropIndicatorElement,
+  registerTableHandleRootElement,
+  registerTableHandleRowMenuRootElement,
+  registerTableHandleRowMenuTriggerElement,
+  registerTableHandleRowPopupElement,
+  registerTableHandleRowPositionerElement,
+} from 'prosekit/lit/table-handle'
 
 import { ContextConsumer } from '@lit/context'
 import { html, LitElement, nothing, type PropertyDeclaration, type PropertyValues } from 'lit'
@@ -236,6 +252,21 @@ class LitTableHandle extends LitElement {
 }
 
 export function registerLitEditorTableHandle() {
+  registerMenuItemElement()
+  registerMenuPopupElement()
+  registerMenuPositionerElement()
+  registerTableHandleColumnMenuRootElement()
+  registerTableHandleColumnMenuTriggerElement()
+  registerTableHandleColumnPopupElement()
+  registerTableHandleColumnPositionerElement()
+  registerTableHandleDragPreviewElement()
+  registerTableHandleDropIndicatorElement()
+  registerTableHandleRootElement()
+  registerTableHandleRowMenuRootElement()
+  registerTableHandleRowMenuTriggerElement()
+  registerTableHandleRowPopupElement()
+  registerTableHandleRowPositionerElement()
+
   if (customElements.get('lit-editor-table-handle')) return
   customElements.define('lit-editor-table-handle', LitTableHandle)
 }

--- a/registry/src/lit/ui/table-handle/table-handle.ts
+++ b/registry/src/lit/ui/table-handle/table-handle.ts
@@ -46,7 +46,7 @@ function getTableHandleState(editor: Editor<TableExtension>) {
   }
 }
 
-class LitTableHandle extends LitElement {
+export class LitTableHandle extends LitElement {
   static override properties = {
     dir: { type: String } satisfies PropertyDeclaration<'ltr' | 'rtl'>,
   }
@@ -232,13 +232,5 @@ class LitTableHandle extends LitElement {
         </prosekit-table-handle-row-popup>
       </prosekit-table-handle-row-positioner>
     </prosekit-table-handle-root>`
-  }
-}
-
-customElements.define('lit-editor-table-handle', LitTableHandle)
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'lit-editor-table-handle': LitTableHandle
   }
 }

--- a/registry/src/lit/ui/table-handle/table-handle.ts
+++ b/registry/src/lit/ui/table-handle/table-handle.ts
@@ -46,7 +46,7 @@ function getTableHandleState(editor: Editor<TableExtension>) {
   }
 }
 
-export class LitTableHandle extends LitElement {
+class LitTableHandle extends LitElement {
   static override properties = {
     dir: { type: String } satisfies PropertyDeclaration<'ltr' | 'rtl'>,
   }

--- a/registry/src/lit/ui/toolbar/index.ts
+++ b/registry/src/lit/ui/toolbar/index.ts
@@ -1,1 +1,18 @@
-import './toolbar'
+import { registryLitEditorButton } from '../button'
+import { registryLitEditorImageUploadPopover } from '../image-upload-popover'
+
+import { LitToolbar } from './toolbar'
+
+export function registryLitEditorToolbar() {
+  registryLitEditorButton()
+  registryLitEditorImageUploadPopover()
+
+  if (customElements.get('lit-editor-toolbar')) return
+  customElements.define('lit-editor-toolbar', LitToolbar)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-toolbar': LitToolbar
+  }
+}

--- a/registry/src/lit/ui/toolbar/index.ts
+++ b/registry/src/lit/ui/toolbar/index.ts
@@ -1,18 +1,1 @@
-import { registryLitEditorButton } from '../button'
-import { registryLitEditorImageUploadPopover } from '../image-upload-popover'
-
-import { LitToolbar } from './toolbar'
-
-export function registryLitEditorToolbar() {
-  registryLitEditorButton()
-  registryLitEditorImageUploadPopover()
-
-  if (customElements.get('lit-editor-toolbar')) return
-  customElements.define('lit-editor-toolbar', LitToolbar)
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'lit-editor-toolbar': LitToolbar
-  }
-}
+export { registryLitEditorToolbar } from './toolbar'

--- a/registry/src/lit/ui/toolbar/index.ts
+++ b/registry/src/lit/ui/toolbar/index.ts
@@ -1,1 +1,1 @@
-export { registryLitEditorToolbar } from './toolbar'
+export { registerLitEditorToolbar } from './toolbar'

--- a/registry/src/lit/ui/toolbar/toolbar.ts
+++ b/registry/src/lit/ui/toolbar/toolbar.ts
@@ -4,7 +4,9 @@ import type { BasicExtension } from 'prosekit/basic'
 import { defineUpdateHandler, type Editor } from 'prosekit/core'
 import type { Uploader } from 'prosekit/extensions/file'
 
+import { registryLitEditorButton } from '../button'
 import { editorContext } from '../editor-context'
+import { registryLitEditorImageUploadPopover } from '../image-upload-popover'
 
 function getToolbarItems(editor: Editor<BasicExtension>) {
   return {
@@ -430,5 +432,19 @@ export class LitToolbar extends LitElement {
           : nothing}
       </div>
     `
+  }
+}
+
+export function registryLitEditorToolbar() {
+  registryLitEditorButton()
+  registryLitEditorImageUploadPopover()
+
+  if (customElements.get('lit-editor-toolbar')) return
+  customElements.define('lit-editor-toolbar', LitToolbar)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-toolbar': LitToolbar
   }
 }

--- a/registry/src/lit/ui/toolbar/toolbar.ts
+++ b/registry/src/lit/ui/toolbar/toolbar.ts
@@ -1,6 +1,3 @@
-import '../button/index'
-import '../image-upload-popover/index'
-
 import { ContextConsumer } from '@lit/context'
 import { html, LitElement, nothing, type PropertyDeclaration, type PropertyValues } from 'lit'
 import type { BasicExtension } from 'prosekit/basic'
@@ -153,7 +150,7 @@ function getToolbarItems(editor: Editor<BasicExtension>) {
   }
 }
 
-class LitToolbar extends LitElement {
+export class LitToolbar extends LitElement {
   static override properties = {
     uploader: { attribute: false } satisfies PropertyDeclaration<Uploader<string>>,
   }
@@ -433,13 +430,5 @@ class LitToolbar extends LitElement {
           : nothing}
       </div>
     `
-  }
-}
-
-customElements.define('lit-editor-toolbar', LitToolbar)
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'lit-editor-toolbar': LitToolbar
   }
 }

--- a/registry/src/lit/ui/toolbar/toolbar.ts
+++ b/registry/src/lit/ui/toolbar/toolbar.ts
@@ -152,7 +152,7 @@ function getToolbarItems(editor: Editor<BasicExtension>) {
   }
 }
 
-export class LitToolbar extends LitElement {
+class LitToolbar extends LitElement {
   static override properties = {
     uploader: { attribute: false } satisfies PropertyDeclaration<Uploader<string>>,
   }

--- a/registry/src/lit/ui/toolbar/toolbar.ts
+++ b/registry/src/lit/ui/toolbar/toolbar.ts
@@ -4,9 +4,9 @@ import type { BasicExtension } from 'prosekit/basic'
 import { defineUpdateHandler, type Editor } from 'prosekit/core'
 import type { Uploader } from 'prosekit/extensions/file'
 
-import { registryLitEditorButton } from '../button'
+import { registerLitEditorButton } from '../button'
 import { editorContext } from '../editor-context'
-import { registryLitEditorImageUploadPopover } from '../image-upload-popover'
+import { registerLitEditorImageUploadPopover } from '../image-upload-popover'
 
 function getToolbarItems(editor: Editor<BasicExtension>) {
   return {
@@ -435,9 +435,9 @@ export class LitToolbar extends LitElement {
   }
 }
 
-export function registryLitEditorToolbar() {
-  registryLitEditorButton()
-  registryLitEditorImageUploadPopover()
+export function registerLitEditorToolbar() {
+  registerLitEditorButton()
+  registerLitEditorImageUploadPopover()
 
   if (customElements.get('lit-editor-toolbar')) return
   customElements.define('lit-editor-toolbar', LitToolbar)


### PR DESCRIPTION
Before


https://github.com/user-attachments/assets/fa729626-cd5e-407e-88c8-66bf332976f7

After



https://github.com/user-attachments/assets/51a649b1-364f-4ec8-858d-ced71610a2fa





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Converted Lit UI components to explicit registration functions for improved tree-shaking control and more predictable component initialization.
  * Updated build configuration to preserve Lit components and CSS files during bundling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->