### PR TITLE
feat(autocomplete): allow custom anchor element

### DIFF
--- a/.changeset/custom-autocomplete-anchor.md
+++ b/.changeset/custom-autocomplete-anchor.md
@@ -1,0 +1,12 @@
+---
+"prosekit": patch
+"@prosekit/lit": patch
+"@prosekit/preact": patch
+"@prosekit/react": patch
+"@prosekit/solid": patch
+"@prosekit/svelte": patch
+"@prosekit/vue": patch
+"@prosekit/web": patch
+---
+
+Allow `AutocompleteRoot` to accept a custom `anchor` for popup positioning.

--- a/packages/preact/src/components/autocomplete/autocomplete-root.gen.ts
+++ b/packages/preact/src/components/autocomplete/autocomplete-root.gen.ts
@@ -29,6 +29,12 @@ export interface AutocompleteRootProps {
    * @default defaultItemFilter
    */
   filter?: AutocompleteRootElementProps['filter'];
+  /**
+   * An element to position the popup against. By default, the popup will be positioned against the text content that triggers the autocomplete.
+   *
+   * @default null
+   */
+  anchor?: AutocompleteRootElementProps['anchor'];
   /** Fired when the open state changes. */
   onOpenChange?: (event: AutocompleteRootEvents['openChange']) => void;
   /** Fired when the query changes. */
@@ -51,14 +57,14 @@ function AutocompleteRootComponent(props: AutocompleteRootProps, forwardedRef: R
   const elementRef = useRef<AutocompleteRootElement>(null);
   const handlersRef = useRef<Array<((event: Event) => void) | undefined>>([]);
 
-  const p0Fallback = useEditorContext();
+  const p1Fallback = useEditorContext();
 
-  const { editor: p0, filter: p1, regex: p2, onOpenChange: e0, onQueryChange: e1, onValueChange: e2, onValuesChange: e3, ...restProps } = props;
+  const { anchor: p0, editor: p1, filter: p2, regex: p3, onOpenChange: e0, onQueryChange: e1, onValueChange: e2, onValuesChange: e3, ...restProps } = props;
 
   useLayoutEffect(() => {
     const element = elementRef.current as Record<string, unknown> | null;
     if (!element) return;
-    Object.assign(element, { editor: p0 ?? p0Fallback, filter: p1, regex: p2 });
+    Object.assign(element, { anchor: p0, editor: p1 ?? p1Fallback, filter: p2, regex: p3 });
     handlersRef.current = [e0, e1, e2, e3] as Array<((event: Event) => void) | undefined>;
   });
 

--- a/packages/preact/src/components/autocomplete/autocomplete-root.gen.ts
+++ b/packages/preact/src/components/autocomplete/autocomplete-root.gen.ts
@@ -30,7 +30,10 @@ export interface AutocompleteRootProps {
    */
   filter?: AutocompleteRootElementProps['filter'];
   /**
-   * An element to position the popup against. By default, the popup will be positioned against the text content that triggers the autocomplete.
+   * The reference to position the popup against. This can be a DOM element, a
+   * Floating UI virtual element, or a function that returns either of them.
+   * By default, the popup will be positioned against the text content that
+   * triggers the autocomplete.
    *
    * @default null
    */

--- a/packages/react/src/components/autocomplete/autocomplete-root.gen.ts
+++ b/packages/react/src/components/autocomplete/autocomplete-root.gen.ts
@@ -27,6 +27,12 @@ export interface AutocompleteRootProps {
    * @default defaultItemFilter
    */
   filter?: AutocompleteRootElementProps['filter'];
+  /**
+   * An element to position the popup against. By default, the popup will be positioned against the text content that triggers the autocomplete.
+   *
+   * @default null
+   */
+  anchor?: AutocompleteRootElementProps['anchor'];
   /** Fired when the open state changes. */
   onOpenChange?: (event: AutocompleteRootEvents['openChange']) => void;
   /** Fired when the query changes. */
@@ -49,14 +55,14 @@ function AutocompleteRootComponent(props: AutocompleteRootProps, forwardedRef: F
   const elementRef = useRef<AutocompleteRootElement>(null);
   const handlersRef = useRef<Array<((event: Event) => void) | undefined>>([]);
 
-  const p0Fallback = useEditorContext();
+  const p1Fallback = useEditorContext();
 
-  const { editor: p0, filter: p1, regex: p2, onOpenChange: e0, onQueryChange: e1, onValueChange: e2, onValuesChange: e3, ...restProps } = props;
+  const { anchor: p0, editor: p1, filter: p2, regex: p3, onOpenChange: e0, onQueryChange: e1, onValueChange: e2, onValuesChange: e3, ...restProps } = props;
 
   useLayoutEffect(() => {
     const element = elementRef.current as Record<string, unknown> | null;
     if (!element) return;
-    Object.assign(element, { editor: p0 ?? p0Fallback, filter: p1, regex: p2 });
+    Object.assign(element, { anchor: p0, editor: p1 ?? p1Fallback, filter: p2, regex: p3 });
     handlersRef.current = [e0, e1, e2, e3] as Array<((event: Event) => void) | undefined>;
   });
 

--- a/packages/react/src/components/autocomplete/autocomplete-root.gen.ts
+++ b/packages/react/src/components/autocomplete/autocomplete-root.gen.ts
@@ -28,7 +28,10 @@ export interface AutocompleteRootProps {
    */
   filter?: AutocompleteRootElementProps['filter'];
   /**
-   * An element to position the popup against. By default, the popup will be positioned against the text content that triggers the autocomplete.
+   * The reference to position the popup against. This can be a DOM element, a
+   * Floating UI virtual element, or a function that returns either of them.
+   * By default, the popup will be positioned against the text content that
+   * triggers the autocomplete.
    *
    * @default null
    */

--- a/packages/solid/src/components/autocomplete/autocomplete-root.gen.ts
+++ b/packages/solid/src/components/autocomplete/autocomplete-root.gen.ts
@@ -29,6 +29,12 @@ export interface AutocompleteRootProps {
    * @default defaultItemFilter
    */
   filter?: AutocompleteRootElementProps['filter'];
+  /**
+   * An element to position the popup against. By default, the popup will be positioned against the text content that triggers the autocomplete.
+   *
+   * @default null
+   */
+  anchor?: AutocompleteRootElementProps['anchor'];
   /** Fired when the open state changes. */
   onOpenChange?: (event: AutocompleteRootEvents['openChange']) => void;
   /** Fired when the query changes. */
@@ -52,15 +58,15 @@ export const AutocompleteRoot: Component<AutocompleteRootProps & JSX.HTMLAttribu
   const [getElement, setElement] = createSignal<AutocompleteRootElement | null>(null);
   const handlers: Array<((event: any) => void) | undefined> = [];
 
-  const [elementProps, eventHandlers, restProps] = splitProps(props, ['editor', 'filter', 'regex'], ['onOpenChange', 'onQueryChange', 'onValueChange', 'onValuesChange']);
+  const [elementProps, eventHandlers, restProps] = splitProps(props, ['anchor', 'editor', 'filter', 'regex'], ['onOpenChange', 'onQueryChange', 'onValueChange', 'onValuesChange']);
 
-  const p0Fallback = useEditorContext();
+  const p1Fallback = useEditorContext();
 
   createEffect(() => {
     const element = getElement();
     if (!element) return;
 
-    Object.assign(element, { editor: elementProps.editor ?? p0Fallback, filter: elementProps.filter, regex: elementProps.regex });
+    Object.assign(element, { anchor: elementProps.anchor, editor: elementProps.editor ?? p1Fallback, filter: elementProps.filter, regex: elementProps.regex });
 
     handlers.length = 0;
     handlers.push(eventHandlers.onOpenChange);

--- a/packages/solid/src/components/autocomplete/autocomplete-root.gen.ts
+++ b/packages/solid/src/components/autocomplete/autocomplete-root.gen.ts
@@ -30,7 +30,10 @@ export interface AutocompleteRootProps {
    */
   filter?: AutocompleteRootElementProps['filter'];
   /**
-   * An element to position the popup against. By default, the popup will be positioned against the text content that triggers the autocomplete.
+   * The reference to position the popup against. This can be a DOM element, a
+   * Floating UI virtual element, or a function that returns either of them.
+   * By default, the popup will be positioned against the text content that
+   * triggers the autocomplete.
    *
    * @default null
    */

--- a/packages/svelte/src/components/autocomplete/autocomplete-root.gen.svelte
+++ b/packages/svelte/src/components/autocomplete/autocomplete-root.gen.svelte
@@ -5,16 +5,16 @@
   import { useEditorContext } from '../../contexts/editor-context.ts'
   registerAutocompleteRootElement()
 
-  let { editor: p0, filter: p1, regex: p2, onOpenChange: e0, onQueryChange: e1, onValueChange: e2, onValuesChange: e3, children = undefined, ...restProps } = $props()
+  let { anchor: p0, editor: p1, filter: p2, regex: p3, onOpenChange: e0, onQueryChange: e1, onValueChange: e2, onValuesChange: e3, children = undefined, ...restProps } = $props()
   let element: AutocompleteRootElement | undefined
   const handlers: EventListener[] = []
 
-  const p0Fallback = useEditorContext()
+  const p1Fallback = useEditorContext()
 
   $effect(() => {
     if (!element) return
 
-    Object.assign(element, { editor: p0 ?? p0Fallback, filter: p1, regex: p2 })
+    Object.assign(element, { anchor: p0, editor: p1 ?? p1Fallback, filter: p2, regex: p3 })
 
     handlers.length = 0
     handlers.push(e0)

--- a/packages/svelte/src/components/autocomplete/autocomplete-root.gen.ts
+++ b/packages/svelte/src/components/autocomplete/autocomplete-root.gen.ts
@@ -28,6 +28,12 @@ export interface AutocompleteRootProps {
    * @default defaultItemFilter
    */
   filter?: AutocompleteRootElementProps['filter'];
+  /**
+   * An element to position the popup against. By default, the popup will be positioned against the text content that triggers the autocomplete.
+   *
+   * @default null
+   */
+  anchor?: AutocompleteRootElementProps['anchor'];
   /** Fired when the open state changes. */
   onOpenChange?: (event: AutocompleteRootEvents['openChange']) => void;
   /** Fired when the query changes. */

--- a/packages/svelte/src/components/autocomplete/autocomplete-root.gen.ts
+++ b/packages/svelte/src/components/autocomplete/autocomplete-root.gen.ts
@@ -29,7 +29,10 @@ export interface AutocompleteRootProps {
    */
   filter?: AutocompleteRootElementProps['filter'];
   /**
-   * An element to position the popup against. By default, the popup will be positioned against the text content that triggers the autocomplete.
+   * The reference to position the popup against. This can be a DOM element, a
+   * Floating UI virtual element, or a function that returns either of them.
+   * By default, the popup will be positioned against the text content that
+   * triggers the autocomplete.
    *
    * @default null
    */

--- a/packages/vue/src/components/autocomplete/autocomplete-root.gen.ts
+++ b/packages/vue/src/components/autocomplete/autocomplete-root.gen.ts
@@ -27,6 +27,12 @@ export interface AutocompleteRootProps {
    * @default defaultItemFilter
    */
   filter?: AutocompleteRootElementProps['filter'];
+  /**
+   * An element to position the popup against. By default, the popup will be positioned against the text content that triggers the autocomplete.
+   *
+   * @default null
+   */
+  anchor?: AutocompleteRootElementProps['anchor'];
   /** Fired when the open state changes. */
   onOpenChange?: (event: AutocompleteRootEvents['openChange']) => void;
   /** Fired when the query changes. */
@@ -50,11 +56,11 @@ export const AutocompleteRoot: DefineSetupFnComponent<AutocompleteRootProps & HT
 
     const elementRef = shallowRef<HTMLElement | null>(null);
 
-    const p0Fallback = useEditorContext();
+    const p1Fallback = useEditorContext();
 
     const splittedProps = computed(() => {
-      const { editor: p0, filter: p1, regex: p2, onOpenChange: e0, onQueryChange: e1, onValueChange: e2, onValuesChange: e3, ...restProps } = props;
-      return [[p0, p1, p2, e0, e1, e2, e3], restProps] as const;
+      const { anchor: p0, editor: p1, filter: p2, regex: p3, onOpenChange: e0, onQueryChange: e1, onValueChange: e2, onValuesChange: e3, ...restProps } = props;
+      return [[p0, p1, p2, p3, e0, e1, e2, e3], restProps] as const;
     });
 
     const handlers: Array<((event: any) => void) | undefined> = [];
@@ -63,9 +69,9 @@ export const AutocompleteRoot: DefineSetupFnComponent<AutocompleteRootProps & HT
       const element = elementRef.value;
       if (!element) return;
 
-      const [p0, p1, p2, e0, e1, e2, e3] = splittedProps.value[0];
+      const [p0, p1, p2, p3, e0, e1, e2, e3] = splittedProps.value[0];
 
-      Object.assign(element, { editor: p0 ?? p0Fallback, filter: p1, regex: p2 });
+      Object.assign(element, { anchor: p0, editor: p1 ?? p1Fallback, filter: p2, regex: p3 });
 
       handlers.length = 0;
       handlers.push(e0);
@@ -96,5 +102,5 @@ export const AutocompleteRoot: DefineSetupFnComponent<AutocompleteRootProps & HT
       return h('prosekit-autocomplete-root', { ...restProps, ref: elementRef }, slots.default?.());
     };
   },
-  { props: ['editor', 'filter', 'regex', 'onOpenChange', 'onQueryChange', 'onValueChange', 'onValuesChange'] },
+  { props: ['anchor', 'editor', 'filter', 'regex', 'onOpenChange', 'onQueryChange', 'onValueChange', 'onValuesChange'] },
 );

--- a/packages/vue/src/components/autocomplete/autocomplete-root.gen.ts
+++ b/packages/vue/src/components/autocomplete/autocomplete-root.gen.ts
@@ -28,7 +28,10 @@ export interface AutocompleteRootProps {
    */
   filter?: AutocompleteRootElementProps['filter'];
   /**
-   * An element to position the popup against. By default, the popup will be positioned against the text content that triggers the autocomplete.
+   * The reference to position the popup against. This can be a DOM element, a
+   * Floating UI virtual element, or a function that returns either of them.
+   * By default, the popup will be positioned against the text content that
+   * triggers the autocomplete.
    *
    * @default null
    */

--- a/packages/web/src/components/autocomplete/autocomplete-root.ts
+++ b/packages/web/src/components/autocomplete/autocomplete-root.ts
@@ -22,6 +22,7 @@ import { getSafeEditorView } from '../../utils/get-safe-editor-view.ts'
 
 import { autocompleteStoreContext, type AutocompleteStore } from './context.ts'
 import { defaultQueryBuilder } from './helpers.ts'
+import type { VirtualElement } from '@floating-ui/dom'
 
 export { OpenChangeEvent }
 
@@ -48,7 +49,14 @@ export interface AutocompleteRootProps {
    * @default defaultItemFilter
    */
   filter: ItemFilter | null
-}
+
+  /**
+  * An element to position the popup against. By default, the popup will be positioned against the text content that triggers the autocomplete.
+  *
+  * @default null
+  */
+    anchor: Element | VirtualElement | (() => (Element | VirtualElement | null)) | null
+  }
 
 /** @internal */
 export const AutocompleteRootPropsDeclaration: PropsDeclaration<AutocompleteRootProps> = /* @__PURE__ */ defineProps<
@@ -57,6 +65,7 @@ export const AutocompleteRootPropsDeclaration: PropsDeclaration<AutocompleteRoot
   editor: { default: null, attribute: false },
   regex: { default: null, attribute: false },
   filter: { default: defaultItemFilter, attribute: false },
+  anchor: { default: null, attribute: false }
 })
 
 /**
@@ -95,7 +104,7 @@ interface RuleHandlers {
 }
 
 interface AutocompleteRuleDeps {
-  reference: Signal<Element | undefined>
+  reference: Signal<Element | VirtualElement | undefined>
   handlers: RuleHandlers
   setQuery: (next: string) => void
   requestOpenChange: (open: boolean) => void
@@ -110,7 +119,7 @@ export function setupAutocompleteRoot(
 ): void {
   const getEditor = props.editor.get
 
-  const reference = createSignal<Element | undefined>(undefined)
+  const reference = createSignal<Element | VirtualElement  | undefined>(undefined)
   const open = createSignal(false)
   const query = createSignal('')
   const keyboardTarget = new KeyboardEventTarget()
@@ -159,7 +168,20 @@ export function setupAutocompleteRoot(
     host.dispatchEvent(new QueryChangeEvent(next))
   }
 
-  useAutocompleteExtension(host, getEditor, props.regex.get, {
+  const getAnchor = (): Element | VirtualElement | undefined  => {
+    const customAnchor = props.anchor.get()
+    if (customAnchor) {
+      if (typeof customAnchor === 'function') {
+        return customAnchor() ?? undefined
+      } else {
+        return customAnchor
+      }
+    }
+    const view = getSafeEditorView(getEditor())
+    return view?.dom.querySelector('.prosekit-autocomplete-match') ?? undefined
+  }
+
+  useAutocompleteExtension(host, getEditor, props.regex.get, getAnchor, {
     reference,
     handlers,
     setQuery,
@@ -202,6 +224,7 @@ function useAutocompleteExtension(
   host: HostElement,
   getEditor: () => Editor | null,
   getRegex: () => RegExp | null,
+  getAnchor: () => Element | VirtualElement | undefined,
   deps: AutocompleteRuleDeps,
 ) {
   useEffect(host, () => {
@@ -212,7 +235,7 @@ function useAutocompleteExtension(
       return
     }
 
-    const rule = createAutocompleteRule(editor, regex, deps)
+    const rule = createAutocompleteRule(editor, regex, getAnchor, deps, )
     const extension = defineAutocomplete(rule)
     return editor.use(extension)
   })
@@ -221,16 +244,16 @@ function useAutocompleteExtension(
 function createAutocompleteRule(
   editor: Editor,
   regex: RegExp,
+  getAnchor: () => Element | VirtualElement | undefined,
   deps: AutocompleteRuleDeps,
 ) {
   const { reference, handlers, setQuery, requestOpenChange } = deps
 
   const handleEnter: MatchHandler = (options) => {
-    const view = getSafeEditorView(editor)
-    const span = view?.dom.querySelector('.prosekit-autocomplete-match')
+    let anchor = getAnchor()
 
-    if (span) {
-      reference.set(span)
+    if (anchor) {
+      reference.set(anchor)
     }
 
     handlers.submit = options.deleteMatch

--- a/packages/web/src/components/autocomplete/autocomplete-root.ts
+++ b/packages/web/src/components/autocomplete/autocomplete-root.ts
@@ -13,6 +13,7 @@ import {
 import { defaultItemFilter, type ItemFilter, type ListboxRootEvents } from '@aria-ui/elements/listbox'
 import { createOverlayStore, OpenChangeEvent, type OverlayStore } from '@aria-ui/elements/overlay'
 import { useEventListener } from '@aria-ui/utils'
+import type { VirtualElement } from '@floating-ui/dom'
 import { defineDOMEventHandler, defineKeymap, withPriority, type Editor, type Extension, type Priority } from '@prosekit/core'
 import { AutocompleteRule, defineAutocomplete, type MatchHandler } from '@prosekit/extensions/autocomplete'
 
@@ -22,7 +23,6 @@ import { getSafeEditorView } from '../../utils/get-safe-editor-view.ts'
 
 import { autocompleteStoreContext, type AutocompleteStore } from './context.ts'
 import { defaultQueryBuilder } from './helpers.ts'
-import type { VirtualElement } from '@floating-ui/dom'
 
 export { OpenChangeEvent }
 
@@ -51,12 +51,12 @@ export interface AutocompleteRootProps {
   filter: ItemFilter | null
 
   /**
-  * An element to position the popup against. By default, the popup will be positioned against the text content that triggers the autocomplete.
-  *
-  * @default null
-  */
-    anchor: Element | VirtualElement | (() => (Element | VirtualElement | null)) | null
-  }
+   * An element to position the popup against. By default, the popup will be positioned against the text content that triggers the autocomplete.
+   *
+   * @default null
+   */
+  anchor: Element | VirtualElement | (() => Element | VirtualElement | null) | null
+}
 
 /** @internal */
 export const AutocompleteRootPropsDeclaration: PropsDeclaration<AutocompleteRootProps> = /* @__PURE__ */ defineProps<
@@ -65,7 +65,7 @@ export const AutocompleteRootPropsDeclaration: PropsDeclaration<AutocompleteRoot
   editor: { default: null, attribute: false },
   regex: { default: null, attribute: false },
   filter: { default: defaultItemFilter, attribute: false },
-  anchor: { default: null, attribute: false }
+  anchor: { default: null, attribute: false },
 })
 
 /**
@@ -119,7 +119,7 @@ export function setupAutocompleteRoot(
 ): void {
   const getEditor = props.editor.get
 
-  const reference = createSignal<Element | VirtualElement  | undefined>(undefined)
+  const reference = createSignal<Element | VirtualElement | undefined>(undefined)
   const open = createSignal(false)
   const query = createSignal('')
   const keyboardTarget = new KeyboardEventTarget()
@@ -168,7 +168,7 @@ export function setupAutocompleteRoot(
     host.dispatchEvent(new QueryChangeEvent(next))
   }
 
-  const getAnchor = (): Element | VirtualElement | undefined  => {
+  const getAnchor = (): Element | VirtualElement | undefined => {
     const customAnchor = props.anchor.get()
     if (customAnchor) {
       if (typeof customAnchor === 'function') {
@@ -235,7 +235,7 @@ function useAutocompleteExtension(
       return
     }
 
-    const rule = createAutocompleteRule(editor, regex, getAnchor, deps, )
+    const rule = createAutocompleteRule(editor, regex, getAnchor, deps)
     const extension = defineAutocomplete(rule)
     return editor.use(extension)
   })
@@ -250,7 +250,7 @@ function createAutocompleteRule(
   const { reference, handlers, setQuery, requestOpenChange } = deps
 
   const handleEnter: MatchHandler = (options) => {
-    let anchor = getAnchor()
+    const anchor = getAnchor()
 
     if (anchor) {
       reference.set(anchor)

--- a/packages/web/src/components/autocomplete/autocomplete-root.ts
+++ b/packages/web/src/components/autocomplete/autocomplete-root.ts
@@ -251,10 +251,7 @@ function createAutocompleteRule(
 
   const handleEnter: MatchHandler = (options) => {
     const anchor = getAnchor()
-
-    if (anchor) {
-      reference.set(anchor)
-    }
+    reference.set(anchor || undefined)
 
     handlers.submit = options.deleteMatch
     handlers.dismiss = options.ignoreMatch

--- a/packages/web/src/components/autocomplete/autocomplete-root.ts
+++ b/packages/web/src/components/autocomplete/autocomplete-root.ts
@@ -51,7 +51,10 @@ export interface AutocompleteRootProps {
   filter: ItemFilter | null
 
   /**
-   * An element to position the popup against. By default, the popup will be positioned against the text content that triggers the autocomplete.
+   * The reference to position the popup against. This can be a DOM element, a
+   * Floating UI virtual element, or a function that returns either of them.
+   * By default, the popup will be positioned against the text content that
+   * triggers the autocomplete.
    *
    * @default null
    */

--- a/packages/web/src/components/autocomplete/autocomplete-root.ts
+++ b/packages/web/src/components/autocomplete/autocomplete-root.ts
@@ -13,7 +13,7 @@ import {
 import { defaultItemFilter, type ItemFilter, type ListboxRootEvents } from '@aria-ui/elements/listbox'
 import { createOverlayStore, OpenChangeEvent, type OverlayStore } from '@aria-ui/elements/overlay'
 import { useEventListener } from '@aria-ui/utils'
-import type { VirtualElement } from '@floating-ui/dom'
+import type { ReferenceElement, VirtualElement } from '@floating-ui/dom'
 import { defineDOMEventHandler, defineKeymap, withPriority, type Editor, type Extension, type Priority } from '@prosekit/core'
 import { AutocompleteRule, defineAutocomplete, type MatchHandler } from '@prosekit/extensions/autocomplete'
 
@@ -104,7 +104,7 @@ interface RuleHandlers {
 }
 
 interface AutocompleteRuleDeps {
-  reference: Signal<Element | VirtualElement | undefined>
+  reference: Signal<ReferenceElement | undefined>
   handlers: RuleHandlers
   setQuery: (next: string) => void
   requestOpenChange: (open: boolean) => void
@@ -119,7 +119,7 @@ export function setupAutocompleteRoot(
 ): void {
   const getEditor = props.editor.get
 
-  const reference = createSignal<Element | VirtualElement | undefined>(undefined)
+  const reference = createSignal<ReferenceElement | undefined>(undefined)
   const open = createSignal(false)
   const query = createSignal('')
   const keyboardTarget = new KeyboardEventTarget()
@@ -168,17 +168,17 @@ export function setupAutocompleteRoot(
     host.dispatchEvent(new QueryChangeEvent(next))
   }
 
-  const getAnchor = (): Element | VirtualElement | undefined => {
+  const getAnchor = (): ReferenceElement | null => {
     const customAnchor = props.anchor.get()
     if (customAnchor) {
       if (typeof customAnchor === 'function') {
-        return customAnchor() ?? undefined
+        return customAnchor() || null
       } else {
         return customAnchor
       }
     }
     const view = getSafeEditorView(getEditor())
-    return view?.dom.querySelector('.prosekit-autocomplete-match') ?? undefined
+    return view?.dom.querySelector('.prosekit-autocomplete-match') || null
   }
 
   useAutocompleteExtension(host, getEditor, props.regex.get, getAnchor, {
@@ -224,7 +224,7 @@ function useAutocompleteExtension(
   host: HostElement,
   getEditor: () => Editor | null,
   getRegex: () => RegExp | null,
-  getAnchor: () => Element | VirtualElement | undefined,
+  getAnchor: () => ReferenceElement | null,
   deps: AutocompleteRuleDeps,
 ) {
   useEffect(host, () => {
@@ -244,7 +244,7 @@ function useAutocompleteExtension(
 function createAutocompleteRule(
   editor: Editor,
   regex: RegExp,
-  getAnchor: () => Element | VirtualElement | undefined,
+  getAnchor: () => ReferenceElement | null,
   deps: AutocompleteRuleDeps,
 ) {
   const { reference, handlers, setQuery, requestOpenChange } = deps


### PR DESCRIPTION
Closes https://github.com/prosekit/prosekit/issues/1598 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AutocompleteRoot accepts an optional anchor in React, Vue, Solid, Svelte, Preact, and Web. Provide a DOM element, a virtual (Floating UI) reference, or a function returning one to control popup positioning. The prop is optional (defaults to null) and enables precise, dynamic autocomplete popup placement independent of editor content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->