### PR TITLE
refactor(registry): migrate example toolbars to useEditorDerivedValue

### DIFF
--- a/registry/src/preact/examples/hard-break/toolbar.tsx
+++ b/registry/src/preact/examples/hard-break/toolbar.tsx
@@ -1,18 +1,28 @@
-import { useEditor } from 'prosekit/preact'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/preact'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    hardBreak: {
+      canExec: editor.commands.insertHardBreak.canExec(),
+      command: () => editor.commands.insertHardBreak(),
+    },
+  }
+}
+
 export default function Toolbar() {
-  const editor = useEditor<EditorExtension>({ update: true })
+  const items = useEditorDerivedValue(getToolbarItems)
 
   return (
     <div className="CSS_TOOLBAR">
       <Button
         pressed={false}
-        disabled={!editor.commands.insertHardBreak.canExec()}
-        onClick={() => editor.commands.insertHardBreak()}
+        disabled={!items.hardBreak.canExec}
+        onClick={items.hardBreak.command}
       >
         Insert Hard Break
       </Button>

--- a/registry/src/preact/examples/highlight/toolbar.tsx
+++ b/registry/src/preact/examples/highlight/toolbar.tsx
@@ -1,18 +1,29 @@
-import { useEditor } from 'prosekit/preact'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/preact'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    highlight: {
+      isActive: editor.marks.highlight.isActive(),
+      canExec: editor.commands.toggleHighlight.canExec(),
+      command: () => editor.commands.toggleHighlight(),
+    },
+  }
+}
+
 export default function Toolbar() {
-  const editor = useEditor<EditorExtension>({ update: true })
+  const items = useEditorDerivedValue(getToolbarItems)
 
   return (
     <div className="CSS_TOOLBAR">
       <Button
-        pressed={false}
-        disabled={!editor.commands.toggleHighlight.canExec()}
-        onClick={() => editor.commands.toggleHighlight()}
+        pressed={items.highlight.isActive}
+        disabled={!items.highlight.canExec}
+        onClick={items.highlight.command}
       >
         Highlight
       </Button>

--- a/registry/src/preact/examples/strike/toolbar.tsx
+++ b/registry/src/preact/examples/strike/toolbar.tsx
@@ -1,18 +1,29 @@
-import { useEditor } from 'prosekit/preact'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/preact'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    strike: {
+      isActive: editor.marks.strike.isActive(),
+      canExec: editor.commands.toggleStrike.canExec(),
+      command: () => editor.commands.toggleStrike(),
+    },
+  }
+}
+
 export default function Toolbar() {
-  const editor = useEditor<EditorExtension>({ update: true })
+  const items = useEditorDerivedValue(getToolbarItems)
 
   return (
     <div className="CSS_TOOLBAR">
       <Button
-        pressed={false}
-        disabled={!editor.commands.toggleStrike.canExec()}
-        onClick={() => editor.commands.toggleStrike()}
+        pressed={items.strike.isActive}
+        disabled={!items.strike.canExec}
+        onClick={items.strike.command}
       >
         Strikethrough
       </Button>

--- a/registry/src/preact/examples/sub-sup/toolbar.tsx
+++ b/registry/src/preact/examples/sub-sup/toolbar.tsx
@@ -1,25 +1,41 @@
-import { useEditor } from 'prosekit/preact'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/preact'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    subscript: {
+      isActive: editor.marks.subscript.isActive(),
+      canExec: editor.commands.toggleSubscript.canExec(),
+      command: () => editor.commands.toggleSubscript(),
+    },
+    superscript: {
+      isActive: editor.marks.superscript.isActive(),
+      canExec: editor.commands.toggleSuperscript.canExec(),
+      command: () => editor.commands.toggleSuperscript(),
+    },
+  }
+}
+
 export default function Toolbar() {
-  const editor = useEditor<EditorExtension>({ update: true })
+  const items = useEditorDerivedValue(getToolbarItems)
 
   return (
     <div className="CSS_TOOLBAR">
       <Button
-        pressed={false}
-        disabled={!editor.commands.toggleSubscript.canExec()}
-        onClick={() => editor.commands.toggleSubscript()}
+        pressed={items.subscript.isActive}
+        disabled={!items.subscript.canExec}
+        onClick={items.subscript.command}
       >
         Subscript
       </Button>
       <Button
-        pressed={false}
-        disabled={!editor.commands.toggleSuperscript.canExec()}
-        onClick={() => editor.commands.toggleSuperscript()}
+        pressed={items.superscript.isActive}
+        disabled={!items.superscript.canExec}
+        onClick={items.superscript.command}
       >
         Superscript
       </Button>

--- a/registry/src/react/examples/hard-break/toolbar.tsx
+++ b/registry/src/react/examples/hard-break/toolbar.tsx
@@ -1,20 +1,30 @@
 'use client'
 
-import { useEditor } from 'prosekit/react'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/react'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    hardBreak: {
+      canExec: editor.commands.insertHardBreak.canExec(),
+      command: () => editor.commands.insertHardBreak(),
+    },
+  }
+}
+
 export default function Toolbar() {
-  const editor = useEditor<EditorExtension>({ update: true })
+  const items = useEditorDerivedValue(getToolbarItems)
 
   return (
     <div className="CSS_TOOLBAR">
       <Button
         pressed={false}
-        disabled={!editor.commands.insertHardBreak.canExec()}
-        onClick={() => editor.commands.insertHardBreak()}
+        disabled={!items.hardBreak.canExec}
+        onClick={items.hardBreak.command}
       >
         Insert Hard Break
       </Button>

--- a/registry/src/react/examples/highlight/toolbar.tsx
+++ b/registry/src/react/examples/highlight/toolbar.tsx
@@ -1,20 +1,31 @@
 'use client'
 
-import { useEditor } from 'prosekit/react'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/react'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    highlight: {
+      isActive: editor.marks.highlight.isActive(),
+      canExec: editor.commands.toggleHighlight.canExec(),
+      command: () => editor.commands.toggleHighlight(),
+    },
+  }
+}
+
 export default function Toolbar() {
-  const editor = useEditor<EditorExtension>({ update: true })
+  const items = useEditorDerivedValue(getToolbarItems)
 
   return (
     <div className="CSS_TOOLBAR">
       <Button
-        pressed={false}
-        disabled={!editor.commands.toggleHighlight.canExec()}
-        onClick={() => editor.commands.toggleHighlight()}
+        pressed={items.highlight.isActive}
+        disabled={!items.highlight.canExec}
+        onClick={items.highlight.command}
       >
         Highlight
       </Button>

--- a/registry/src/react/examples/strike/toolbar.tsx
+++ b/registry/src/react/examples/strike/toolbar.tsx
@@ -1,20 +1,31 @@
 'use client'
 
-import { useEditor } from 'prosekit/react'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/react'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    strike: {
+      isActive: editor.marks.strike.isActive(),
+      canExec: editor.commands.toggleStrike.canExec(),
+      command: () => editor.commands.toggleStrike(),
+    },
+  }
+}
+
 export default function Toolbar() {
-  const editor = useEditor<EditorExtension>({ update: true })
+  const items = useEditorDerivedValue(getToolbarItems)
 
   return (
     <div className="CSS_TOOLBAR">
       <Button
-        pressed={false}
-        disabled={!editor.commands.toggleStrike.canExec()}
-        onClick={() => editor.commands.toggleStrike()}
+        pressed={items.strike.isActive}
+        disabled={!items.strike.canExec}
+        onClick={items.strike.command}
       >
         Strikethrough
       </Button>

--- a/registry/src/react/examples/sub-sup/toolbar.tsx
+++ b/registry/src/react/examples/sub-sup/toolbar.tsx
@@ -1,27 +1,43 @@
 'use client'
 
-import { useEditor } from 'prosekit/react'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/react'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    subscript: {
+      isActive: editor.marks.subscript.isActive(),
+      canExec: editor.commands.toggleSubscript.canExec(),
+      command: () => editor.commands.toggleSubscript(),
+    },
+    superscript: {
+      isActive: editor.marks.superscript.isActive(),
+      canExec: editor.commands.toggleSuperscript.canExec(),
+      command: () => editor.commands.toggleSuperscript(),
+    },
+  }
+}
+
 export default function Toolbar() {
-  const editor = useEditor<EditorExtension>({ update: true })
+  const items = useEditorDerivedValue(getToolbarItems)
 
   return (
     <div className="CSS_TOOLBAR">
       <Button
-        pressed={false}
-        disabled={!editor.commands.toggleSubscript.canExec()}
-        onClick={() => editor.commands.toggleSubscript()}
+        pressed={items.subscript.isActive}
+        disabled={!items.subscript.canExec}
+        onClick={items.subscript.command}
       >
         Subscript
       </Button>
       <Button
-        pressed={false}
-        disabled={!editor.commands.toggleSuperscript.canExec()}
-        onClick={() => editor.commands.toggleSuperscript()}
+        pressed={items.superscript.isActive}
+        disabled={!items.superscript.canExec}
+        onClick={items.superscript.command}
       >
         Superscript
       </Button>

--- a/registry/src/solid/examples/hard-break/toolbar.tsx
+++ b/registry/src/solid/examples/hard-break/toolbar.tsx
@@ -1,19 +1,29 @@
-import { useEditor } from 'prosekit/solid'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/solid'
 import type { JSX } from 'solid-js'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    hardBreak: {
+      canExec: editor.commands.insertHardBreak.canExec(),
+      command: () => editor.commands.insertHardBreak(),
+    },
+  }
+}
+
 export default function Toolbar(): JSX.Element {
-  const editor = useEditor<EditorExtension>({ update: true })
+  const items = useEditorDerivedValue(getToolbarItems)
 
   return (
     <div class="CSS_TOOLBAR">
       <Button
         pressed={false}
-        disabled={!editor().commands.insertHardBreak.canExec()}
-        onClick={() => editor().commands.insertHardBreak()}
+        disabled={!items().hardBreak.canExec}
+        onClick={items().hardBreak.command}
       >
         Insert Hard Break
       </Button>

--- a/registry/src/solid/examples/highlight/toolbar.tsx
+++ b/registry/src/solid/examples/highlight/toolbar.tsx
@@ -1,19 +1,30 @@
-import { useEditor } from 'prosekit/solid'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/solid'
 import type { JSX } from 'solid-js'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    highlight: {
+      isActive: editor.marks.highlight.isActive(),
+      canExec: editor.commands.toggleHighlight.canExec(),
+      command: () => editor.commands.toggleHighlight(),
+    },
+  }
+}
+
 export default function Toolbar(): JSX.Element {
-  const editor = useEditor<EditorExtension>({ update: true })
+  const items = useEditorDerivedValue(getToolbarItems)
 
   return (
     <div class="CSS_TOOLBAR">
       <Button
-        pressed={false}
-        disabled={!editor().commands.toggleHighlight.canExec()}
-        onClick={() => editor().commands.toggleHighlight()}
+        pressed={items().highlight.isActive}
+        disabled={!items().highlight.canExec}
+        onClick={items().highlight.command}
       >
         Highlight
       </Button>

--- a/registry/src/solid/examples/strike/toolbar.tsx
+++ b/registry/src/solid/examples/strike/toolbar.tsx
@@ -1,19 +1,30 @@
-import { useEditor } from 'prosekit/solid'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/solid'
 import type { JSX } from 'solid-js'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    strike: {
+      isActive: editor.marks.strike.isActive(),
+      canExec: editor.commands.toggleStrike.canExec(),
+      command: () => editor.commands.toggleStrike(),
+    },
+  }
+}
+
 export default function Toolbar(): JSX.Element {
-  const editor = useEditor<EditorExtension>({ update: true })
+  const items = useEditorDerivedValue(getToolbarItems)
 
   return (
     <div class="CSS_TOOLBAR">
       <Button
-        pressed={false}
-        disabled={!editor().commands.toggleStrike.canExec()}
-        onClick={() => editor().commands.toggleStrike()}
+        pressed={items().strike.isActive}
+        disabled={!items().strike.canExec}
+        onClick={items().strike.command}
       >
         Strikethrough
       </Button>

--- a/registry/src/solid/examples/sub-sup/toolbar.tsx
+++ b/registry/src/solid/examples/sub-sup/toolbar.tsx
@@ -1,26 +1,42 @@
-import { useEditor } from 'prosekit/solid'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/solid'
 import type { JSX } from 'solid-js'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    subscript: {
+      isActive: editor.marks.subscript.isActive(),
+      canExec: editor.commands.toggleSubscript.canExec(),
+      command: () => editor.commands.toggleSubscript(),
+    },
+    superscript: {
+      isActive: editor.marks.superscript.isActive(),
+      canExec: editor.commands.toggleSuperscript.canExec(),
+      command: () => editor.commands.toggleSuperscript(),
+    },
+  }
+}
+
 export default function Toolbar(): JSX.Element {
-  const editor = useEditor<EditorExtension>({ update: true })
+  const items = useEditorDerivedValue(getToolbarItems)
 
   return (
     <div class="CSS_TOOLBAR">
       <Button
-        pressed={false}
-        disabled={!editor().commands.toggleSubscript.canExec()}
-        onClick={() => editor().commands.toggleSubscript()}
+        pressed={items().subscript.isActive}
+        disabled={!items().subscript.canExec}
+        onClick={items().subscript.command}
       >
         Subscript
       </Button>
       <Button
-        pressed={false}
-        disabled={!editor().commands.toggleSuperscript.canExec()}
-        onClick={() => editor().commands.toggleSuperscript()}
+        pressed={items().superscript.isActive}
+        disabled={!items().superscript.canExec}
+        onClick={items().superscript.command}
       >
         Superscript
       </Button>

--- a/registry/src/solid/ui/search/search.tsx
+++ b/registry/src/solid/ui/search/search.tsx
@@ -31,7 +31,7 @@ export default function Search(props: { onClose?: VoidFunction }): JSX.Element {
 
   useExtension(extension)
 
-  const editor = useEditor<SearchCommandsExtension>({ update: true })
+  const editor = useEditor<SearchCommandsExtension>()
 
   const handleSearchKeyDown = (event: KeyboardEvent) => {
     if (isEnter(event)) {

--- a/registry/src/svelte/examples/hard-break/toolbar.svelte
+++ b/registry/src/svelte/examples/hard-break/toolbar.svelte
@@ -1,18 +1,28 @@
 <script lang="ts">
-import { useEditor } from 'prosekit/svelte'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/svelte'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
-const editor = useEditor<EditorExtension>({ update: true })
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    hardBreak: {
+      canExec: editor.commands.insertHardBreak.canExec(),
+      command: () => editor.commands.insertHardBreak(),
+    },
+  }
+}
+
+const items = useEditorDerivedValue(getToolbarItems)
 </script>
 
 <div class="CSS_TOOLBAR">
   <Button
     pressed={false}
-    disabled={!$editor.commands.insertHardBreak.canExec()}
-    onClick={() => $editor.commands.insertHardBreak()}
+    disabled={!$items.hardBreak.canExec}
+    onClick={$items.hardBreak.command}
   >
     Insert Hard Break
   </Button>

--- a/registry/src/svelte/examples/highlight/toolbar.svelte
+++ b/registry/src/svelte/examples/highlight/toolbar.svelte
@@ -1,18 +1,29 @@
 <script lang="ts">
-import { useEditor } from 'prosekit/svelte'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/svelte'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
-const editor = useEditor<EditorExtension>({ update: true })
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    highlight: {
+      isActive: editor.marks.highlight.isActive(),
+      canExec: editor.commands.toggleHighlight.canExec(),
+      command: () => editor.commands.toggleHighlight(),
+    },
+  }
+}
+
+const items = useEditorDerivedValue(getToolbarItems)
 </script>
 
 <div class="CSS_TOOLBAR">
   <Button
-    pressed={false}
-    disabled={!$editor.commands.toggleHighlight.canExec()}
-    onClick={() => $editor.commands.toggleHighlight()}
+    pressed={$items.highlight.isActive}
+    disabled={!$items.highlight.canExec}
+    onClick={$items.highlight.command}
   >
     Highlight
   </Button>

--- a/registry/src/svelte/examples/strike/toolbar.svelte
+++ b/registry/src/svelte/examples/strike/toolbar.svelte
@@ -1,18 +1,29 @@
 <script lang="ts">
-import { useEditor } from 'prosekit/svelte'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/svelte'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
-const editor = useEditor<EditorExtension>({ update: true })
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    strike: {
+      isActive: editor.marks.strike.isActive(),
+      canExec: editor.commands.toggleStrike.canExec(),
+      command: () => editor.commands.toggleStrike(),
+    },
+  }
+}
+
+const items = useEditorDerivedValue(getToolbarItems)
 </script>
 
 <div class="CSS_TOOLBAR">
   <Button
