### PR TITLE
refactor(code-block): simplify code block preview decoration API

### DIFF
--- a/.changeset/ext-code-deco.md
+++ b/.changeset/ext-code-deco.md
@@ -3,4 +3,4 @@
 "@prosekit/extensions": patch
 ---
 
-Add `defineCodeBlockPreviewPlugin()` and `hasCodeBlockPreviewHiddenDecoration()` to `prosekit/extensions/code-block`. A node view for `codeBlock` can use them to swap between an editable source view and a rendered view based on whether the cursor is inside.
+Add `defineCodeBlockPreviewPlugin()` and `isCodeBlockPreviewHiddenDecoration()` to `prosekit/extensions/code-block`. A node view for `codeBlock` can use them to swap between an editable source view and a rendered view based on whether the cursor is inside.

--- a/packages/extensions/src/code-block/code-block-preview.spec.ts
+++ b/packages/extensions/src/code-block/code-block-preview.spec.ts
@@ -8,7 +8,6 @@ import { defineTestExtension, setupTestFromExtension } from '../testing/index.ts
 import {
   codeBlockPreviewDecorationsPluginKey,
   defineCodeBlockPreviewPlugin,
-  hasCodeBlockPreviewHiddenDecoration,
   HIDE_CODE_BLOCK_PREVIEW,
   isCodeBlockPreviewHiddenDecoration,
 } from './code-block-preview.ts'
@@ -21,30 +20,20 @@ function setupEditor() {
   return setupTestFromExtension(extension)
 }
 
