### PR TITLE
feat: use shadcn-svelte and shadcn-vue CLIs for Svelte/Vue registry installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ The ultimate toolkit for text editing. Based on [ProseMirror](https://prosemirro
 
 ## Quick Start
 
-You can install a full-featured example with a single command using [shadcn/ui](https://ui.shadcn.com):
+You can install a full-featured example with a single command:
 
 ```bash
-# Use React
+# Use React (shadcn)
 npx shadcn@latest add @prosekit/react-example-full
-# Use Vue
-npx shadcn@latest add @prosekit/vue-example-full
-# Use Preact
+# Use Preact (shadcn)
 npx shadcn@latest add @prosekit/preact-example-full
-# Use Svelte
-npx shadcn@latest add @prosekit/svelte-example-full
-# Use Solid
+# Use Solid (shadcn)
 npx shadcn@latest add @prosekit/solid-example-full
+# Use Vue (shadcn-vue)
+npx shadcn-vue@latest add https://unpkg.com/prosekit-registry/dist/r/vue-example-full.json
+# Use Svelte (shadcn-svelte)
+npx shadcn-svelte@latest add https://unpkg.com/prosekit-registry/dist/r/svelte-example-full.json
 ```
 
 ## Documentation

--- a/website/src/components/ui/demo/shadcn-install-code-block.astro
+++ b/website/src/components/ui/demo/shadcn-install-code-block.astro
@@ -26,7 +26,8 @@ const { frameworks, registryName }: Props = Astro.props
   <Fragment slot="svelte">{frameworks.includes('svelte') ? (
     <div>
       <div class="not-content mb-2 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200">
-        Svelte projects use the <a href="https://www.shadcn-svelte.com/docs/cli" target="_blank" rel="noopener noreferrer"><code>shadcn-svelte</code></a> CLI instead of <code>shadcn</code>.
+        Svelte projects use the <a href="https://www.shadcn-svelte.com/docs/cli" target="_blank" rel="noopener noreferrer"><code
+          >shadcn-svelte</code></a> CLI instead of <code>shadcn</code>.
       </div>
       <Code lang="bash" code={`npx shadcn-svelte@latest add https://unpkg.com/prosekit-registry/dist/r/svelte-${registryName}.json`} />
     </div>
@@ -37,7 +38,8 @@ const { frameworks, registryName }: Props = Astro.props
   <Fragment slot="vue">{frameworks.includes('vue') ? (
     <div>
       <div class="not-content mb-2 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200">
-        Vue projects use the <a href="https://www.shadcn-vue.com/docs/cli" target="_blank" rel="noopener noreferrer"><code>shadcn-vue</code></a> CLI instead of <code>shadcn</code>.
+        Vue projects use the <a href="https://www.shadcn-vue.com/docs/cli" target="_blank" rel="noopener noreferrer"><code
+          >shadcn-vue</code></a> CLI instead of <code>shadcn</code>.
       </div>
       <Code lang="bash" code={`npx shadcn-vue@latest add https://unpkg.com/prosekit-registry/dist/r/vue-${registryName}.json`} />
     </div>

--- a/website/src/components/ui/demo/shadcn-install-code-block.astro
+++ b/website/src/components/ui/demo/shadcn-install-code-block.astro
@@ -24,12 +24,22 @@ const { frameworks, registryName }: Props = Astro.props
     <Code lang="bash" code={`npx shadcn@latest add @prosekit/solid-${registryName}`} />
   ) : null}</Fragment>
   <Fragment slot="svelte">{frameworks.includes('svelte') ? (
-    <Code lang="bash" code={`npx shadcn@latest add @prosekit/svelte-${registryName}`} />
+    <div>
+      <div class="not-content mb-2 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200">
+        Svelte projects use the <a href="https://www.shadcn-svelte.com/docs/cli" target="_blank" rel="noopener noreferrer"><code>shadcn-svelte</code></a> CLI instead of <code>shadcn</code>.
+      </div>
+      <Code lang="bash" code={`npx shadcn-svelte@latest add https://unpkg.com/prosekit-registry/dist/r/svelte-${registryName}.json`} />
+    </div>
   ) : null}</Fragment>
   <Fragment slot="vanilla">{frameworks.includes('vanilla') ? (
     <Code lang="bash" code={`npx shadcn@latest add @prosekit/vanilla-${registryName}`} />
   ) : null}</Fragment>
   <Fragment slot="vue">{frameworks.includes('vue') ? (
-    <Code lang="bash" code={`npx shadcn@latest add @prosekit/vue-${registryName}`} />
+    <div>
+      <div class="not-content mb-2 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200">
+        Vue projects use the <a href="https://www.shadcn-vue.com/docs/cli" target="_blank" rel="noopener noreferrer"><code>shadcn-vue</code></a> CLI instead of <code>shadcn</code>.
+      </div>
+      <Code lang="bash" code={`npx shadcn-vue@latest add https://unpkg.com/prosekit-registry/dist/r/vue-${registryName}.json`} />
+    </div>
   ) : null}</Fragment>
 </CurrentFrameworkContent>


### PR DESCRIPTION
## Summary

- **Svelte**: replaces `npx shadcn@latest add @prosekit/svelte-*` with `npx shadcn-svelte@latest add <URL>` — the shadcn-svelte CLI uses direct JSON registry URLs rather than npm package names
- **Vue**: replaces `npx shadcn@latest add @prosekit/vue-*` with `npx shadcn-vue@latest add <URL>` — same pattern as shadcn-svelte
- Adds an amber callout for both frameworks explaining the CLI difference and linking to the respective docs (shadcn-svelte.com/docs/cli and shadcn-vue.com/docs/cli)

The install command URLs follow the existing registry base: `https://unpkg.com/prosekit-registry/dist/r/{framework}-{registryName}.json`

## References
- shadcn-svelte registry docs: https://www.shadcn-svelte.com/docs/registry
- shadcn-vue registry docs: https://www.shadcn-vue.com/docs/registry

## Test plan
- [x] Dev server confirmed all three code paths render correctly (`react` → shadcn, `svelte` → shadcn-svelte with URL, `vue` → shadcn-vue with URL)
- [x] Verified on example pages (`/examples/full`) and component doc pages (`/components/block-handle`)
- [x] Callout text and links present in rendered HTML for both Svelte and Vue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start installation commands: added Vue and Svelte install examples using unpkg registry JSON URLs; React/Preact/Solid examples continue to use npx shadcn...
  * Demo install code now displays an informational notice for Vue/Svelte and presents framework-specific add commands for clearer guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prosekit/prosekit/pull/1614)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->