-    pressed={false}
-    disabled={!$editor.commands.toggleStrike.canExec()}
-    onClick={() => $editor.commands.toggleStrike()}
+    pressed={$items.strike.isActive}
+    disabled={!$items.strike.canExec}
+    onClick={$items.strike.command}
   >
     Strikethrough
   </Button>

--- a/registry/src/svelte/examples/sub-sup/toolbar.svelte
+++ b/registry/src/svelte/examples/sub-sup/toolbar.svelte
@@ -1,25 +1,41 @@
 <script lang="ts">
-import { useEditor } from 'prosekit/svelte'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/svelte'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
-const editor = useEditor<EditorExtension>({ update: true })
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    subscript: {
+      isActive: editor.marks.subscript.isActive(),
+      canExec: editor.commands.toggleSubscript.canExec(),
+      command: () => editor.commands.toggleSubscript(),
+    },
+    superscript: {
+      isActive: editor.marks.superscript.isActive(),
+      canExec: editor.commands.toggleSuperscript.canExec(),
+      command: () => editor.commands.toggleSuperscript(),
+    },
+  }
+}
+
+const items = useEditorDerivedValue(getToolbarItems)
 </script>
 
 <div class="CSS_TOOLBAR">
   <Button
-    pressed={false}
-    disabled={!$editor.commands.toggleSubscript.canExec()}
-    onClick={() => $editor.commands.toggleSubscript()}
+    pressed={$items.subscript.isActive}
+    disabled={!$items.subscript.canExec}
+    onClick={$items.subscript.command}
   >
     Subscript
   </Button>
   <Button
