### PR TITLE
feat(core): add spec patch extensions

### DIFF
--- a/packages/core/src/extensions/mark-spec.spec.ts
+++ b/packages/core/src/extensions/mark-spec.spec.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 import { union } from '../editor/union.ts'
 import { defineDoc, defineParagraph, defineText, setupTestFromExtension } from '../testing/index.ts'
 
-import { defineMarkAttr, defineMarkSpec } from './mark-spec.ts'
+import { defineMarkAttr, defineMarkSpec, defineMarkSpecPatch } from './mark-spec.ts'
 
 describe('defineMarkSpec', () => {
   it('can merge mark specs', () => {
@@ -56,6 +56,34 @@ describe('defineMarkSpec', () => {
         baz: { default: 'baz:2' },
       },
     })
+  })
+
+  it('can patch mark spec', () => {
+    const extension = union(
+      defineMarkSpec({
+        name: 'bold',
+        parseDOM: [{ tag: 'strong' }],
+        toDOM: () => ['strong', 0],
+      }),
+      defineMarkSpecPatch({
+        type: 'bold',
+        patch: (spec) => ({
+          ...spec,
+          parseDOM: [
+            ...(spec.parseDOM ?? []),
+            { tag: 'b' },
+          ],
+        }),
+      }),
+      defineDoc(),
+      defineText(),
+      defineParagraph(),
+    )
+
+    expect(extension.schema?.spec.marks.get('bold')?.parseDOM).toEqual([
+      { tag: 'strong' },
+      { tag: 'b' },
+    ])
   })
 })
 

--- a/packages/core/src/extensions/mark-spec.ts
+++ b/packages/core/src/extensions/mark-spec.ts
@@ -6,7 +6,7 @@ import { defineFacetPayload } from '../facets/facet-extension.ts'
 import { defineFacet } from '../facets/facet.ts'
 import { schemaSpecFacet } from '../facets/schema-spec.ts'
 import type { AnyAttrs, AttrSpec } from '../types/attrs.ts'
-import type { Extension } from '../types/extension.ts'
+import type { Extension, PlainExtension } from '../types/extension.ts'
 import { assert } from '../utils/assert.ts'
 import { mergeSpecs } from '../utils/merge-specs.ts'
 import { wrapOutputSpecAttrs, wrapParseRuleAttrs } from '../utils/output-spec.ts'
