### PR TITLE
feat(registry): add inline menu example for Lit

### DIFF
--- a/.changeset/lit-inline-menu.md
+++ b/.changeset/lit-inline-menu.md
@@ -1,0 +1,5 @@
+---
+"prosekit-registry": patch
+---
+
+Add a Lit inline-menu example and UI component to the registry.

--- a/.changeset/lit-inline-menu.md
+++ b/.changeset/lit-inline-menu.md
@@ -1,4 +1,5 @@
 ---
+'prosekit': patch
 "prosekit-registry": patch
 ---
 

--- a/registry/package.json
+++ b/registry/package.json
@@ -16,6 +16,7 @@
     "./examples.gen.json": "./src/examples.gen.json",
     "./lit/examples/block-handle": "./src/lit/examples/block-handle/index.ts",
     "./lit/examples/code-block": "./src/lit/examples/code-block/index.ts",
+    "./lit/examples/inline-menu": "./src/lit/examples/inline-menu/index.ts",
     "./lit/examples/minimal": "./src/lit/examples/minimal/index.ts",
     "./lit/examples/slash-menu": "./src/lit/examples/slash-menu/index.ts",
     "./lit/examples/table": "./src/lit/examples/table/index.ts",

--- a/registry/src/examples.gen.json
+++ b/registry/src/examples.gen.json
@@ -183,6 +183,7 @@
         "react",
         "preact",
         "vue",
+        "lit",
         "svelte",
         "solid"
       ],
@@ -2596,6 +2597,20 @@
         "registry/src/lit/ui/image-upload-popover/index.ts",
         "registry/src/lit/ui/toolbar/index.ts",
         "registry/src/lit/ui/toolbar/toolbar.ts"
+      ]
+    },
+    "lit-example-inline-menu": {
+      "story": "inline-menu",
+      "files": [
+        "registry/src/lit/examples/inline-menu/editor.ts",
+        "registry/src/lit/examples/inline-menu/extension.ts",
+        "registry/src/lit/examples/inline-menu/index.ts",
+        "registry/src/lit/sample/sample-doc-inline-menu.ts",
+        "registry/src/lit/ui/button/button.ts",
+        "registry/src/lit/ui/button/index.ts",
+        "registry/src/lit/ui/editor-context.ts",
+        "registry/src/lit/ui/inline-menu/index.ts",
+        "registry/src/lit/ui/inline-menu/inline-menu.ts"
       ]
     },
     "lit-example-minimal": {

--- a/registry/src/lit/examples/inline-menu/editor.ts
+++ b/registry/src/lit/examples/inline-menu/editor.ts
@@ -1,0 +1,73 @@
+import 'prosekit/basic/style.css'
+import 'prosekit/basic/typography.css'
+
+import { ContextProvider } from '@lit/context'
+import { html, LitElement, type PropertyDeclaration, type PropertyValues } from 'lit'
+import { createRef, ref, type Ref } from 'lit/directives/ref.js'
+import type { Editor } from 'prosekit/core'
+import { createEditor } from 'prosekit/core'
+
+import { sampleContent } from '../../sample/sample-doc-inline-menu'
+import { editorContext } from '../../ui/editor-context'
+import { registerLitEditorInlineMenu } from '../../ui/inline-menu'
+
+import { defineExtension } from './extension'
+
+export class LitEditor extends LitElement {
+  static override properties = {
+    editor: {
+      state: true,
+      attribute: false,
+    } satisfies PropertyDeclaration<Editor>,
+  }
+
+  private editor: Editor
+  private ref: Ref<HTMLDivElement>
+  constructor() {
+    super()
+
+    const extension = defineExtension()
+    this.editor = createEditor({ extension, defaultContent: sampleContent })
+    this.ref = createRef<HTMLDivElement>()
+    new ContextProvider(this, {
+      context: editorContext,
+      initialValue: this.editor,
+    })
+  }
+
+  override createRenderRoot() {
+    return this
+  }
+
+  override disconnectedCallback() {
+    this.editor.unmount()
+    super.disconnectedCallback()
+  }
+
+  override updated(changedProperties: PropertyValues) {
+    super.updated(changedProperties)
+    this.editor.mount(this.ref.value)
+  }
+
+  override render() {
+    return html`<div class="CSS_EDITOR_VIEWPORT">
+      <div class="CSS_EDITOR_SCROLLING">
+        <div ${ref(this.ref)} class="CSS_EDITOR_CONTENT"></div>
+        <lit-editor-inline-menu style="display: contents;"></lit-editor-inline-menu>
+      </div>
+    </div>`
+  }
+}
+
+export function registerLitEditor() {
+  registerLitEditorInlineMenu()
+
+  if (customElements.get('lit-editor-example-inline-menu')) return
+  customElements.define('lit-editor-example-inline-menu', LitEditor)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-example-inline-menu': LitEditor
+  }
+}