-    pressed={false}
-    disabled={!$editor.commands.toggleSuperscript.canExec()}
-    onClick={() => $editor.commands.toggleSuperscript()}
+    pressed={$items.superscript.isActive}
+    disabled={!$items.superscript.canExec}
+    onClick={$items.superscript.command}
   >
     Superscript
   </Button>

--- a/registry/src/vue/examples/hard-break/toolbar.vue
+++ b/registry/src/vue/examples/hard-break/toolbar.vue
@@ -1,19 +1,29 @@
 <script setup lang="ts">
-import { useEditor } from 'prosekit/vue'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/vue'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
-const editor = useEditor<EditorExtension>({ update: true })
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    hardBreak: {
+      canExec: editor.commands.insertHardBreak.canExec(),
+      command: () => editor.commands.insertHardBreak(),
+    },
+  }
+}
+
+const items = useEditorDerivedValue(getToolbarItems)
 </script>
 
 <template>
   <div class="CSS_TOOLBAR">
     <Button
       :pressed="false"
-      :disabled="!editor.commands.insertHardBreak.canExec()"
-      @click="editor.commands.insertHardBreak()"
+      :disabled="!items.hardBreak.canExec"
+      @click="items.hardBreak.command"
     >
       Insert Hard Break
     </Button>

--- a/registry/src/vue/examples/highlight/toolbar.vue
+++ b/registry/src/vue/examples/highlight/toolbar.vue
@@ -1,19 +1,30 @@
 <script setup lang="ts">