-describe('hasCodeBlockPreviewHiddenDecoration', () => {
-  it('returns false for an empty array', () => {
-    expect(hasCodeBlockPreviewHiddenDecoration([])).toBe(false)
-  })
-
-  it('returns true when a decoration has the HIDE_CODE_BLOCK_PREVIEW spec', () => {
+describe('isCodeBlockPreviewHiddenDecoration', () => {
+  it('returns true for a decoration with the HIDE_CODE_BLOCK_PREVIEW spec', () => {
     const deco = Decoration.node(0, 1, {}, HIDE_CODE_BLOCK_PREVIEW)
-    expect(hasCodeBlockPreviewHiddenDecoration([deco])).toBe(true)
+    expect(isCodeBlockPreviewHiddenDecoration(deco)).toBe(true)
   })
 
-  it('returns false when no decoration has the HIDE spec', () => {
+  it('returns false for a decoration with a different spec', () => {
     const deco = Decoration.node(0, 1, {}, { someOtherProp: true })
-    expect(hasCodeBlockPreviewHiddenDecoration([deco])).toBe(false)
+    expect(isCodeBlockPreviewHiddenDecoration(deco)).toBe(false)
   })
 
-  it('returns true when one of multiple decorations has the HIDE spec', () => {
-    const deco1 = Decoration.node(0, 1, {}, { someOther: true })
-    const deco2 = Decoration.node(2, 3, {}, HIDE_CODE_BLOCK_PREVIEW)
-    expect(hasCodeBlockPreviewHiddenDecoration([deco1, deco2])).toBe(true)
-  })
-
-  it('returns false for inline decorations without spec', () => {
+  it('returns false for an inline decoration without spec', () => {
     const deco = Decoration.inline(0, 1, { class: 'foo' })
-    expect(hasCodeBlockPreviewHiddenDecoration([deco])).toBe(false)
+    expect(isCodeBlockPreviewHiddenDecoration(deco)).toBe(false)
   })
 })
 

--- a/packages/extensions/src/code-block/code-block-preview.ts
+++ b/packages/extensions/src/code-block/code-block-preview.ts
@@ -13,7 +13,7 @@ export const codeBlockPreviewDecorationsPluginKey: PluginKey<PluginState> = new 
 )
 
 /**
- * Defines a plugin that adds a decoration to hide the code block preview when the cursor is inside a code block.
+ * Defines a plugin that adds a decoration to hide the code block preview when the cursor is inside a code block. Use {@link isCodeBlockPreviewHiddenDecoration} to check whether a given decoration hides the code block preview.
  */
 export function defineCodeBlockPreviewPlugin(): PlainExtension {
   return definePlugin(
@@ -44,9 +44,7 @@ export function defineCodeBlockPreviewPlugin(): PlainExtension {
 
 /**
  * Returns whether the given decoration hides the code block preview (i.e.
- * the cursor is inside the code block it decorates). Combine with
- * `Array.prototype.some` to check a list of decorations:
- * `decorations.some(isCodeBlockPreviewHiddenDecoration)`.
+ * the cursor is inside the code block it decorates).
  */
 export function isCodeBlockPreviewHiddenDecoration(decoration: Decoration): boolean {
   return decoration.spec === HIDE_CODE_BLOCK_PREVIEW

--- a/packages/extensions/src/code-block/code-block-preview.ts
+++ b/packages/extensions/src/code-block/code-block-preview.ts
@@ -42,18 +42,14 @@ export function defineCodeBlockPreviewPlugin(): PlainExtension {
   )
 }
 
-/** @internal */
+/**
+ * Returns whether the given decoration hides the code block preview (i.e.
+ * the cursor is inside the code block it decorates). Combine with
+ * `Array.prototype.some` to check a list of decorations:
+ * `decorations.some(isCodeBlockPreviewHiddenDecoration)`.
+ */
 export function isCodeBlockPreviewHiddenDecoration(decoration: Decoration): boolean {
   return decoration.spec === HIDE_CODE_BLOCK_PREVIEW
-}
-
-/**
- * Whether the given decorations include a decoration that hides the code block preview.
- */
-export function hasCodeBlockPreviewHiddenDecoration(
-  decorations: readonly Decoration[],
-): boolean {
-  return decorations.some(isCodeBlockPreviewHiddenDecoration)
 }
 
 function createCodeBlockPreviewDecorations(state: EditorState): DecorationSet | undefined {

--- a/packages/extensions/src/code-block/index.ts
+++ b/packages/extensions/src/code-block/index.ts
@@ -2,7 +2,7 @@ export { defineCodeBlockCommands, type CodeBlockCommandsExtension } from './code
 export { defineCodeBlockHighlight, type CodeBlockHighlightOptions, type HighlightParser } from './code-block-highlight.ts'
 export { defineCodeBlockEnterRule, defineCodeBlockInputRule } from './code-block-input-rule.ts'
 export { defineCodeBlockKeymap } from './code-block-keymap.ts'
-export { defineCodeBlockPreviewPlugin, hasCodeBlockPreviewHiddenDecoration } from './code-block-preview.ts'
+export { defineCodeBlockPreviewPlugin, isCodeBlockPreviewHiddenDecoration } from './code-block-preview.ts'
 export { defineCodeBlockShiki, type CodeBlockShikiOptions } from './code-block-shiki.ts'
 export { defineCodeBlockSpec, type CodeBlockSpecExtension } from './code-block-spec.ts'
 export type { CodeBlockAttrs } from './code-block-types.ts'

--- a/registry/src/lit/ui/code-block-view/code-block-view.ts
+++ b/registry/src/lit/ui/code-block-view/code-block-view.ts
@@ -4,7 +4,7 @@ import type { Extension } from 'prosekit/core'
 import { defineNodeView } from 'prosekit/core'
 import type { CodeBlockAttrs } from 'prosekit/extensions/code-block'
 import {
-  hasCodeBlockPreviewHiddenDecoration,
+  isCodeBlockPreviewHiddenDecoration,
   shikiBundledLanguagesInfo,
 } from 'prosekit/extensions/code-block'
 import type { ProseMirrorNode } from 'prosekit/pm/model'
@@ -79,7 +79,7 @@ class CodeBlockNodeView {
 
   private sync() {
     const language = (this.node.attrs as CodeBlockAttrs).language || ''
-    const forceShowSource = hasCodeBlockPreviewHiddenDecoration(this.decorations)
+    const forceShowSource = this.decorations.some(isCodeBlockPreviewHiddenDecoration)
     const showMermaidPreview = !forceShowSource && language === 'mermaid'
 
     render(

--- a/registry/src/preact/ui/code-block-view/code-block-view.tsx
+++ b/registry/src/preact/ui/code-block-view/code-block-view.tsx
@@ -1,14 +1,14 @@
 import { renderMermaidSVG, THEMES } from 'beautiful-mermaid'
 import type { JSX } from 'preact'
 import { useMemo } from 'preact/hooks'
-import { hasCodeBlockPreviewHiddenDecoration, shikiBundledLanguagesInfo, type CodeBlockAttrs } from 'prosekit/extensions/code-block'
+import { isCodeBlockPreviewHiddenDecoration, shikiBundledLanguagesInfo, type CodeBlockAttrs } from 'prosekit/extensions/code-block'
 import { TextSelection } from 'prosekit/pm/state'
 import type { PreactNodeViewProps } from 'prosekit/preact'
 
 export default function CodeBlockView(props: PreactNodeViewProps) {
   const attrs = props.node.attrs as CodeBlockAttrs
   const language = attrs.language || ''
-  const forceShowSource = hasCodeBlockPreviewHiddenDecoration(props.decorations)
+  const forceShowSource = props.decorations.some(isCodeBlockPreviewHiddenDecoration)
 
   const showMermaidPreview = !forceShowSource && language === 'mermaid'
 

--- a/registry/src/react/ui/code-block-view/code-block-view.tsx
+++ b/registry/src/react/ui/code-block-view/code-block-view.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { renderMermaidSVG, THEMES } from 'beautiful-mermaid'
-import { hasCodeBlockPreviewHiddenDecoration, shikiBundledLanguagesInfo, type CodeBlockAttrs } from 'prosekit/extensions/code-block'
+import { isCodeBlockPreviewHiddenDecoration, shikiBundledLanguagesInfo, type CodeBlockAttrs } from 'prosekit/extensions/code-block'
 import { TextSelection } from 'prosekit/pm/state'
 import type { ReactNodeViewProps } from 'prosekit/react'
 import { useMemo } from 'react'
@@ -9,7 +9,7 @@ import { useMemo } from 'react'
 export default function CodeBlockView(props: ReactNodeViewProps) {
   const attrs = props.node.attrs as CodeBlockAttrs
   const language = attrs.language || ''
-  const forceShowSource = hasCodeBlockPreviewHiddenDecoration(props.decorations)
+  const forceShowSource = props.decorations.some(isCodeBlockPreviewHiddenDecoration)
 
   const showMermaidPreview = !forceShowSource && language === 'mermaid'
 

--- a/registry/src/solid/ui/code-block-view/code-block-view.tsx
+++ b/registry/src/solid/ui/code-block-view/code-block-view.tsx
@@ -1,5 +1,5 @@
 import { renderMermaidSVG, THEMES } from 'beautiful-mermaid'
-import { hasCodeBlockPreviewHiddenDecoration, shikiBundledLanguagesInfo, type CodeBlockAttrs } from 'prosekit/extensions/code-block'
+import { isCodeBlockPreviewHiddenDecoration, shikiBundledLanguagesInfo, type CodeBlockAttrs } from 'prosekit/extensions/code-block'
 import { TextSelection } from 'prosekit/pm/state'
 import type { SolidNodeViewProps } from 'prosekit/solid'
 import { createMemo, For, Show, type JSX } from 'solid-js'
@@ -7,7 +7,7 @@ import { createMemo, For, Show, type JSX } from 'solid-js'
 export default function CodeBlockView(props: SolidNodeViewProps): JSX.Element {
   const attrs = () => props.node.attrs as CodeBlockAttrs
   const language = () => attrs().language || ''
-  const forceShowSource = () => hasCodeBlockPreviewHiddenDecoration(props.decorations)
+  const forceShowSource = () => props.decorations.some(isCodeBlockPreviewHiddenDecoration)
   const showMermaidPreview = () => !forceShowSource() && language() === 'mermaid'
 
   const mermaidPreview = createMemo<{ svg: string | null; error: Error | null }>(() => {

--- a/registry/src/svelte/ui/code-block-view/code-block-view.svelte
+++ b/registry/src/svelte/ui/code-block-view/code-block-view.svelte
@@ -2,7 +2,7 @@
 import { renderMermaidSVG, THEMES } from 'beautiful-mermaid'
 import type { ProseMirrorNode } from 'prosekit/pm/model'
 import type { CodeBlockAttrs } from 'prosekit/extensions/code-block'
-import { hasCodeBlockPreviewHiddenDecoration, shikiBundledLanguagesInfo } from 'prosekit/extensions/code-block'
+import { isCodeBlockPreviewHiddenDecoration, shikiBundledLanguagesInfo } from 'prosekit/extensions/code-block'
 import { TextSelection } from 'prosekit/pm/state'
 import type { Decoration } from 'prosekit/pm/view'
 import type { SvelteNodeViewProps } from 'prosekit/svelte'
@@ -16,7 +16,7 @@ const decorations: readonly Decoration[] = $derived(fromStore(props.decorations)
 
 const attrs = $derived(node.attrs as CodeBlockAttrs)
 const language = $derived(attrs.language || '')
-const forceShowSource = $derived(hasCodeBlockPreviewHiddenDecoration(decorations))
+const forceShowSource = $derived(decorations.some(isCodeBlockPreviewHiddenDecoration))
 const showMermaidPreview = $derived(!forceShowSource && language === 'mermaid')
 
 const mermaidPreview = $derived.by<{ svg: string | null; error: Error | null }>(() => {

--- a/registry/src/vue/ui/code-block-view/code-block-view.vue
+++ b/registry/src/vue/ui/code-block-view/code-block-view.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { renderMermaidSVG, THEMES } from 'beautiful-mermaid'
-import { hasCodeBlockPreviewHiddenDecoration, shikiBundledLanguagesInfo, type CodeBlockAttrs } from 'prosekit/extensions/code-block'
+import { isCodeBlockPreviewHiddenDecoration, shikiBundledLanguagesInfo, type CodeBlockAttrs } from 'prosekit/extensions/code-block'
 import { TextSelection } from 'prosekit/pm/state'
 import type { VueNodeViewProps } from 'prosekit/vue'
 import { computed } from 'vue'
@@ -9,7 +9,7 @@ const props = defineProps<VueNodeViewProps>()
 
 const attrs = computed(() => props.node.value.attrs as CodeBlockAttrs)
 const language = computed(() => attrs.value.language || '')
-const forceShowSource = computed(() => hasCodeBlockPreviewHiddenDecoration(props.decorations.value))
+const forceShowSource = computed(() => props.decorations.value.some(isCodeBlockPreviewHiddenDecoration))
 const showMermaidPreview = computed(() => !forceShowSource.value && language.value === 'mermaid')
 
 const mermaidPreview = computed<{ svg: string | null; error: Error | null }>(() => {

--- a/website/src/content/docs/extensions/code-block.mdx
+++ b/website/src/content/docs/extensions/code-block.mdx
@@ -114,7 +114,7 @@ const extension = defineCodeBlockHighlight({ parser })
 
 ## Live rendering
 
-`defineCodeBlockPreviewPlugin()` marks the code block containing the current selection with a node decoration. A custom node view can check for that decoration with `hasCodeBlockPreviewHiddenDecoration` and render a custom view (for example a [Mermaid](https://mermaid.js.org) diagram) when the cursor is elsewhere, or the editable source when the cursor is inside.
+`defineCodeBlockPreviewPlugin()` marks the code block containing the current selection with a node decoration. A custom node view can detect that decoration by checking whether `decorations.some(isCodeBlockPreviewHiddenDecoration)` is true and render a custom view (for example a [Mermaid](https://mermaid.js.org) diagram) when the cursor is elsewhere, or the editable source when the cursor is inside.
 
 See [examples/code-block](/examples/code-block) for a runnable implementation that renders Mermaid diagrams inside the standard code-block view.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed code-block preview hidden-decoration detection API from `hasCodeBlockPreviewHiddenDecoration()` to `isCodeBlockPreviewHiddenDecoration()` for improved consistency.

* **Documentation**
  * Updated code-block preview plugin documentation to reflect the new decoration detection approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prosekit/prosekit/pull/1647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->