--- a/registry/src/lit/examples/inline-menu/extension.ts
+++ b/registry/src/lit/examples/inline-menu/extension.ts
@@ -1,0 +1,7 @@
+import { defineBasicExtension } from 'prosekit/basic'
+
+export function defineExtension() {
+  return defineBasicExtension()
+}
+
+export type EditorExtension = ReturnType<typeof defineExtension>

--- a/registry/src/lit/examples/inline-menu/index.ts
+++ b/registry/src/lit/examples/inline-menu/index.ts
@@ -1,0 +1,1 @@
+export { LitEditor as ExampleEditor, registerLitEditor } from './editor'

--- a/registry/src/lit/loaders.gen.ts
+++ b/registry/src/lit/loaders.gen.ts
@@ -3,6 +3,7 @@
 export const loaders = {
   'block-handle': () => import('./examples/block-handle').then((m) => m.registerLitEditor()),
   'code-block': () => import('./examples/code-block').then((m) => m.registerLitEditor()),
+  'inline-menu': () => import('./examples/inline-menu').then((m) => m.registerLitEditor()),
   'minimal': () => import('./examples/minimal').then((m) => m.registerLitEditor()),
   'slash-menu': () => import('./examples/slash-menu').then((m) => m.registerLitEditor()),
   'table': () => import('./examples/table').then((m) => m.registerLitEditor()),

--- a/registry/src/lit/sample/sample-doc-inline-menu.ts
+++ b/registry/src/lit/sample/sample-doc-inline-menu.ts
@@ -1,0 +1,33 @@
+import type { NodeJSON } from 'prosekit/core'
+
+const loremText =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Aliquet nec ullamcorper sit amet risus. Nam aliquam sem et tortor consequat id porta. Interdum posuere lorem ipsum dolor sit amet. Lectus sit amet est placerat in egestas erat. Egestas sed tempus urna et pharetra pharetra. Sit amet cursus sit amet dictum sit amet. Porttitor leo a diam sollicitudin. Tellus orci ac auctor augue. Tellus in hac habitasse platea dictumst vestibulum. At elementum eu facilisis sed odio morbi. Dolor magna eget est lorem ipsum. Et malesuada fames ac turpis egestas. Arcu risus quis varius quam quisque id diam. Purus viverra accumsan in nisl nisi scelerisque eu ultrices. Ut tortor pretium viverra suspendisse potenti nullam ac tortor vitae.'
+
+export const sampleContent: NodeJSON = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          marks: [
+            {
+              type: 'bold',
+            },
+          ],
+          text: 'Try to select some text',
+        },
+      ],
+    },
+    ...Array.from({ length: 10 }, () => ({
+      type: 'paragraph' as const,
+      content: [
+        {
+          type: 'text' as const,
+          text: loremText,
+        },
+      ],
+    })),
+  ],
+}

--- a/registry/src/lit/ui/inline-menu/index.ts
+++ b/registry/src/lit/ui/inline-menu/index.ts
@@ -1,0 +1,1 @@
+export { registerLitEditorInlineMenu } from './inline-menu'

