### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    # Only consider versions that have been published for more than 24 hours.
+    cooldown:
+      default-days: 1
+    # Combine all non-major (minor and patch) updates into a single pull request.
+    groups:
+      non-major:
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 1
+    groups:
+      non-major:
+        update-types:
+          - minor
+          - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       default-days: 1
       exclude:
         - "@ocavue/eslint-config"
+        - "@ocavue/tsconfig"
+        - "@ocavue/utils"
     groups:
       non-major:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,6 @@ updates:
           - patch
     commit-message:
       prefix: "chore"
-    open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
     directory: /
     schedule:
       interval: daily
-    # Only consider versions that have been published for more than 24 hours.
     cooldown:
       default-days: 1
-    # Combine all non-major (minor and patch) updates into a single pull request.
+      exclude:
+        - "@ocavue/eslint-config"
     groups:
       non-major:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
         update-types:
           - minor
           - patch
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
     open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
@@ -29,3 +32,5 @@ updates:
         update-types:
           - minor
           - patch
+    commit-message:
+      prefix: "chore"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,6 @@ updates:
           - patch
     commit-message:
       prefix: "chore"
-      prefix-development: "chore"
     open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,9 @@ updates:
     cooldown:
       default-days: 1
       exclude:
-        - "@ocavue/eslint-config"
-        - "@ocavue/tsconfig"
-        - "@ocavue/utils"
+        - "@ocavue/*"
+        - "@aria-ui/*"
+        - "astrobook"
     groups:
       non-major:
         update-types:

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -101,7 +101,7 @@
     "prosemirror-search": "^1.1.0",
     "prosemirror-tables": "^1.8.5",
     "server-dom-shim": "^1.1.0",
-    "shiki": "^4.0.2"
+    "shiki": "^4.0.0"
   },
   "peerDependencies": {
     "loro-crdt": ">= 1.10.0",

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -139,7 +139,7 @@
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
     "tsdown": "catalog:",
-    "type-fest": "^5.6.0",
+    "type-fest": "^5.0.0",
     "typescript": "catalog:",
     "unified": "^11.0.5",
     "vitest": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,7 +301,7 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       shiki:
-        specifier: ^4.0.2
+        specifier: ^4.0.0
         version: 4.0.2
     devDependencies:
       '@prosekit/config-ts':
@@ -350,7 +350,7 @@ importers:
         specifier: 'catalog:'
         version: 0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.8(typescript@6.0.3))
       type-fest:
-        specifier: ^5.6.0
+        specifier: ^5.0.0
         version: 5.6.0
       typescript:
         specifier: 'catalog:'


### PR DESCRIPTION
Let's try GitHub Dependabot since Renovate doesn't work for now (memory limit issue since pnpm v11).