### PR TITLE
docs: improve README files across packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,7 @@ See [CONTRIBUTING.md](https://github.com/prosekit/prosekit/blob/master/CONTRIBUT
 
 ## Sponsors
 
-<p align="center">
-	<a href="https://github.com/sponsors/ocavue">
-		<img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors">
-	</a>
-</p>
+<p align="center"><a href="https://github.com/sponsors/ocavue"><img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors"></a></p>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/prosekit)](https://www.npmjs.com/package/prosekit)
 
-The ultimate toolkit for building rich text editors on the web. Headless, type-safe, and composable, built on [ProseMirror](https://prosemirror.net/) with first-class support for React, Vue, Preact, Svelte, Solid, and vanilla JavaScript.
+The ultimate toolkit for building rich text editors on the web. Headless, type-safe, and composable, built on [ProseMirror](https://prosemirror.net/) with first-class support for [React](https://react.dev/), [Vue](https://vuejs.org/), [Preact](https://preactjs.com/), [Svelte](https://svelte.dev/), [Solid](https://www.solidjs.com/), and vanilla JavaScript.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,30 @@
 
 [![npm](https://img.shields.io/npm/v/prosekit)](https://www.npmjs.com/package/prosekit)
 
-The ultimate toolkit for text editing. Based on [ProseMirror](https://prosemirror.net/).
+The ultimate toolkit for building rich text editors on the web. Headless, type-safe, and composable, built on [ProseMirror](https://prosemirror.net/) with first-class support for React, Vue, Preact, Svelte, Solid, and vanilla JavaScript.
 
 ## Quick Start
 
-You can install a full-featured example with a single command using [shadcn/ui](https://ui.shadcn.com):
+Install the package:
 
 ```bash
-# Use React
+npm install prosekit
+```
+
+Then follow the [Quick Start guide](https://prosekit.dev/getting-started/quick-start) to build your first editor.
+
+Using [shadcn/ui](https://ui.shadcn.com)? Scaffold a full-featured editor with a single command:
+
+```bash
+# React
 npx shadcn@latest add @prosekit/react-example-full
-# Use Vue
+# Vue
 npx shadcn@latest add @prosekit/vue-example-full
-# Use Preact
+# Preact
 npx shadcn@latest add @prosekit/preact-example-full
-# Use Svelte
+# Svelte
 npx shadcn@latest add @prosekit/svelte-example-full
-# Use Solid
+# Solid
 npx shadcn@latest add @prosekit/solid-example-full
 ```
 
@@ -31,11 +39,11 @@ Join the community on [Discord](https://prosekit.dev/chat).
 
 ## Changelog
 
-Detailed changes for each release are documented in the [CHANGELOG.md](https://github.com/ocavue/prosekit/blob/master/packages/prosekit/CHANGELOG.md).
+Detailed changes for each release are documented in the [CHANGELOG.md](https://github.com/prosekit/prosekit/blob/master/packages/prosekit/CHANGELOG.md).
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/ocavue/prosekit/blob/master/CONTRIBUTING.md) for details.
+See [CONTRIBUTING.md](https://github.com/prosekit/prosekit/blob/master/CONTRIBUTING.md) for details.
 
 ## Sponsors
 

--- a/packages/basic/README.md
+++ b/packages/basic/README.md
@@ -1,0 +1,15 @@
+# @prosekit/basic
+
+[![npm](https://img.shields.io/npm/v/@prosekit/basic)](https://www.npmjs.com/package/@prosekit/basic)
+
+A quick starter for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. `defineBasicExtension()` bundles the most common nodes and marks — paragraphs, headings, bold, italic, lists, and more — so you can spin up a working editor in a single call.
+
+> **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package. Most users should install `prosekit` and import from `prosekit/basic` instead of depending on this package directly.
+
+## Documentation
+
+See the [`prosekit/basic` reference](https://prosekit.dev/references/basic) and the [Quick Start](https://prosekit.dev/getting-started/quick-start) on [prosekit.dev](https://prosekit.dev).
+
+## License
+
+[MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/basic/README.md
+++ b/packages/basic/README.md
@@ -10,6 +10,10 @@ A quick starter for [ProseKit](https://prosekit.dev), the toolkit for building r
 
 See the [`prosekit/basic` reference](https://prosekit.dev/references/basic) and the [Quick Start](https://prosekit.dev/getting-started/quick-start) on [prosekit.dev](https://prosekit.dev).
 
+## Sponsors
+
+<p align="center"><a href="https://github.com/sponsors/ocavue"><img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors"></a></p>
+
 ## License
 
 [MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/basic/README.md
+++ b/packages/basic/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@prosekit/basic)](https://www.npmjs.com/package/@prosekit/basic)
 
-A quick starter for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. `defineBasicExtension()` bundles the most common nodes and marks — paragraphs, headings, bold, italic, lists, and more — so you can spin up a working editor in a single call.
+A quick starter for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. `defineBasicExtension()` bundles the most common nodes and marks (paragraphs, headings, bold, italic, lists, and more), so you can spin up a working editor in a single call.
 
 > **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package. Most users should install `prosekit` and import from `prosekit/basic` instead of depending on this package directly.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -10,6 +10,10 @@ The core editor engine and extension system for [ProseKit](https://prosekit.dev)
 
 See the [`prosekit/core` reference](https://prosekit.dev/references/core) and the [Extensions concept](https://prosekit.dev/concepts/extensions) on [prosekit.dev](https://prosekit.dev).
 
+## Sponsors
+
+<p align="center"><a href="https://github.com/sponsors/ocavue"><img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors"></a></p>
+
 ## License
 
 [MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,1 +1,15 @@
 # @prosekit/core
+
+[![npm](https://img.shields.io/npm/v/@prosekit/core)](https://www.npmjs.com/package/@prosekit/core)
+
+The core editor engine and extension system for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. It provides `createEditor`, the `union` extension composer, and the `define*` primitives that every other ProseKit extension is built from.
+
+> **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package. Most users should install `prosekit` and import from `prosekit/core` instead of depending on this package directly.
+
+## Documentation
+
+See the [`prosekit/core` reference](https://prosekit.dev/references/core) and the [Extensions concept](https://prosekit.dev/concepts/extensions) on [prosekit.dev](https://prosekit.dev).
+
+## License
+
+[MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@prosekit/extensions)](https://www.npmjs.com/package/@prosekit/extensions)
 
-A collection of common extensions for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Each feature — bold, italic, headings, lists, links, tables, code blocks, and many more — ships as its own entry point, so you only bundle what you use.
+A collection of common extensions for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Each feature (bold, italic, headings, lists, links, tables, code blocks, and many more) ships as its own entry point, so you only bundle what you use.
 
 ```ts
 import { defineBold } from '@prosekit/extensions/bold'

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -1,0 +1,20 @@
+# @prosekit/extensions
+
+[![npm](https://img.shields.io/npm/v/@prosekit/extensions)](https://www.npmjs.com/package/@prosekit/extensions)
+
+A collection of common extensions for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Each feature — bold, italic, headings, lists, links, tables, code blocks, and many more — ships as its own entry point, so you only bundle what you use.
+
+```ts
+import { defineBold } from '@prosekit/extensions/bold'
+import { defineList } from '@prosekit/extensions/list'
+```
+
+> **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package. Most users should install `prosekit` and import from `prosekit/extensions/*` instead of depending on this package directly.
+
+## Documentation
+
+See the [extensions overview](https://prosekit.dev/extensions/overview) and the [`prosekit/extensions` reference](https://prosekit.dev/references/extensions) on [prosekit.dev](https://prosekit.dev).
+
+## License
+
+[MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -15,6 +15,10 @@ import { defineList } from '@prosekit/extensions/list'
 
 See the [extensions overview](https://prosekit.dev/extensions/overview) and the [`prosekit/extensions` reference](https://prosekit.dev/references/extensions) on [prosekit.dev](https://prosekit.dev).
 
+## Sponsors
+
+<p align="center"><a href="https://github.com/sponsors/ocavue"><img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors"></a></p>
+
 ## License
 
 [MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/lit/README.md
+++ b/packages/lit/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@prosekit/lit)](https://www.npmjs.com/package/@prosekit/lit)
 
-[Lit](https://lit.dev/)-based components and utilities for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. They implement ProseKit's UI primitives — block handles, menus, popovers, tooltips, and more.
+[Lit](https://lit.dev/)-based components and utilities for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. They implement ProseKit's UI primitives: block handles, menus, popovers, tooltips, and more.
 
 > **Note:** This is a low-level building block. Most users should install the main [`prosekit`](https://www.npmjs.com/package/prosekit) package and use the components for their framework instead.
 

--- a/packages/lit/README.md
+++ b/packages/lit/README.md
@@ -10,6 +10,10 @@
 
 See the [components documentation](https://prosekit.dev/components/) on [prosekit.dev](https://prosekit.dev).
 
+## Sponsors
+
+<p align="center"><a href="https://github.com/sponsors/ocavue"><img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors"></a></p>
+
 ## License
 
 [MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/lit/README.md
+++ b/packages/lit/README.md
@@ -1,0 +1,15 @@
+# @prosekit/lit
+
+[![npm](https://img.shields.io/npm/v/@prosekit/lit)](https://www.npmjs.com/package/@prosekit/lit)
+
+[Lit](https://lit.dev/)-based components and utilities for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. They implement ProseKit's UI primitives — block handles, menus, popovers, tooltips, and more.
+
+> **Note:** This is a low-level building block. Most users should install the main [`prosekit`](https://www.npmjs.com/package/prosekit) package and use the components for their framework instead.
+
+## Documentation
+
+See the [components documentation](https://prosekit.dev/components/) on [prosekit.dev](https://prosekit.dev).
+
+## License
+
+[MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/pm/README.md
+++ b/packages/pm/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@prosekit/pm)](https://www.npmjs.com/package/@prosekit/pm)
 
-The [ProseMirror](https://prosemirror.net/) packages that [ProseKit](https://prosekit.dev) builds on, re-exported under a single dependency with consistent versions. Import each module from its own entry point:
+The core [ProseMirror](https://prosemirror.net/) packages that [ProseKit](https://prosekit.dev) builds on, re-exported under a single dependency with consistent versions. Import each module from its own entry point:
 
 | Entry point               | Re-exports                                                                       |
 | ------------------------- | -------------------------------------------------------------------------------- |

--- a/packages/pm/README.md
+++ b/packages/pm/README.md
@@ -26,6 +26,10 @@ import { Schema } from '@prosekit/pm/model'
 
 See the [`prosekit/pm` reference](https://prosekit.dev/references/pm) on [prosekit.dev](https://prosekit.dev).
 
+## Sponsors
+
+<p align="center"><a href="https://github.com/sponsors/ocavue"><img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors"></a></p>
+
 ## License
 
 [MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/pm/README.md
+++ b/packages/pm/README.md
@@ -1,8 +1,10 @@
 # @prosekit/pm
 
-This package provides a convenient way to install all the core ProseMirror packages at once. It simply re-exports the following packages:
+[![npm](https://img.shields.io/npm/v/@prosekit/pm)](https://www.npmjs.com/package/@prosekit/pm)
 
-| Entry points              | Package                                                                          |
+The [ProseMirror](https://prosemirror.net/) packages that [ProseKit](https://prosekit.dev) builds on, re-exported under a single dependency with consistent versions. Import each module from its own entry point:
+
+| Entry point               | Re-exports                                                                       |
 | ------------------------- | -------------------------------------------------------------------------------- |
 | `@prosekit/pm/model`      | [`prosemirror-model`](https://www.npmjs.com/package/prosemirror-model)           |
 | `@prosekit/pm/state`      | [`prosemirror-state`](https://www.npmjs.com/package/prosemirror-state)           |
@@ -12,8 +14,18 @@ This package provides a convenient way to install all the core ProseMirror packa
 | `@prosekit/pm/keymap`     | [`prosemirror-keymap`](https://www.npmjs.com/package/prosemirror-keymap)         |
 | `@prosekit/pm/inputrules` | [`prosemirror-inputrules`](https://www.npmjs.com/package/prosemirror-inputrules) |
 
-You can import the individual packages using the entry points listed above. For example, to import the `Schema` from `prosemirror-model` package, you can do:
+For example, to import `Schema` from `prosemirror-model`:
 
-```js
+```ts
 import { Schema } from '@prosekit/pm/model'
 ```
+
+> **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package, where the same modules are available as `prosekit/pm/*`.
+
+## Documentation
+
+See the [`prosekit/pm` reference](https://prosekit.dev/references/pm) on [prosekit.dev](https://prosekit.dev).
+
+## License
+
+[MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@prosekit/preact)](https://www.npmjs.com/package/@prosekit/preact)
 
-Preact bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and hooks for wiring a ProseKit editor into your Preact app.
+[Preact](https://preactjs.com/) bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and hooks for wiring a ProseKit editor into your Preact app.
 
 > **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package. Most users should install `prosekit` and import from `prosekit/preact` instead of depending on this package directly.
 

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -10,6 +10,10 @@
 
 See the [Preact guide](https://prosekit.dev/frameworks/preact) on [prosekit.dev](https://prosekit.dev).
 
+## Sponsors
+
+<p align="center"><a href="https://github.com/sponsors/ocavue"><img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors"></a></p>
+
 ## License
 
 [MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -1,0 +1,15 @@
+# @prosekit/preact
+
+[![npm](https://img.shields.io/npm/v/@prosekit/preact)](https://www.npmjs.com/package/@prosekit/preact)
+
+Preact bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and hooks for wiring a ProseKit editor into your Preact app.
+
+> **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package. Most users should install `prosekit` and import from `prosekit/preact` instead of depending on this package directly.
+
+## Documentation
+
+See the [Preact guide](https://prosekit.dev/frameworks/preact) on [prosekit.dev](https://prosekit.dev).
+
+## License
+
+[MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/prosekit/README.md
+++ b/packages/prosekit/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/prosekit)](https://www.npmjs.com/package/prosekit)
 
-The ultimate toolkit for building rich text editors on the web. Headless, type-safe, and composable, built on [ProseMirror](https://prosemirror.net/) with first-class support for React, Vue, Preact, Svelte, Solid, and vanilla JavaScript.
+The ultimate toolkit for building rich text editors on the web. Headless, type-safe, and composable, built on [ProseMirror](https://prosemirror.net/) with first-class support for [React](https://react.dev/), [Vue](https://vuejs.org/), [Preact](https://preactjs.com/), [Svelte](https://svelte.dev/), [Solid](https://www.solidjs.com/), and vanilla JavaScript.
 
 ## Installation
 
@@ -20,13 +20,6 @@ const editor = createEditor({ extension: defineBasicExtension() })
 ```
 
 Then mount the editor in your framework of choice. See the [Quick Start](https://prosekit.dev/getting-started/quick-start) for a complete example.
-
-`prosekit` bundles every `@prosekit/*` package under a single dependency, and each entry point re-exports its scoped counterpart. So these two imports are equivalent:
-
-```ts
-import { defineItalic } from '@prosekit/extensions/italic'
-import { defineItalic } from 'prosekit/extensions/italic'
-```
 
 ## Documentation
 

--- a/packages/prosekit/README.md
+++ b/packages/prosekit/README.md
@@ -1,13 +1,45 @@
 # prosekit
 
-This package provides a convenient way to install all the `@prosekit` scoped packages at once. This saves you from having to install each package individually.
+[![npm](https://img.shields.io/npm/v/prosekit)](https://www.npmjs.com/package/prosekit)
 
-For example, the following two imports are equivalent:
+The ultimate toolkit for building rich text editors on the web. Headless, type-safe, and composable, built on [ProseMirror](https://prosemirror.net/) with first-class support for React, Vue, Preact, Svelte, Solid, and vanilla JavaScript.
 
-```js
+## Installation
+
+```bash
+npm install prosekit
+```
+
+## Usage
+
+```ts
+import { createEditor } from 'prosekit/core'
+import { defineBasicExtension } from 'prosekit/basic'
+
+const editor = createEditor({ extension: defineBasicExtension() })
+```
+
+Then mount the editor in your framework of choice. See the [Quick Start](https://prosekit.dev/getting-started/quick-start) for a complete example.
+
+`prosekit` bundles every `@prosekit/*` package under a single dependency, and each entry point re-exports its scoped counterpart. So these two imports are equivalent:
+
+```ts
 import { defineItalic } from 'prosekit/extensions/italic'
+import { defineItalic } from '@prosekit/extensions/italic'
 ```
 
-```js
-import { defineItalic } from '@prosekit/extension-italic'
-```
+## Documentation
+
+For full documentation, visit [prosekit.dev](https://prosekit.dev).
+
+## Community
+
+Join the community on [Discord](https://prosekit.dev/chat).
+
+## Changelog
+
+Detailed changes for each release are documented in the [CHANGELOG.md](https://github.com/prosekit/prosekit/blob/master/packages/prosekit/CHANGELOG.md).
+
+## License
+
+[MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/prosekit/README.md
+++ b/packages/prosekit/README.md
@@ -33,6 +33,10 @@ Join the community on [Discord](https://prosekit.dev/chat).
 
 Detailed changes for each release are documented in the [CHANGELOG.md](https://github.com/prosekit/prosekit/blob/master/packages/prosekit/CHANGELOG.md).
 
+## Sponsors
+
+<p align="center"><a href="https://github.com/sponsors/ocavue"><img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors"></a></p>
+
 ## License
 
 [MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/prosekit/README.md
+++ b/packages/prosekit/README.md
@@ -13,8 +13,8 @@ npm install prosekit
 ## Usage
 
 ```ts
-import { createEditor } from 'prosekit/core'
 import { defineBasicExtension } from 'prosekit/basic'
+import { createEditor } from 'prosekit/core'
 
 const editor = createEditor({ extension: defineBasicExtension() })
 ```
@@ -24,8 +24,8 @@ Then mount the editor in your framework of choice. See the [Quick Start](https:/
 `prosekit` bundles every `@prosekit/*` package under a single dependency, and each entry point re-exports its scoped counterpart. So these two imports are equivalent:
 
 ```ts
-import { defineItalic } from 'prosekit/extensions/italic'
 import { defineItalic } from '@prosekit/extensions/italic'
+import { defineItalic } from 'prosekit/extensions/italic'
 ```
 
 ## Documentation

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,15 @@
+# @prosekit/react
+
+[![npm](https://img.shields.io/npm/v/@prosekit/react)](https://www.npmjs.com/package/@prosekit/react)
+
+React bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and hooks for wiring a ProseKit editor into your React app.
+
+> **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package. Most users should install `prosekit` and import from `prosekit/react` instead of depending on this package directly.
+
+## Documentation
+
+See the [React guide](https://prosekit.dev/frameworks/react) on [prosekit.dev](https://prosekit.dev).
+
+## License
+
+[MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -10,6 +10,10 @@
 
 See the [React guide](https://prosekit.dev/frameworks/react) on [prosekit.dev](https://prosekit.dev).
 
+## Sponsors
+
+<p align="center"><a href="https://github.com/sponsors/ocavue"><img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors"></a></p>
+
 ## License
 
 [MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@prosekit/react)](https://www.npmjs.com/package/@prosekit/react)
 
-React bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and hooks for wiring a ProseKit editor into your React app.
+[React](https://react.dev/) bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and hooks for wiring a ProseKit editor into your React app.
 
 > **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package. Most users should install `prosekit` and import from `prosekit/react` instead of depending on this package directly.
 

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -10,6 +10,10 @@
 
 See the [Solid guide](https://prosekit.dev/frameworks/solid) on [prosekit.dev](https://prosekit.dev).
 
+## Sponsors
+
+<p align="center"><a href="https://github.com/sponsors/ocavue"><img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors"></a></p>
+
 ## License
 
 [MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,0 +1,15 @@
+# @prosekit/solid
+
+[![npm](https://img.shields.io/npm/v/@prosekit/solid)](https://www.npmjs.com/package/@prosekit/solid)
+
+Solid bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and utilities for wiring a ProseKit editor into your Solid app.
+
+> **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package. Most users should install `prosekit` and import from `prosekit/solid` instead of depending on this package directly.
+
+## Documentation
+
+See the [Solid guide](https://prosekit.dev/frameworks/solid) on [prosekit.dev](https://prosekit.dev).
+
+## License
+
+[MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@prosekit/solid)](https://www.npmjs.com/package/@prosekit/solid)
 
-Solid bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and utilities for wiring a ProseKit editor into your Solid app.
+[Solid](https://www.solidjs.com/) bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and utilities for wiring a ProseKit editor into your Solid app.
 
 > **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package. Most users should install `prosekit` and import from `prosekit/solid` instead of depending on this package directly.
 

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,0 +1,15 @@
+# @prosekit/svelte
+
+[![npm](https://img.shields.io/npm/v/@prosekit/svelte)](https://www.npmjs.com/package/@prosekit/svelte)
+
+Svelte bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and utilities for wiring a ProseKit editor into your Svelte app.
+
+> **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package. Most users should install `prosekit` and import from `prosekit/svelte` instead of depending on this package directly.
+
+## Documentation
+
+See the [Svelte guide](https://prosekit.dev/frameworks/svelte) on [prosekit.dev](https://prosekit.dev).
+
+## License
+
+[MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@prosekit/svelte)](https://www.npmjs.com/package/@prosekit/svelte)
 
-Svelte bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and utilities for wiring a ProseKit editor into your Svelte app.
+[Svelte](https://svelte.dev/) bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and utilities for wiring a ProseKit editor into your Svelte app.
 
 > **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package. Most users should install `prosekit` and import from `prosekit/svelte` instead of depending on this package directly.
 

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -10,6 +10,10 @@
 
 See the [Svelte guide](https://prosekit.dev/frameworks/svelte) on [prosekit.dev](https://prosekit.dev).
 
+## Sponsors
+
+<p align="center"><a href="https://github.com/sponsors/ocavue"><img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors"></a></p>
+
 ## License
 
 [MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/typedoc-plugin/README.md
+++ b/packages/typedoc-plugin/README.md
@@ -1,3 +1,5 @@
 # @prosekit/typedoc-plugin
 
-A internal Typedoc plugin for ProseKit's documentation.
+An internal [TypeDoc](https://typedoc.org/) plugin used to generate the API reference on [prosekit.dev](https://prosekit.dev).
+
+> **Note:** This is an internal package for ProseKit's documentation build. It is private, not published to npm, and not intended for external use.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -10,6 +10,10 @@
 
 See the [Vue guide](https://prosekit.dev/frameworks/vue) on [prosekit.dev](https://prosekit.dev).
 
+## Sponsors
+
+<p align="center"><a href="https://github.com/sponsors/ocavue"><img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors"></a></p>
+
 ## License
 
 [MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@prosekit/vue)](https://www.npmjs.com/package/@prosekit/vue)
 
-Vue bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and composables for wiring a ProseKit editor into your Vue app.
+[Vue](https://vuejs.org/) bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and composables for wiring a ProseKit editor into your Vue app.
 
 > **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package. Most users should install `prosekit` and import from `prosekit/vue` instead of depending on this package directly.
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,0 +1,15 @@
+# @prosekit/vue
+
+[![npm](https://img.shields.io/npm/v/@prosekit/vue)](https://www.npmjs.com/package/@prosekit/vue)
+
+Vue bindings for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. Provides the components and composables for wiring a ProseKit editor into your Vue app.
+
+> **Note:** This package is bundled into the main [`prosekit`](https://www.npmjs.com/package/prosekit) package. Most users should install `prosekit` and import from `prosekit/vue` instead of depending on this package directly.
+
+## Documentation
+
+See the [Vue guide](https://prosekit.dev/frameworks/vue) on [prosekit.dev](https://prosekit.dev).
+
+## License
+
+[MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@prosekit/web)](https://www.npmjs.com/package/@prosekit/web)
 
-Framework-agnostic [web components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. These custom elements implement ProseKit's UI primitives — block handles, menus, popovers, tooltips, and more — and are wrapped by the framework packages such as [`@prosekit/react`](https://www.npmjs.com/package/@prosekit/react) and [`@prosekit/vue`](https://www.npmjs.com/package/@prosekit/vue).
+Framework-agnostic [web components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. These custom elements implement ProseKit's UI primitives (block handles, menus, popovers, tooltips, and more) and are wrapped by the framework packages such as [`@prosekit/react`](https://www.npmjs.com/package/@prosekit/react) and [`@prosekit/vue`](https://www.npmjs.com/package/@prosekit/vue).
 
 > **Note:** This is a low-level building block. Most users should install the main [`prosekit`](https://www.npmjs.com/package/prosekit) package and use the components for their framework instead.
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,0 +1,15 @@
+# @prosekit/web
+
+[![npm](https://img.shields.io/npm/v/@prosekit/web)](https://www.npmjs.com/package/@prosekit/web)
+
+Framework-agnostic [web components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) for [ProseKit](https://prosekit.dev), the toolkit for building rich text editors on the web. These custom elements implement ProseKit's UI primitives — block handles, menus, popovers, tooltips, and more — and are wrapped by the framework packages such as [`@prosekit/react`](https://www.npmjs.com/package/@prosekit/react) and [`@prosekit/vue`](https://www.npmjs.com/package/@prosekit/vue).
+
+> **Note:** This is a low-level building block. Most users should install the main [`prosekit`](https://www.npmjs.com/package/prosekit) package and use the components for their framework instead.
+
+## Documentation
+
+See the [components documentation](https://prosekit.dev/components/) on [prosekit.dev](https://prosekit.dev).
+
+## License
+
+[MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -10,6 +10,10 @@ Framework-agnostic [web components](https://developer.mozilla.org/en-US/docs/Web
 
 See the [components documentation](https://prosekit.dev/components/) on [prosekit.dev](https://prosekit.dev).
 
+## Sponsors
+
+<p align="center"><a href="https://github.com/sponsors/ocavue"><img src="https://cdn.jsdelivr.net/gh/ocavue/sponsors/sponsorkit/sponsors.svg" alt="My Sponsors"></a></p>
+
 ## License
 
 [MIT](https://github.com/prosekit/prosekit/blob/master/LICENSE)


### PR DESCRIPTION
## Summary

Improves every `README.md` in the repo to be clear, pithy, and helpful. Most package READMEs were empty stubs even though they serve as the npm landing pages.

- **Root `README.md`**: sharper tagline, added an `npm install` step linking the Quick Start, and fixed two stale `ocavue/prosekit` links to `prosekit/prosekit`.
- **`prosekit`** (flagship npm page): a proper landing page with install, a minimal `createEditor` example, and the `prosekit/*` vs `@prosekit/*` equivalence. Corrected the outdated `@prosekit/extension-italic` to `@prosekit/extensions/italic`.
- **`core` / `basic` / `extensions`**: filled in with a consistent structure (badge, one-line summary, a note steering users to install `prosekit`, and docs links).
- **Framework bindings** (`react`, `vue`, `preact`, `solid`, `svelte`): consistent READMEs, each linking to its `/frameworks/<x>` guide.
- **`pm`**: kept the re-export table, added badge, intro, and license.
- **`web` / `lit`**: described as low-level UI building blocks.
- **`typedoc-plugin`**: clarified that it is private, internal, and not published.

## Notes

- `.changeset/README.md` is intentionally left untouched (auto-generated changesets boilerplate).
- `.md` prose is outside dprint's scope (it only formats `.mdx`), so no reformatting was needed.
- All docs links were verified. Fixed one dead link (`/extensions/` now points to `/extensions/overview`, since only `/components/` has a redirect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated root README to present ProseKit as a rich-text editor toolkit, expanded Quick Start with an explicit npm install step and Quick Start link, and reshaped scaffolding guidance for a single-command setup.
  * Added or refreshed README files for core, web, framework bindings (React, Vue, Svelte, Preact, Lit, Solid), extensions, and tooling packages.
  * Clarified bundling/entry-point guidance, marked TypeDoc plugin as private, corrected repository links, and reformatted sponsors block.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->