--- a/registry/src/lit/ui/inline-menu/inline-menu.ts
+++ b/registry/src/lit/ui/inline-menu/inline-menu.ts
@@ -1,0 +1,300 @@
+import { ContextConsumer } from '@lit/context'
+import { html, LitElement, nothing, type PropertyDeclaration, type PropertyValues } from 'lit'
+import type { BasicExtension } from 'prosekit/basic'
+import { defineUpdateHandler, type Editor } from 'prosekit/core'
+import type { LinkAttrs } from 'prosekit/extensions/link'
+import {
+  registerInlinePopoverPopupElement,
+  registerInlinePopoverPositionerElement,
+  registerInlinePopoverRootElement,
+} from 'prosekit/lit/inline-popover'
+import type { EditorState } from 'prosekit/pm/state'
+
+import { registerLitEditorButton } from '../button'
+import { editorContext } from '../editor-context'
+
+function getInlineMenuItems(editor: Editor<BasicExtension>) {
+  return {
+    bold: editor.commands.toggleBold
+      ? {
+          isActive: editor.marks.bold.isActive(),
+          canExec: editor.commands.toggleBold.canExec(),
+          command: () => editor.commands.toggleBold(),
+        }
+      : undefined,
+    italic: editor.commands.toggleItalic
+      ? {
+          isActive: editor.marks.italic.isActive(),
+          canExec: editor.commands.toggleItalic.canExec(),
+          command: () => editor.commands.toggleItalic(),
+        }
+      : undefined,
+    underline: editor.commands.toggleUnderline
+      ? {
+          isActive: editor.marks.underline.isActive(),
+          canExec: editor.commands.toggleUnderline.canExec(),
+          command: () => editor.commands.toggleUnderline(),
+        }
+      : undefined,
+    strike: editor.commands.toggleStrike
+      ? {
+          isActive: editor.marks.strike.isActive(),
+          canExec: editor.commands.toggleStrike.canExec(),
+          command: () => editor.commands.toggleStrike(),
+        }
+      : undefined,
+    code: editor.commands.toggleCode
+      ? {
+          isActive: editor.marks.code.isActive(),
+          canExec: editor.commands.toggleCode.canExec(),
+          command: () => editor.commands.toggleCode(),
+        }
+      : undefined,
+    link: editor.commands.addLink
+      ? {
+          isActive: editor.marks.link.isActive(),
+          canExec: editor.commands.addLink.canExec({ href: '' }),
+          command: () => editor.commands.expandLink(),
+          currentLink: getCurrentLink(editor.state) || '',
+        }
+      : undefined,
+  }
+}
+
+function getCurrentLink(state: EditorState): string | undefined {
+  const { $from } = state.selection
+  const marks = $from.marksAcross($from)
+  if (!marks) {
+    return
+  }
+  for (const mark of marks) {
+    if (mark.type.name === 'link') {
+      return (mark.attrs as LinkAttrs).href
+    }
+  }
+}
+
+class LitInlineMenu extends LitElement {
+  static override properties = {
+    linkMenuOpen: { state: true, attribute: false } satisfies PropertyDeclaration<boolean>,
+  }
+
+  private linkMenuOpen = false
+
+  private editorConsumer = new ContextConsumer(this, {
+    context: editorContext,
+    subscribe: true,
+  })
+
+  private removeUpdateExtension?: VoidFunction
+
+  override createRenderRoot() {
+    return this
+  }
+
+  override connectedCallback() {
+    super.connectedCallback()
+    this.classList.add('contents')
+    this.attachEditorListener()
+  }
+
+  override disconnectedCallback() {
+    this.detachEditorListener()
+    super.disconnectedCallback()
+  }
+
+  override updated(changedProperties: PropertyValues) {
+    super.updated(changedProperties)
+    this.attachEditorListener()
+  }
+
+  private attachEditorListener() {
+    this.detachEditorListener()
+
+    const editor = this.editorConsumer.value
+    if (!editor) return
+
+    this.removeUpdateExtension = editor.use(defineUpdateHandler(() => this.requestUpdate()))
+  }
+
+  private detachEditorListener() {
+    this.removeUpdateExtension?.()
+    this.removeUpdateExtension = undefined
+  }
+
+  private handleLinkUpdate(editor: Editor<BasicExtension>, href?: string) {
+    if (href) {
+      editor.commands.addLink({ href })
+    } else {
+      editor.commands.removeLink()
+    }
+
+    this.linkMenuOpen = false
+    editor.focus()
+  }
+
+  override render() {
+    const editor = this.editorConsumer.value as Editor<BasicExtension> | undefined
+    if (!editor) {
+      return nothing
+    }
+
+    const items = getInlineMenuItems(editor)
+
+    return html`
+      <prosekit-inline-popover-root
+        .editor=${editor}
+        @openChange=${(event: CustomEvent<boolean>) => {
+          if (!event.detail) {
+            this.linkMenuOpen = false
+          }
+        }}
+      >
+        <prosekit-inline-popover-positioner class="CSS_INLINE_MENU_POSITIONER">
+          <prosekit-inline-popover-popup
+            data-testid="inline-menu-main"
+            class="CSS_INLINE_MENU_MAIN_POPUP"
+          >
+            ${items.bold
+              ? html`
+                  <lit-editor-button
+                    .pressed=${items.bold.isActive}
+                    .disabled=${!items.bold.canExec}
+                    tooltip="Bold"
+                    icon="CSS_ICON_BOLD"
+                    @click=${items.bold.command}
+                  ></lit-editor-button>
+                `
+              : nothing}
+            ${items.italic
+              ? html`
+                  <lit-editor-button
+                    .pressed=${items.italic.isActive}
+                    .disabled=${!items.italic.canExec}
+                    tooltip="Italic"
+                    icon="CSS_ICON_ITALIC"
+                    @click=${items.italic.command}
+                  ></lit-editor-button>
+                `
+              : nothing}
+            ${items.underline
+              ? html`
+                  <lit-editor-button
+                    .pressed=${items.underline.isActive}
+                    .disabled=${!items.underline.canExec}
+                    tooltip="Underline"
+                    icon="CSS_ICON_UNDERLINE"
+                    @click=${items.underline.command}
+                  ></lit-editor-button>
+                `
+              : nothing}
+            ${items.strike
+              ? html`
+                  <lit-editor-button
+                    .pressed=${items.strike.isActive}
+                    .disabled=${!items.strike.canExec}
+                    tooltip="Strikethrough"
+                    icon="CSS_ICON_STRIKETHROUGH"
+                    @click=${items.strike.command}
+                  ></lit-editor-button>
+                `
+              : nothing}
+            ${items.code
+              ? html`
+                  <lit-editor-button
+                    .pressed=${items.code.isActive}
+                    .disabled=${!items.code.canExec}
+                    tooltip="Code"
+                    icon="CSS_ICON_CODE"
+                    @click=${items.code.command}
+                  ></lit-editor-button>
+                `
+              : nothing}
+            ${items.link && items.link.canExec
+              ? html`
+                  <lit-editor-button
+                    .pressed=${items.link.isActive}
+                    tooltip="Link"
+                    icon="CSS_ICON_LINK"
+                    @click=${() => {
+                      items.link?.command?.()
+                      this.linkMenuOpen = !this.linkMenuOpen
+                    }}
+                  ></lit-editor-button>
+                `
+              : nothing}
+          </prosekit-inline-popover-popup>
+        </prosekit-inline-popover-positioner>
+      </prosekit-inline-popover-root>
+
+      ${items.link
+        ? html`
+            <prosekit-inline-popover-root
+              .editor=${editor}
+              .defaultOpen=${false}
+              .open=${this.linkMenuOpen}
+              @openChange=${(event: CustomEvent<boolean>) => {
+                this.linkMenuOpen = event.detail
+              }}
+            >
+              <prosekit-inline-popover-positioner
+                placement="bottom"
+                class="CSS_INLINE_MENU_POSITIONER"
+              >
+                <prosekit-inline-popover-popup
+                  data-testid="inline-menu-link"
+                  class="CSS_INLINE_MENU_LINK_POPUP"
+                >
+                  ${this.linkMenuOpen
+                    ? html`
+                        <form
+                          @submit=${(event: SubmitEvent) => {
+                            event.preventDefault()
+                            const target = event.target as HTMLFormElement | null
+                            const href = target?.querySelector('input')?.value?.trim()
+                            this.handleLinkUpdate(editor, href)
+                          }}
+                        >
+                          <input
+                            placeholder="Paste the link..."
+                            value=${items.link.currentLink}
+                            class="CSS_INLINE_MENU_LINK_POPUP_INPUT"
+                          />
+                        </form>
+                      `
+                    : nothing}
+                  ${items.link.isActive
+                    ? html`
+                        <button
+                          @click=${() => this.handleLinkUpdate(editor)}
+                          @mousedown=${(event: MouseEvent) => event.preventDefault()}
+                          class="CSS_INLINE_MENU_LINK_POPUP_REMOVE_BUTTON"
+                        >
+                          Remove link
+                        </button>
+                      `
+                    : nothing}
+                </prosekit-inline-popover-popup>
+              </prosekit-inline-popover-positioner>
+            </prosekit-inline-popover-root>
+          `
+        : nothing}
+    `
+  }
+}
+
+export function registerLitEditorInlineMenu() {
+  registerLitEditorButton()
+  registerInlinePopoverRootElement()
+  registerInlinePopoverPositionerElement()
+  registerInlinePopoverPopupElement()
+
+  if (customElements.get('lit-editor-inline-menu')) return
+  customElements.define('lit-editor-inline-menu', LitInlineMenu)
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lit-editor-inline-menu': LitInlineMenu
+  }
+}

