### PR TITLE
feat(pm): export EditorNode and EditorFragment aliases

### DIFF
--- a/.changeset/editor-node-fragment.md
+++ b/.changeset/editor-node-fragment.md
@@ -1,0 +1,6 @@
+---
+"@prosekit/pm": patch
+"prosekit": patch
+---
+
+Add `EditorNode` and `EditorFragment` as aliases for ProseMirror's `Node` and `Fragment`.

--- a/packages/pm/src/model.ts
+++ b/packages/pm/src/model.ts
@@ -1,2 +1,2 @@
 export * from 'prosemirror-model'
-export { Fragment as ProseMirrorFragment, Node as ProseMirrorNode } from 'prosemirror-model'
+export { Fragment as EditorFragment, Fragment as ProseMirrorFragment, Node as EditorNode, Node as ProseMirrorNode } from 'prosemirror-model'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `EditorNode` and `EditorFragment` aliases, expanding available type naming conventions for editor structures in your applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->