-import { useEditor } from 'prosekit/vue'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/vue'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
-const editor = useEditor<EditorExtension>({ update: true })
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    highlight: {
+      isActive: editor.marks.highlight.isActive(),
+      canExec: editor.commands.toggleHighlight.canExec(),
+      command: () => editor.commands.toggleHighlight(),
+    },
+  }
+}
+
+const items = useEditorDerivedValue(getToolbarItems)
 </script>
 
 <template>
   <div class="CSS_TOOLBAR">
     <Button
-      :pressed="false"
-      :disabled="!editor.commands.toggleHighlight.canExec()"
-      @click="() => editor.commands.toggleHighlight()"
+      :pressed="items.highlight.isActive"
+      :disabled="!items.highlight.canExec"
+      @click="items.highlight.command"
     >
       Highlight
     </Button>

--- a/registry/src/vue/examples/strike/toolbar.vue
+++ b/registry/src/vue/examples/strike/toolbar.vue
@@ -1,19 +1,30 @@
 <script setup lang="ts">
-import { useEditor } from 'prosekit/vue'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/vue'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
-const editor = useEditor<EditorExtension>({ update: true })
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    strike: {
+      isActive: editor.marks.strike.isActive(),
+      canExec: editor.commands.toggleStrike.canExec(),
+      command: () => editor.commands.toggleStrike(),
+    },
+  }
+}
+
+const items = useEditorDerivedValue(getToolbarItems)
 </script>
 
 <template>
   <div class="CSS_TOOLBAR">
     <Button