@@ -64,6 +64,21 @@ export interface MarkAttrOptions<
 }
 
 /**
+ * @public
+ */
+export interface MarkSpecPatchOptions<MarkName extends string = string> {
+  /**
+   * The name of the mark type to patch.
+   */
+  type: MarkName
+
+  /**
+   * Receives the merged mark spec and returns a patched mark spec.
+   */
+  patch: (spec: MarkSpec) => MarkSpec
+}
+
+/**
  * Defines a mark type into the editor schema.
  *
  * @public
@@ -91,7 +106,7 @@ export function defineMarkSpec<
 ): Extension<{
   Marks: { [K in Mark]: Attrs }
 }> {
-  const payload: MarkSpecPayload = [options, undefined]
+  const payload: MarkSpecPayload = [options, undefined, undefined]
   return defineFacetPayload(markSpecFacet, [payload]) as Extension<{
     Marks: any
   }>
@@ -109,15 +124,30 @@ export function defineMarkAttr<
 ): Extension<{
   Marks: { [K in MarkType]: AttrType }
 }> {
-  const payload: MarkSpecPayload = [undefined, options]
+  const payload: MarkSpecPayload = [undefined, options, undefined]
   return defineFacetPayload(markSpecFacet, [payload]) as Extension<{
     Marks: any
   }>
 }
 
+/**
+ * Patches a mark type after all mark specs and mark attrs are merged.
+ *
+ * @public
+ */
+export function defineMarkSpecPatch<
+  MarkType extends string = string,
+>(
+  options: MarkSpecPatchOptions<MarkType>,
+): PlainExtension {
+  const payload: MarkSpecPayload = [undefined, undefined, options]
+  return defineFacetPayload(markSpecFacet, [payload]) as PlainExtension
+}
+
 type MarkSpecPayload = [
   MarkSpecOptions | undefined,
   MarkAttrOptions | undefined,
+  MarkSpecPatchOptions | undefined,
 ]
 
 const markSpecFacet = defineFacet<MarkSpecPayload, SchemaSpec>({
@@ -126,14 +156,13 @@ const markSpecFacet = defineFacet<MarkSpecPayload, SchemaSpec>({
 
     const specPayloads = payloads.map((input) => input[0]).filter(isNotNullish)
     const attrPayloads = payloads.map((input) => input[1]).filter(isNotNullish)
+    const patchPayloads = payloads.map((input) => input[2]).filter(isNotNullish)
 
     for (const { name, ...spec } of specPayloads) {
       const prevSpec = specs.get(name)
       if (prevSpec) {
         specs = specs.update(name, mergeSpecs(prevSpec, spec))
       } else {
-        // The latest spec has the highest priority, so we put it at the start
-        // of the map.
         specs = specs.addToStart(name, spec)
       }
     }
@@ -161,6 +190,23 @@ const markSpecFacet = defineFacet<MarkSpecPayload, SchemaSpec>({
 
       if (oldSpec.parseDOM) {
         newSpec.parseDOM = oldSpec.parseDOM.map((rule) => wrapParseRuleAttrs(rule, attrs))
+      }
+
+      specs = specs.update(type, newSpec)
+    }
+
+    const groupedPatches = mapGroupBy(patchPayloads, (payload) => payload.type)
+
+    for (const [type, patches] of groupedPatches.entries()) {
+      if (!patches) continue
+
+      const oldSpec = specs.get(type)
+      assert(oldSpec, `Mark type ${type} must be defined`)
+
+      let newSpec = { ...oldSpec, attrs: oldSpec.attrs ? { ...oldSpec.attrs } : undefined } satisfies MarkSpec
+
+      for (const { patch } of patches) {
+        newSpec = patch(newSpec)
       }
 
       specs = specs.update(type, newSpec)

--- a/packages/core/src/extensions/node-spec.spec.ts
+++ b/packages/core/src/extensions/node-spec.spec.ts
@@ -7,7 +7,7 @@ import { defineDoc, defineParagraph, defineText, setupTestFromExtension } from '
 
 import { defineHistory } from './history.ts'
 import { defineBaseKeymap } from './keymap-base.ts'
-import { defineNodeAttr, defineNodeSpec } from './node-spec.ts'
+import { defineNodeAttr, defineNodeSpec, defineNodeSpecPatch } from './node-spec.ts'
 
 describe('defineNodeSpec', () => {
   it('can merge node specs', () => {
@@ -106,6 +106,68 @@ describe('defineNodeSpec', () => {
 
     expect(schema6 === schema5).toBe(true)
   })
+
+  it('can patch node spec toDOM and parseDOM', () => {
+    const extension = union(
+      defineDoc(),
+      defineText(),
+      defineParagraph(),
+      defineNodeSpecPatch({
+        type: 'paragraph',
+        patch: (spec) => ({
+          ...spec,
+          toDOM: () => ['p', { 'data-patched': 'yes' }, 0],
+          parseDOM: [
+            ...(spec.parseDOM ?? []),
+            { tag: 'p[data-patched="yes"]' },
+          ],
+        }),
+      }),
+    )
+
+    const spec = extension.schema?.spec.nodes.get('paragraph')
+    expect(spec?.parseDOM).toEqual([
+      { tag: 'p' },
+      { tag: 'p[data-patched="yes"]' },
+    ])
+    expect(spec?.toDOM?.(null as never)).toEqual([
+      'p',
+      { 'data-patched': 'yes' },
+      0,
+    ])
+  })
+
+  it('applies multiple node spec patches in order', () => {
+    const extension = union(
+      defineDoc(),
+      defineText(),
+      defineNodeSpec({
+        name: 'paragraph',
+        content: 'text*',
+        parseDOM: [{ tag: 'p' }],
+        toDOM: () => ['p', 0],
+      }),
+      defineNodeSpecPatch({
+        type: 'paragraph',
+        patch: (spec) => ({
+          ...spec,
+          group: 'block',
+        }),
+      }),
+      defineNodeSpecPatch({
+        type: 'paragraph',
+        patch: (spec) => ({
+          ...spec,
+          defining: true,
+        }),
+      }),
+    )
+
+    expect(extension.schema?.spec.nodes.get('paragraph')).toMatchObject({
+      group: 'block',
+      defining: true,
+    })
+  })
 })
 
 describe('defineNodeAttr', () => {
@@ -181,6 +243,30 @@ describe('defineNodeAttr', () => {
     editor.setContent(html1)
     const json2 = editor.getDocJSON()
     expect(json2).toEqual(json1)
+  })
+
+  it('applies node spec patch after node attrs', () => {
+    const extension = union(
+      defineDoc(),
+      defineText(),
+      defineParagraph(),
+      defineNodeAttr({
+        type: 'paragraph',
+        attr: 'nodeId',
+        default: null,
+        toDOM: (value) => (value ? ['data-node-id', value] : null),
+        parseDOM: (node: HTMLElement) => node.dataset.nodeId ?? null,
+      }),
+      defineNodeSpecPatch({
+        type: 'paragraph',
+        patch: (spec) => {
+          expect(spec.attrs?.nodeId).toBeTruthy()
+          return spec
+        },
+      }),
+    )
+
+    expect(extension.schema?.spec.nodes.get('paragraph')?.attrs?.nodeId).toBeTruthy()
   })
 })
 

--- a/packages/core/src/extensions/node-spec.ts
+++ b/packages/core/src/extensions/node-spec.ts
@@ -6,7 +6,7 @@ import { defineFacetPayload } from '../facets/facet-extension.ts'
 import { defineFacet } from '../facets/facet.ts'
 import { schemaSpecFacet } from '../facets/schema-spec.ts'
 import type { AnyAttrs, AttrSpec } from '../types/attrs.ts'
-import type { Extension } from '../types/extension.ts'
+import type { Extension, PlainExtension } from '../types/extension.ts'
 import { assert } from '../utils/assert.ts'
 import { mergeSpecs } from '../utils/merge-specs.ts'
 import { wrapOutputSpecAttrs, wrapTagParseRuleAttrs } from '../utils/output-spec.ts'
@@ -81,6 +81,21 @@ export interface NodeAttrOptions<
 }
 
 /**
+ * @public
+ */
+export interface NodeSpecPatchOptions<NodeName extends string = string> {
+  /**
+   * The name of the node type to patch.
+   */
+  type: NodeName
+
+  /**
+   * Receives the merged node spec and returns a patched node spec.
+   */
+  patch: (spec: NodeSpec) => NodeSpec
+}
+
+/**
  * Defines a node type into the editor schema.
  *
  * @public
@@ -107,7 +122,7 @@ export function defineNodeSpec<
 ): Extension<{
   Nodes: { [K in Node]: Attrs }
 }> {
-  const payload: NodeSpecPayload = [options, undefined]
+  const payload: NodeSpecPayload = [options, undefined, undefined]
   return defineFacetPayload(nodeSpecFacet, [payload]) as Extension<{
     Nodes: any
   }>
@@ -127,15 +142,30 @@ export function defineNodeAttr<
 ): Extension<{
   Nodes: { [K in NodeType]: { [K in AttrName]: AttrType } }
 }> {
-  const payload: NodeSpecPayload = [undefined, options]
+  const payload: NodeSpecPayload = [undefined, options, undefined]
   return defineFacetPayload(nodeSpecFacet, [payload]) as Extension<{
     Nodes: any
   }>
 }
 
+/**
+ * Patches a node type after all node specs and node attrs are merged.
+ *
+ * @public
+ */
+export function defineNodeSpecPatch<
+  NodeType extends string = string,
+>(
+  options: NodeSpecPatchOptions<NodeType>,
+): PlainExtension {
+  const payload: NodeSpecPayload = [undefined, undefined, options]
+  return defineFacetPayload(nodeSpecFacet, [payload]) as PlainExtension
+}
+
 type NodeSpecPayload = [
   NodeSpecOptions | undefined,
   NodeAttrOptions | undefined,
+  NodeSpecPatchOptions | undefined,
 ]
 
 const nodeSpecFacet = defineFacet<NodeSpecPayload, SchemaSpec>({
@@ -145,6 +175,7 @@ const nodeSpecFacet = defineFacet<NodeSpecPayload, SchemaSpec>({
 
     const specPayloads = payloads.map((input) => input[0]).filter(isNotNullish)
     const attrPayloads = payloads.map((input) => input[1]).filter(isNotNullish)
+    const patchPayloads = payloads.map((input) => input[2]).filter(isNotNullish)
 
     for (const { name, topNode, ...spec } of specPayloads) {
       if (topNode) {
@@ -155,8 +186,6 @@ const nodeSpecFacet = defineFacet<NodeSpecPayload, SchemaSpec>({
       if (prevSpec) {
         specs = specs.update(name, mergeSpecs(prevSpec, spec))
       } else {
-        // The latest spec has the highest priority, so we put it at the start
-        // of the map.
         specs = specs.addToStart(name, spec)
       }
     }
@@ -185,6 +214,23 @@ const nodeSpecFacet = defineFacet<NodeSpecPayload, SchemaSpec>({
 
       if (oldSpec.parseDOM) {
         newSpec.parseDOM = oldSpec.parseDOM.map((rule) => wrapTagParseRuleAttrs(rule, attrs))
+      }
+
+      specs = specs.update(type, newSpec)
+    }
+
+    const groupedPatches = mapGroupBy(patchPayloads, (payload) => payload.type)
+
+    for (const [type, patches] of groupedPatches.entries()) {
+      if (!patches) continue
+
+      const oldSpec = specs.get(type)
+      assert(oldSpec, `Node type ${type} must be defined`)
+
+      let newSpec = { ...oldSpec, attrs: oldSpec.attrs ? { ...oldSpec.attrs } : undefined } satisfies NodeSpec
+
+      for (const { patch } of patches) {
+        newSpec = patch(newSpec)
       }
 
       specs = specs.update(type, newSpec)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,36 +1,102 @@
-/**
- * The core module of ProseKit.
- *
- * @module
- */
-
-export { addMark, type AddMarkOptions } from './commands/add-mark.ts'
-export { expandMark, type ExpandMarkOptions } from './commands/expand-mark.ts'
-export { insertDefaultBlock, type InsertDefaultBlockOptions } from './commands/insert-default-block.ts'
-export { insertNode, type InsertNodeOptions } from './commands/insert-node.ts'
-export { removeMark, type RemoveMarkOptions } from './commands/remove-mark.ts'
-export { removeNode, type RemoveNodeOptions } from './commands/remove-node.ts'
-export { selectAll } from './commands/select-all.ts'
-export { selectBlock } from './commands/select-block.ts'
-export { setBlockType, type SetBlockTypeOptions } from './commands/set-block-type.ts'
-export { setNodeAttrsBetween, type SetNodeAttrsBetweenOptions } from './commands/set-node-attrs-between.ts'
-export { setNodeAttrs, type SetNodeAttrsOptions } from './commands/set-node-attrs.ts'
-export { toggleMark, type ToggleMarkOptions } from './commands/toggle-mark.ts'
-export { toggleNode, type ToggleNodeOptions } from './commands/toggle-node.ts'
-export { toggleWrap, type ToggleWrapOptions } from './commands/toggle-wrap.ts'
-export { unsetBlockType, type UnsetBlockTypeOptions } from './commands/unset-block-type.ts'
-export { unsetMark, type UnsetMarkOptions } from './commands/unset-mark.ts'
-export { wrap, type WrapOptions } from './commands/wrap.ts'
-export type { MarkAction, NodeAction, NodeChild } from './editor/action.ts'
-export { createEditor, Editor, type EditorOptions } from './editor/editor.ts'
-export { union } from './editor/union.ts'
-export { withPriority } from './editor/with-priority.ts'
-export { EditorNotFoundError, ProseKitError } from './error.ts'
-export { defineClipboardSerializer, type ClipboardSerializerOptions } from './extensions/clipboard-serializer.ts'
-export { defineBaseCommands, defineCommands, type BaseCommandsExtension } from './extensions/command.ts'
-export { defineDefaultState, type DefaultStateOptions } from './extensions/default-state.ts'
-export { defineDocChangeHandler, type DocChangeHandler } from './extensions/events/doc-change.ts'
-export { defineDOMEventHandler, type DOMEventHandler } from './extensions/events/dom-event.ts'
+export {
+  addMark,
+  type AddMarkOptions,
+} from './commands/add-mark'
+export {
+  expandMark,
+  type ExpandMarkOptions,
+} from './commands/expand-mark'
+export {
+  insertDefaultBlock,
+  type InsertDefaultBlockOptions,
+} from './commands/insert-default-block'
+export {
+  insertNode,
+  type InsertNodeOptions,
+} from './commands/insert-node'
+export {
+  removeMark,
+  type RemoveMarkOptions,
+} from './commands/remove-mark'
+export {
+  removeNode,
+  type RemoveNodeOptions,
+} from './commands/remove-node'
+export {
+  setBlockType,
+  type SetBlockTypeOptions,
+} from './commands/set-block-type'
+export {
+  setNodeAttrs,
+  type SetNodeAttrsOptions,
+} from './commands/set-node-attrs'
+export {
+  toggleMark,
+  type ToggleMarkOptions,
+} from './commands/toggle-mark'
+export {
+  toggleNode,
+  type ToggleNodeOptions,
+} from './commands/toggle-node'
+export {
+  toggleWrap,
+  type ToggleWrapOptions,
+} from './commands/toggle-wrap'
+export {
+  unsetBlockType,
+  type UnsetBlockTypeOptions,
+} from './commands/unset-block-type'
+export {
+  unsetMark,
+  type UnsetMarkOptions,
+} from './commands/unset-mark'
+export {
+  wrap,
+  type WrapOptions,
+} from './commands/wrap'
+export type {
+  MarkAction,
+  MarkBuilder,
+  NodeAction,
+  NodeBuilder,
+  NodeChild,
+} from './editor/action'
+export {
+  createEditor,
+  Editor,
+  type EditorOptions,
+} from './editor/editor'
+export { union } from './editor/union'
+export { withPriority } from './editor/with-priority'
+export {
+  EditorNotFoundError,
+  ProseKitError,
+} from './error'
+export {
+  defineClipboardSerializer,
+  type ClipboardSerializerOptions,
+} from './extensions/clipboard-serializer'
+export {
+  defineBaseCommands,
+  defineCommands,
+  type BaseCommandsExtension,
+} from './extensions/command'
+export {
+  defineDefaultState,
+  type DefaultStateOptions,
+} from './extensions/default-state'
+export {
+  defineDoc,
+  type DocExtension,
+} from './extensions/doc'
+export {
+  defineDocChangeHandler,
+  type DocChangeHandler,
+} from './extensions/events/doc-change'
+export {
+  defineDOMEventHandler,
+  type DOMEventHandler,
+} from './extensions/events/dom-event'
 export {
   defineClickHandler,
   defineClickOnHandler,
@@ -58,8 +124,11 @@ export {
   type TextInputHandler,
   type TripleClickHandler,
   type TripleClickOnHandler,
-} from './extensions/events/editor-event.ts'
-export { defineFocusChangeHandler, type FocusChangeHandler } from './extensions/events/focus.ts'
+} from './extensions/events/editor-event'
+export {
+  defineFocusChangeHandler,
+  type FocusChangeHandler,
+} from './extensions/events/focus'
 export {
   defineMountHandler,
   defineUnmountHandler,
@@ -67,38 +136,87 @@ export {
   type MountHandler,
   type UnmountHandler,
   type UpdateHandler,
-} from './extensions/events/plugin-view.ts'
-export { defineHistory, type HistoryExtension, type HistoryOptions } from './extensions/history.ts'
-export { defineBaseKeymap, type BaseKeymapExtension, type BaseKeymapOptions } from './extensions/keymap-base.ts'
-export { defineKeymap, keymapFacet, type Keymap, type KeymapPayload } from './extensions/keymap.ts'
-export { defineMarkAttr, defineMarkSpec, type MarkAttrOptions, type MarkSpecOptions } from './extensions/mark-spec.ts'
+} from './extensions/events/plugin-view'
+export {
+  defineHistory,
+  type HistoryExtension,
+  type HistoryOptions,
+} from './extensions/history'
+export {
+  defineKeymap,
+  keymapFacet,
+  type Keymap,
+  type KeymapPayload,
+} from './extensions/keymap'
+export {
+  defineBaseKeymap,
+  type BaseKeymapExtension,
+} from './extensions/keymap-base'
+export {
+  defineMarkAttr,
+  defineMarkSpec,
+  defineMarkSpecPatch,
+  type MarkAttrOptions,
+  type MarkSpecPatchOptions,
+  type MarkSpecOptions,
+} from './extensions/mark-spec'
+export {
+  defineMarkView,
+  type MarkViewOptions,
+} from './extensions/mark-view'
 export {
   defineMarkViewComponent,
   defineMarkViewFactory,
   type MarkViewComponentOptions,
   type MarkViewFactoryOptions,
-} from './extensions/mark-view-effect.ts'
-export { defineMarkView, type MarkViewOptions } from './extensions/mark-view.ts'
-export { defineNodeAttr, defineNodeSpec, type NodeAttrOptions, type NodeSpecOptions } from './extensions/node-spec.ts'
+} from './extensions/mark-view-effect'
+export {
+  defineNodeAttr,
+  defineNodeSpec,
+  defineNodeSpecPatch,
+  type NodeAttrOptions,
+  type NodeSpecPatchOptions,
+  type NodeSpecOptions,
+} from './extensions/node-spec'
+export {
+  defineNodeView,
+  type NodeViewOptions,
+} from './extensions/node-view'
 export {
   defineNodeViewComponent,
   defineNodeViewFactory,
   type NodeViewComponentOptions,
   type NodeViewFactoryOptions,
-} from './extensions/node-view-effect.ts'
-export { defineNodeView, type NodeViewOptions } from './extensions/node-view.ts'
-export { definePlugin, pluginFacet, type PluginPayload } from './extensions/plugin.ts'
-export { defineFacetPayload } from './facets/facet-extension.ts'
-export { defineFacet, type Facet } from './facets/facet.ts'
-export type { AnyFunction } from './types/any-function.ts'
-export type { AnyAttrs, AttrSpec } from './types/attrs.ts'
-export type { CommandAction, CommandTyping } from './types/extension-command.ts'
-export type { MarkTyping, ToMarkAction } from './types/extension-mark.ts'
-export type { NodeTyping, ToNodeAction } from './types/extension-node.ts'
+} from './extensions/node-view-effect'
+export {
+  defineParagraph,
+  type ParagraphExtension,
+} from './extensions/paragraph'
+export {
+  definePlugin,
+  pluginFacet,
+  type PluginPayload,
+} from './extensions/plugin'
+export {
+  defineText,
+  type TextExtension,
+} from './extensions/text'
+export {
+  defineFacet,
+  type Facet,
+} from './facets/facet'
+export { defineFacetPayload } from './facets/facet-extension'
+export type { AnyFunction } from './types/any-function'
+export type {
+  AnyAttrs,
+  AttrSpec,
+} from './types/attrs'
+export type { BaseNodeViewOptions } from './types/base-node-view-options'
 export type {
   Extension,
   ExtensionTyping,
   ExtractCommandActions,
+  ExtractCommandAppliers,
   ExtractCommandCreators,
   ExtractCommands,
   ExtractMarkActions,
@@ -108,28 +226,54 @@ export type {
   ExtractTyping,
   PlainExtension,
   Union,
-} from './types/extension.ts'
-export type { NodeJSON, SelectionJSON, StateJSON, StepJSON } from './types/model.ts'
-export type { PickSubType } from './types/pick-sub-type.ts'
-export { Priority } from './types/priority.ts'
-export type { SimplifyDeeper } from './types/simplify-deeper.ts'
-export type { SimplifyUnion } from './types/simplify-union.ts'
-export { assert } from './utils/assert.ts'
-export { canUseRegexLookbehind } from './utils/can-use-regex-lookbehind.ts'
-export { clsx } from './utils/clsx.ts'
-export { containsInlineNode } from './utils/contains-inline-node.ts'
-export { defaultBlockAt } from './utils/default-block-at.ts'
-export { isApple } from './utils/env.ts'
-export { findNode, findNodes, type FindNodeResult } from './utils/find-node.ts'
-export { findParentNodeOfType } from './utils/find-parent-node-of-type.ts'
-export { findParentNode, type FindParentNodeResult } from './utils/find-parent-node.ts'
-export { getMarkType } from './utils/get-mark-type.ts'
-export { getNodeType } from './utils/get-node-type.ts'
-export { isAtBlockStart } from './utils/is-at-block-start.ts'
-export { isInCodeBlock } from './utils/is-in-code-block.ts'
-export { isMarkAbsent } from './utils/is-mark-absent.ts'
-export { isMarkActive } from './utils/is-mark-active.ts'
-export { maybeRun } from './utils/maybe-run.ts'
+  UnionExtension,
+} from './types/extension'
+export type {
+  CommandAction,
+  CommandTyping,
+} from './types/extension-command'
+export type {
+  MarkTyping,
+  ToMarkAction,
+} from './types/extension-mark'
+export type {
+  NodeTyping,
+  ToNodeAction,
+} from './types/extension-node'
+export type {
+  NodeJSON,
+  SelectionJSON,
+  StateJSON,
+  StepJSON,
+} from './types/model'
+export type { PickSubType } from './types/pick-sub-type'
+export { Priority } from './types/priority'
+export type { SimplifyDeeper } from './types/simplify-deeper'
+export type { SimplifyUnion } from './types/simplify-union'
+export { assert } from './utils/assert'
+export { canUseRegexLookbehind } from './utils/can-use-regex-lookbehind'
+export { clsx } from './utils/clsx'
+export { collectChildren } from './utils/collect-children'
+export {
+  collectNodes,
+  type NodeContent,
+} from './utils/collect-nodes'
+export { containsInlineNode } from './utils/contains-inline-node'
+export { defaultBlockAt } from './utils/default-block-at'
+export { isApple } from './utils/env'
+export {
+  findParentNode,
+  type FindParentNodeResult,
+} from './utils/find-parent-node'
+export { findParentNodeOfType } from './utils/find-parent-node-of-type'
+export { getId as _getId } from './utils/get-id'
+export { getMarkType } from './utils/get-mark-type'
+export { getNodeType } from './utils/get-node-type'
+export { isAtBlockStart } from './utils/is-at-block-start'
+export { isInCodeBlock } from './utils/is-in-code-block'
+export { isMarkAbsent } from './utils/is-mark-absent'
+export { isMarkActive } from './utils/is-mark-active'
+export { maybeRun } from './utils/maybe-run'
 export {
   elementFromJSON,
   elementFromNode,
@@ -146,8 +290,8 @@ export {
   type DOMParserOptions,
   type DOMSerializerOptions,
   type JSONParserOptions,
-} from './utils/parse.ts'
-export { setSelectionAround } from './utils/set-selection-around.ts'
+} from './utils/parse'
+export { setSelectionAround } from './utils/set-selection-around'
 export {
   isAllSelection,
   isFragment,
@@ -157,6 +301,6 @@ export {
   isSelection,
   isSlice,
   isTextSelection,
-} from './utils/type-assertion.ts'
-export * from './utils/unicode.ts'
-export { withSkipCodeBlock } from './utils/with-skip-code-block.ts'
+} from './utils/type-assertion'
+export * from './utils/unicode'
+export { withSkipCodeBlock } from './utils/with-skip-code-block'

--- a/website/src/content/docs/getting-started/using-extensions.mdx
+++ b/website/src/content/docs/getting-started/using-extensions.mdx
@@ -1,0 +1,189 @@
+---
+title: Using Extensions
+sidebar:
+  order: 50
+---
+
+import Demo from '@/components/ui/demo/demo.astro';
+import { Aside, CardGrid } from '@astrojs/starlight/components';
+import LinkCard from 'starlight-theme-nova/components/LinkCard.astro';
+
+Extensions are at the heart of ProseKit's flexibility and power. They allow you to add functionality to your editor in a modular way, making it easy to build exactly the editing experience you need.
+
+## What are extensions?
+
+Extensions in ProseKit are modular pieces of functionality that you can add to your editor. They can provide:
+
+- **Nodes** (paragraphs, headings, lists, code blocks, etc.)
+- **Marks** (bold, italic, underline, etc.)
+- **Commands** (functions that modify the document)
+- **Keyboard shortcuts**
+- **Input rules** (automatic transformations as you type)
+- **Custom behaviors** and much more
+
+## Basic extension usage
+
+ProseKit provides a `defineBasicExtension()` function that includes the most common features:
+
+```ts twoslash
+import { defineBasicExtension } from 'prosekit/basic'
+import { createEditor } from 'prosekit/core'
+
+// Create an editor with the extension
+const editor = createEditor({ extension: defineBasicExtension() })
+```
+
+## Composing extensions with `union`
+
+A key concept in ProseKit is that all extensions are composed of other extensions using the `union` function. This composability lets you create complex functionality by combining simpler building blocks.
+
+For example, `defineBasicExtension` is simply a composition of many smaller extensions:
+
+```ts twoslash
+import {
+  defineBaseCommands,
+  defineBaseKeymap,
+  defineHistory,
+  union,
+} from 'prosekit/core'
+import { defineBlockquote } from 'prosekit/extensions/blockquote'
+import { defineBold } from 'prosekit/extensions/bold'
+import { defineCode } from 'prosekit/extensions/code'
+import { defineCodeBlock } from 'prosekit/extensions/code-block'
+import { defineDoc } from 'prosekit/extensions/doc'
+import { defineGapCursor } from 'prosekit/extensions/gap-cursor'
+import { defineHeading } from 'prosekit/extensions/heading'
+import { defineHorizontalRule } from 'prosekit/extensions/horizontal-rule'
+import { defineImage } from 'prosekit/extensions/image'
+import { defineItalic } from 'prosekit/extensions/italic'
+import { defineLink } from 'prosekit/extensions/link'
+import { defineList } from 'prosekit/extensions/list'
+import { defineModClickPrevention } from 'prosekit/extensions/mod-click-prevention'
+import { defineParagraph } from 'prosekit/extensions/paragraph'
+import { defineStrike } from 'prosekit/extensions/strike'
+import { defineTable } from 'prosekit/extensions/table'
+import { defineText } from 'prosekit/extensions/text'
+import { defineUnderline } from 'prosekit/extensions/underline'
+import { defineVirtualSelection } from 'prosekit/extensions/virtual-selection'
+
+function defineBasicExtension() {
+  return union(
+    // Nodes
+    defineDoc(),
+    defineText(),
+    defineParagraph(),
+    defineHeading(),
+    defineList(),
+    defineBlockquote(),
+    defineImage(),
+    defineHorizontalRule(),
+    defineTable(),
+    defineCodeBlock(),
+    // Marks
+    defineItalic(),
+    defineBold(),
+    defineUnderline(),
+    defineStrike(),
+    defineCode(),
+    defineLink(),
+    // Others
+    defineBaseKeymap(),
+    defineBaseCommands(),
+    defineHistory(),
+    defineGapCursor(),
+    defineVirtualSelection(),
+    defineModClickPrevention(),
+  )
+}
+```
+
+This compositional pattern allows you to build on existing extensions and add exactly the features you need. For example, if you want all the functionality of the basic extension plus syntax highlighting for code blocks, you can simply combine them:
+
+```ts twoslash
+import { defineBasicExtension } from 'prosekit/basic'
+import {
+  createEditor,
+  union,
+} from 'prosekit/core'
+import { defineCodeBlockShiki } from 'prosekit/extensions/code-block'
+
+function defineMyExtension() {
+  return union(
+    defineBasicExtension(),
+    defineCodeBlockShiki(),
+  )
+}
+
+const editor = createEditor({ extension: defineMyExtension() })
+```
+
+## Customizing extensions
+
+Since each extension is composed of smaller parts, you can easily customize functionality by picking exactly which components you want. For example, the `defineCode()` extension defines a mark spec, commands, keyboard shortcut, and input rule.
+
+If you want to keep everything except the keyboard shortcut, you can inspect the source code of the `defineCode()` extension, and create a custom version:
+
+```ts twoslash
+import { union } from 'prosekit/core'
+import {
+  defineCodeCommands,
+  defineCodeInputRule,
+  defineCodeSpec,
+  // Omitting defineCodeKeymap
+} from 'prosekit/extensions/code'
+
+function defineMyCode() {
+  return union(
+    defineCodeSpec(),
+    defineCodeCommands(),
+    defineCodeInputRule(),
+    // No keyboard shortcut
+  )
+}
+```
+
+<Aside>
+
+`defineCodeCommands`, `defineCodeInputRule`, and `defineCodeSpec` are exported from the `prosekit/extensions/code` module, but they are marked as `@internal` APIs thus they are not visible in the [reference documentation](/references/extensions/code).
+
+</Aside>
+
+### Patching existing specs
+
+If you only need to tweak part of an existing node or mark spec, you can patch the merged spec instead of rewriting it from scratch.
+
+```ts twoslash
+import { union, defineNodeSpecPatch } from 'prosekit/core'
+import { defineHeading } from 'prosekit/extensions/heading'
+
+function defineMyHeading() {
+  return union(
+    defineHeading(),
+    defineNodeSpecPatch({
+      type: 'heading',
+      patch: (spec) => ({
+        ...spec,
+        toDOM(node) {
+          return [`h${node.attrs.level}`, { 'data-custom': '1' }, 0]
+        },
+        parseDOM: [
+          ...(spec.parseDOM ?? []),
+          { tag: 'h1[data-custom]' },
+        ],
+      }),
+    }),
+  )
+}
+```
+
+Spec patches run after node specs or mark specs are merged, and after attributes added with `defineNodeAttr()` or `defineMarkAttr()`.
+
+<Aside>
+
+Use spec patches for small changes to fields like `toDOM`, `parseDOM`, or `attrs`. If you need to add or remove larger pieces of behavior such as commands, keymaps, or input rules, compose a custom extension from smaller parts instead.
+
+</Aside>
+
+{/* Link References */}
+
+[Shiki]: https://github.com/shikijs/shiki


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a patching mechanism for node and mark specifications, enabling post-merge customization of existing specs and making it easier to extend built-in behavior.

* **Documentation**
  * Added a guide showing how and when to apply spec patches with examples.

* **Tests**
  * Added tests verifying patch application order, attribute visibility to patches, and merged parse/toDOM behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->