--- a/website/src/stories/lit.stories.ts
+++ b/website/src/stories/lit.stories.ts
@@ -5,6 +5,7 @@ export default { component }
 
 export const BlockHandle = { args: { story: 'block-handle' } }
 export const CodeBlock = { args: { story: 'code-block' } }
+export const InlineMenu = { args: { story: 'inline-menu' } }
 export const Minimal = { args: { story: 'minimal' } }
 export const SlashMenu = { args: { story: 'slash-menu' } }
 export const Table = { args: { story: 'table' } }


### PR DESCRIPTION
## Summary

Adds the `inline-menu` example for the Lit framework, bringing Lit to parity with React/Preact/Vue/Svelte/Solid for this story.

- New shared UI component at `registry/src/lit/ui/inline-menu/` (`<lit-editor-inline-menu>`) using `prosekit/lit/inline-popover`, mirroring the React component's behavior, DOM structure, button order, CSS classes, and `data-testid` values.
- New example at `registry/src/lit/examples/inline-menu/` plus its sample document at `registry/src/lit/sample/sample-doc-inline-menu.ts`.
- Regenerated `registry/package.json`, `registry/src/examples.gen.json`, `registry/src/lit/loaders.gen.ts`, and `website/src/stories/lit.stories.ts` via `pnpm gen`.

The component follows the existing Lit registry conventions: `editorContext` consumer with `subscribe: true`, `defineUpdateHandler` + `requestUpdate()` for editor change reactivity (same as `lit/ui/toolbar`), light DOM (`createRenderRoot()` returns `this`), `class="contents"` on the host, and an idempotent `registerLitEditorInlineMenu()` registration.

## Test plan

- [x] `pnpm run lint` — 0 errors, 0 warnings
- [x] `pnpm run typecheck` — passes
- [ ] Manually verify in the playground that selecting text opens the inline menu, that bold/italic/underline/strike/code toggle correctly, and that the link button opens a secondary popover that can add and remove links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Lit inline-menu example with formatting controls (bold, italic, underline, strike, code) and link editing capabilities to the component registry and Storybook.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prosekit/prosekit/pull/1634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->