-      :pressed="false"
-      :disabled="!editor.commands.toggleStrike.canExec()"
-      @click="editor.commands.toggleStrike()"
+      :pressed="items.strike.isActive"
+      :disabled="!items.strike.canExec"
+      @click="items.strike.command"
     >
       Strikethrough
     </Button>

--- a/registry/src/vue/examples/sub-sup/toolbar.vue
+++ b/registry/src/vue/examples/sub-sup/toolbar.vue
@@ -1,26 +1,42 @@
 <script setup lang="ts">
-import { useEditor } from 'prosekit/vue'
+import type { Editor } from 'prosekit/core'
+import { useEditorDerivedValue } from 'prosekit/vue'
 
 import { Button } from '../../ui/button'
 
 import type { EditorExtension } from './extension'
 
-const editor = useEditor<EditorExtension>({ update: true })
+function getToolbarItems(editor: Editor<EditorExtension>) {
+  return {
+    subscript: {
+      isActive: editor.marks.subscript.isActive(),
+      canExec: editor.commands.toggleSubscript.canExec(),
+      command: () => editor.commands.toggleSubscript(),
+    },
+    superscript: {
+      isActive: editor.marks.superscript.isActive(),
+      canExec: editor.commands.toggleSuperscript.canExec(),
+      command: () => editor.commands.toggleSuperscript(),
+    },
+  }
+}
+
+const items = useEditorDerivedValue(getToolbarItems)
 </script>
 
 <template>
   <div class="CSS_TOOLBAR">
     <Button
-      :pressed="false"
-      :disabled="!editor.commands.toggleSubscript.canExec()"
-      @click="editor.commands.toggleSubscript()"
+      :pressed="items.subscript.isActive"
+      :disabled="!items.subscript.canExec"
+      @click="items.subscript.command"
     >
       Subscript
     </Button>
     <Button
-      :pressed="false"
-      :disabled="!editor.commands.toggleSuperscript.canExec()"
-      @click="editor.commands.toggleSuperscript()"
+      :pressed="items.superscript.isActive"
+      :disabled="!items.superscript.canExec"
+      @click="items.superscript.command"
     >
       Superscript
     </Button>


### PR DESCRIPTION
## Summary

Migrate the remaining example toolbars from the legacy `useEditor({ update: true })` pattern to `useEditorDerivedValue`, matching the production UI components (`ui/toolbar`) and the newer `text-align` / `text-color` examples.

The new pattern memoises the derived items object and only triggers re-renders when the toolbar state actually changes, instead of subscribing the whole component to every editor update.

## Files touched (21)

- `highlight` (React, Preact, Vue, Solid, Svelte)
- `strike` (React, Preact, Vue, Solid, Svelte)
- `sub-sup` (React, Preact, Vue, Solid, Svelte)
- `hard-break` (React, Preact, Vue, Solid, Svelte)
- `solid/ui/search/search.tsx` — drop the unused `{ update: true }` (this file only invokes commands in event handlers, never reads derived state in render)

For the toggle marks (`highlight`, `strike`, `subscript`, `superscript`) the migration also wires up real `isActive` via `editor.marks.<name>.isActive()` instead of the hardcoded `pressed={false}` the old examples used. `hard-break` is not a toggle and keeps `pressed={false}`.

## Verification

Run locally and all green:

- `nr typecheck`
- `nr -w fix`
- `nr -w lint` (ESLint, svelte-check, vue-tsc, astro check, knip — 0 errors / 0 warnings)
- `grep -rn "useEditor.*update.*true" registry/src/` returns zero matches.

## Test plan

- [ ] CI green on this PR.
- [ ] Manually verify in the website that the Highlight / Strike / Subscript / Superscript buttons reflect their `pressed` state as the cursor moves through the corresponding mark.
- [ ] Hard-break button remains disabled outside valid contexts and inserts a hard break when clicked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated toolbar example components across all supported frameworks to improve code maintainability and consistency in state management patterns.
  * Refined editor integration implementation in example components for better code organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prosekit/prosekit/pull/1626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->