### PR TITLE
feat(inline-popover): allow custom anchor element

### DIFF
--- a/.changeset/inline-popover-anchor.md
+++ b/.changeset/inline-popover-anchor.md
@@ -1,0 +1,12 @@
+---
+"prosekit": patch
+"@prosekit/lit": patch
+"@prosekit/preact": patch
+"@prosekit/react": patch
+"@prosekit/solid": patch
+"@prosekit/svelte": patch
+"@prosekit/vue": patch
+"@prosekit/web": patch
+---
+
+Allow `InlinePopoverRoot` to accept a custom `anchor` for popup positioning. When set, the inline popover is positioned against the provided element or virtual element instead of the current text selection.

--- a/.changeset/inline-popover-anchor.md
+++ b/.changeset/inline-popover-anchor.md
@@ -1,12 +1,12 @@
 ---
-"prosekit": patch
-"@prosekit/lit": patch
-"@prosekit/preact": patch
-"@prosekit/react": patch
-"@prosekit/solid": patch
-"@prosekit/svelte": patch
-"@prosekit/vue": patch
-"@prosekit/web": patch
+"prosekit": minor
+"@prosekit/lit": minor
+"@prosekit/preact": minor
+"@prosekit/react": minor
+"@prosekit/solid": minor
+"@prosekit/svelte": minor
+"@prosekit/vue": minor
+"@prosekit/web": minor
 ---
 
 Allow `InlinePopoverRoot` to accept a custom `anchor` for popup positioning. When set, the inline popover is positioned against the provided element or virtual element instead of the current text selection.

--- a/packages/preact/src/components/inline-popover/inline-popover-root.gen.ts
+++ b/packages/preact/src/components/inline-popover/inline-popover-root.gen.ts
@@ -31,6 +31,17 @@ export interface InlinePopoverRootProps {
    */
   dismissOnEscape?: InlinePopoverRootElementProps['dismissOnEscape'];
   /**
+   * The reference to position the popover against. This can be a DOM element, a
+   * Floating UI virtual element, or a function that returns either of them.
+   *
+   * When set, the popover is anchored to this reference instead of the current
+   * text selection, and the text selection no longer drives the open state, so
+   * control it with the `open` property.
+   *
+   * @default null
+   */
+  anchor?: InlinePopoverRootElementProps['anchor'];
+  /**
    * Whether the overlay is currently open.
    * @default null
    */
@@ -50,14 +61,14 @@ function InlinePopoverRootComponent(props: InlinePopoverRootProps, forwardedRef:
   const elementRef = useRef<InlinePopoverRootElement>(null);
   const handlersRef = useRef<Array<((event: Event) => void) | undefined>>([]);
 
-  const p3Fallback = useEditorContext();
+  const p4Fallback = useEditorContext();
 
-  const { defaultOpen: p0, disabled: p1, dismissOnEscape: p2, editor: p3, open: p4, onOpenChange: e0, ...restProps } = props;
+  const { anchor: p0, defaultOpen: p1, disabled: p2, dismissOnEscape: p3, editor: p4, open: p5, onOpenChange: e0, ...restProps } = props;
 
   useLayoutEffect(() => {
     const element = elementRef.current as Record<string, unknown> | null;
     if (!element) return;
-    Object.assign(element, { defaultOpen: p0, disabled: p1, dismissOnEscape: p2, editor: p3 ?? p3Fallback, open: p4 });
+    Object.assign(element, { anchor: p0, defaultOpen: p1, disabled: p2, dismissOnEscape: p3, editor: p4 ?? p4Fallback, open: p5 });
     handlersRef.current = [e0] as Array<((event: Event) => void) | undefined>;
   });
 

--- a/packages/react/src/components/inline-popover/inline-popover-root.gen.ts
+++ b/packages/react/src/components/inline-popover/inline-popover-root.gen.ts
@@ -29,6 +29,17 @@ export interface InlinePopoverRootProps {
    */
   dismissOnEscape?: InlinePopoverRootElementProps['dismissOnEscape'];
   /**
+   * The reference to position the popover against. This can be a DOM element, a
+   * Floating UI virtual element, or a function that returns either of them.
+   *
+   * When set, the popover is anchored to this reference instead of the current
+   * text selection, and the text selection no longer drives the open state, so
+   * control it with the `open` property.
+   *
+   * @default null
+   */
+  anchor?: InlinePopoverRootElementProps['anchor'];
+  /**
    * Whether the overlay is currently open.
    * @default null
    */
@@ -48,14 +59,14 @@ function InlinePopoverRootComponent(props: InlinePopoverRootProps, forwardedRef:
   const elementRef = useRef<InlinePopoverRootElement>(null);
   const handlersRef = useRef<Array<((event: Event) => void) | undefined>>([]);
 
-  const p3Fallback = useEditorContext();
+  const p4Fallback = useEditorContext();
 
-  const { defaultOpen: p0, disabled: p1, dismissOnEscape: p2, editor: p3, open: p4, onOpenChange: e0, ...restProps } = props;
+  const { anchor: p0, defaultOpen: p1, disabled: p2, dismissOnEscape: p3, editor: p4, open: p5, onOpenChange: e0, ...restProps } = props;
 
   useLayoutEffect(() => {
     const element = elementRef.current as Record<string, unknown> | null;
     if (!element) return;
-    Object.assign(element, { defaultOpen: p0, disabled: p1, dismissOnEscape: p2, editor: p3 ?? p3Fallback, open: p4 });
+    Object.assign(element, { anchor: p0, defaultOpen: p1, disabled: p2, dismissOnEscape: p3, editor: p4 ?? p4Fallback, open: p5 });
     handlersRef.current = [e0] as Array<((event: Event) => void) | undefined>;
   });
 

--- a/packages/solid/src/components/inline-popover/inline-popover-root.gen.ts
+++ b/packages/solid/src/components/inline-popover/inline-popover-root.gen.ts
@@ -31,6 +31,17 @@ export interface InlinePopoverRootProps {
    */
   dismissOnEscape?: InlinePopoverRootElementProps['dismissOnEscape'];
   /**
+   * The reference to position the popover against. This can be a DOM element, a
+   * Floating UI virtual element, or a function that returns either of them.
+   *
+   * When set, the popover is anchored to this reference instead of the current
+   * text selection, and the text selection no longer drives the open state, so
+   * control it with the `open` property.
+   *
+   * @default null
+   */
+  anchor?: InlinePopoverRootElementProps['anchor'];
+  /**
    * Whether the overlay is currently open.
    * @default null
    */
@@ -51,15 +62,15 @@ export const InlinePopoverRoot: Component<InlinePopoverRootProps & JSX.HTMLAttri
   const [getElement, setElement] = createSignal<InlinePopoverRootElement | null>(null);
   const handlers: Array<((event: any) => void) | undefined> = [];
 
-  const [elementProps, eventHandlers, restProps] = splitProps(props, ['defaultOpen', 'disabled', 'dismissOnEscape', 'editor', 'open'], ['onOpenChange']);
+  const [elementProps, eventHandlers, restProps] = splitProps(props, ['anchor', 'defaultOpen', 'disabled', 'dismissOnEscape', 'editor', 'open'], ['onOpenChange']);
 
-  const p3Fallback = useEditorContext();
+  const p4Fallback = useEditorContext();
 
   createEffect(() => {
     const element = getElement();
     if (!element) return;
 
-    Object.assign(element, { defaultOpen: elementProps.defaultOpen, disabled: elementProps.disabled, dismissOnEscape: elementProps.dismissOnEscape, editor: elementProps.editor ?? p3Fallback, open: elementProps.open });
+    Object.assign(element, { anchor: elementProps.anchor, defaultOpen: elementProps.defaultOpen, disabled: elementProps.disabled, dismissOnEscape: elementProps.dismissOnEscape, editor: elementProps.editor ?? p4Fallback, open: elementProps.open });
 
     handlers.length = 0;
     handlers.push(eventHandlers.onOpenChange);

--- a/packages/svelte/src/components/inline-popover/inline-popover-root.gen.svelte
+++ b/packages/svelte/src/components/inline-popover/inline-popover-root.gen.svelte
@@ -5,16 +5,16 @@
   import { useEditorContext } from '../../contexts/editor-context.ts'
   registerInlinePopoverRootElement()
 
-  let { defaultOpen: p0, disabled: p1, dismissOnEscape: p2, editor: p3, open: p4, onOpenChange: e0, children = undefined, ...restProps } = $props()
+  let { anchor: p0, defaultOpen: p1, disabled: p2, dismissOnEscape: p3, editor: p4, open: p5, onOpenChange: e0, children = undefined, ...restProps } = $props()
   let element: InlinePopoverRootElement | undefined
   const handlers: EventListener[] = []
 
-  const p3Fallback = useEditorContext()
+  const p4Fallback = useEditorContext()
 
   $effect(() => {
     if (!element) return
 
-    Object.assign(element, { defaultOpen: p0, disabled: p1, dismissOnEscape: p2, editor: p3 ?? p3Fallback, open: p4 })
+    Object.assign(element, { anchor: p0, defaultOpen: p1, disabled: p2, dismissOnEscape: p3, editor: p4 ?? p4Fallback, open: p5 })
 
     handlers.length = 0
     handlers.push(e0)

--- a/packages/svelte/src/components/inline-popover/inline-popover-root.gen.ts
+++ b/packages/svelte/src/components/inline-popover/inline-popover-root.gen.ts
@@ -30,6 +30,17 @@ export interface InlinePopoverRootProps {
    */
   dismissOnEscape?: InlinePopoverRootElementProps['dismissOnEscape'];
   /**
+   * The reference to position the popover against. This can be a DOM element, a
+   * Floating UI virtual element, or a function that returns either of them.
+   *
+   * When set, the popover is anchored to this reference instead of the current
+   * text selection, and the text selection no longer drives the open state, so
+   * control it with the `open` property.
+   *
+   * @default null
+   */
+  anchor?: InlinePopoverRootElementProps['anchor'];
+  /**
    * Whether the overlay is currently open.
    * @default null
    */

--- a/packages/vue/src/components/inline-popover/inline-popover-root.gen.ts
+++ b/packages/vue/src/components/inline-popover/inline-popover-root.gen.ts
@@ -29,6 +29,17 @@ export interface InlinePopoverRootProps {
    */
   dismissOnEscape?: InlinePopoverRootElementProps['dismissOnEscape'];
   /**
+   * The reference to position the popover against. This can be a DOM element, a
+   * Floating UI virtual element, or a function that returns either of them.
+   *
+   * When set, the popover is anchored to this reference instead of the current
+   * text selection, and the text selection no longer drives the open state, so
+   * control it with the `open` property.
+   *
+   * @default null
+   */
+  anchor?: InlinePopoverRootElementProps['anchor'];
+  /**
    * Whether the overlay is currently open.
    * @default null
    */
@@ -49,11 +60,11 @@ export const InlinePopoverRoot: DefineSetupFnComponent<InlinePopoverRootProps & 
 
     const elementRef = shallowRef<HTMLElement | null>(null);
 
-    const p3Fallback = useEditorContext();
+    const p4Fallback = useEditorContext();
 
     const splittedProps = computed(() => {
-      const { defaultOpen: p0, disabled: p1, dismissOnEscape: p2, editor: p3, open: p4, onOpenChange: e0, ...restProps } = props;
-      return [[p0, p1, p2, p3, p4, e0], restProps] as const;
+      const { anchor: p0, defaultOpen: p1, disabled: p2, dismissOnEscape: p3, editor: p4, open: p5, onOpenChange: e0, ...restProps } = props;
+      return [[p0, p1, p2, p3, p4, p5, e0], restProps] as const;
     });
 
     const handlers: Array<((event: any) => void) | undefined> = [];
@@ -62,9 +73,9 @@ export const InlinePopoverRoot: DefineSetupFnComponent<InlinePopoverRootProps & 
       const element = elementRef.value;
       if (!element) return;
 
-      const [p0, p1, p2, p3, p4, e0] = splittedProps.value[0];
+      const [p0, p1, p2, p3, p4, p5, e0] = splittedProps.value[0];
 
-      Object.assign(element, { defaultOpen: p0, disabled: p1, dismissOnEscape: p2, editor: p3 ?? p3Fallback, open: p4 });
+      Object.assign(element, { anchor: p0, defaultOpen: p1, disabled: p2, dismissOnEscape: p3, editor: p4 ?? p4Fallback, open: p5 });
 
       handlers.length = 0;
       handlers.push(e0);
@@ -92,5 +103,5 @@ export const InlinePopoverRoot: DefineSetupFnComponent<InlinePopoverRootProps & 
       return h('prosekit-inline-popover-root', { ...restProps, ref: elementRef }, slots.default?.());
     };
   },
-  { props: ['defaultOpen', 'disabled', 'dismissOnEscape', 'editor', 'open', 'onOpenChange'] },
+  { props: ['anchor', 'defaultOpen', 'disabled', 'dismissOnEscape', 'editor', 'open', 'onOpenChange'] },
 );

--- a/packages/web/src/components/autocomplete/autocomplete-root.ts
+++ b/packages/web/src/components/autocomplete/autocomplete-root.ts
@@ -13,13 +13,14 @@ import {
 import { defaultItemFilter, type ItemFilter, type ListboxRootEvents } from '@aria-ui/elements/listbox'
 import { createOverlayStore, OpenChangeEvent, type OverlayStore } from '@aria-ui/elements/overlay'
 import { useEventListener } from '@aria-ui/utils'
-import type { ReferenceElement, VirtualElement } from '@floating-ui/dom'
+import type { ReferenceElement } from '@floating-ui/dom'
 import { defineDOMEventHandler, defineKeymap, withPriority, type Editor, type Extension, type Priority } from '@prosekit/core'
 import { AutocompleteRule, defineAutocomplete, type MatchHandler } from '@prosekit/extensions/autocomplete'
 
 import { useEditorExtension } from '../../hooks/use-editor-extension.ts'
 import { KeyboardEventTarget } from '../../utils/event.ts'
 import { getSafeEditorView } from '../../utils/get-safe-editor-view.ts'
+import { resolveAnchor, type AnchorProp } from '../../utils/resolve-anchor.ts'
 
 import { autocompleteStoreContext, type AutocompleteStore } from './context.ts'
 import { defaultQueryBuilder } from './helpers.ts'
@@ -58,7 +59,7 @@ export interface AutocompleteRootProps {
    *
    * @default null
    */
-  anchor: Element | VirtualElement | (() => Element | VirtualElement | null) | null
+  anchor: AnchorProp
 }
 
 /** @internal */
@@ -166,13 +167,9 @@ export function setupAutocompleteRoot(
   }
 
   const getAnchor = (): ReferenceElement | null => {
-    const customAnchor = props.anchor.get()
+    const customAnchor = resolveAnchor(props.anchor.get())
     if (customAnchor) {
-      if (typeof customAnchor === 'function') {
-        return customAnchor() || null
-      } else {
-        return customAnchor
-      }
+      return customAnchor
     }
     const view = getSafeEditorView(getEditor())
     return view?.dom.querySelector('.prosekit-autocomplete-match') || null

--- a/packages/web/src/components/autocomplete/autocomplete-root.ts
+++ b/packages/web/src/components/autocomplete/autocomplete-root.ts
@@ -20,7 +20,7 @@ import { AutocompleteRule, defineAutocomplete, type MatchHandler } from '@prosek
 import { useEditorExtension } from '../../hooks/use-editor-extension.ts'
 import { KeyboardEventTarget } from '../../utils/event.ts'
 import { getSafeEditorView } from '../../utils/get-safe-editor-view.ts'
-import { resolveAnchor, type AnchorProp } from '../../utils/resolve-anchor.ts'
+import { resolveAnchor, type AnchorReference } from '../../utils/resolve-anchor.ts'
 
 import { autocompleteStoreContext, type AutocompleteStore } from './context.ts'
 import { defaultQueryBuilder } from './helpers.ts'
@@ -59,7 +59,7 @@ export interface AutocompleteRootProps {
    *
    * @default null
    */
-  anchor: AnchorProp
+  anchor: AnchorReference
 }
 
 /** @internal */

--- a/packages/web/src/components/inline-popover/inline-popover-root.ts
+++ b/packages/web/src/components/inline-popover/inline-popover-root.ts
@@ -1,4 +1,5 @@
 import {
+  computed,
   defineCustomElement,
   defineProps,
   registerCustomElement,
@@ -6,7 +7,7 @@ import {
   type HostElement,
   type HostElementConstructor,
   type PropsDeclaration,
-  type State, computed
+  type State,
 } from '@aria-ui/core'
 import type { OpenChangeEvent } from '@aria-ui/elements/overlay'
 import { OverlayRootPropsDeclaration, useOverlayStore, type OverlayRootProps } from '@aria-ui/elements/overlay'
@@ -85,7 +86,6 @@ export function setupInlinePopoverRoot(
   const store = useOverlayStore(host, props)
   InlinePopoverStoreContext.provide(host, store)
 
-
   let editorFocused = false
   useEditorFocusChangeEvent(host, props.editor.get, (focus) => {
     editorFocused = focus
@@ -99,7 +99,6 @@ export function setupInlinePopoverRoot(
     if (!anchor) return
     store.setAnchorElement(anchor)
   })
-
 
   let prevSelection: Selection | undefined
   useEditorUpdateEvent(host, props.editor.get, (view) => {

--- a/packages/web/src/components/inline-popover/inline-popover-root.ts
+++ b/packages/web/src/components/inline-popover/inline-popover-root.ts
@@ -2,6 +2,7 @@ import {
   defineCustomElement,
   defineProps,
   registerCustomElement,
+  useEffect,
   type HostElement,
   type HostElementConstructor,
   type PropsDeclaration,
@@ -15,6 +16,7 @@ import type { Selection } from '@prosekit/pm/state'
 import { useEditorFocusChangeEvent } from '../../hooks/use-editor-focus-event.ts'
 import { useEditorUpdateEvent } from '../../hooks/use-editor-update-event.ts'
 import { useKeymap } from '../../hooks/use-keymap.ts'
+import { resolveAnchor, type AnchorProp } from '../../utils/resolve-anchor.ts'
 
 import { InlinePopoverStoreContext } from './store.ts'
 import { getVirtualSelectionElement } from './virtual-selection-element.ts'
@@ -43,6 +45,18 @@ export interface InlinePopoverRootProps extends OverlayRootProps {
    * @default true
    */
   dismissOnEscape: boolean
+
+  /**
+   * The reference to position the popover against. This can be a DOM element, a
+   * Floating UI virtual element, or a function that returns either of them.
+   *
+   * When set, the popover is anchored to this reference instead of the current
+   * text selection, and the text selection no longer drives the open state, so
+   * control it with the `open` property.
+   *
+   * @default null
+   */
+  anchor: AnchorProp
 }
 
 /** @internal */
@@ -53,6 +67,7 @@ export const InlinePopoverRootPropsDeclaration: PropsDeclaration<InlinePopoverRo
   editor: { default: null, attribute: false },
   defaultOpen: { default: true, attribute: 'default-open', type: 'boolean' },
   dismissOnEscape: { default: true, attribute: 'dismiss-on-escape', type: 'boolean' },
+  anchor: { default: null, attribute: false },
 })
 
 export interface InlinePopoverRootEvents {
@@ -70,13 +85,24 @@ export function setupInlinePopoverRoot(
   const store = useOverlayStore(host, props)
   InlinePopoverStoreContext.provide(host, store)
 
+  // Custom-anchor mode: the consumer supplies the reference element and controls
+  // the open state. Re-runs whenever the `anchor` property changes.
+  useEffect(host, () => {
+    const anchor = resolveAnchor(props.anchor.get())
+    if (!anchor) return
+    store.setAnchorElement(anchor)
+  })
+
   let editorFocused = false
   useEditorFocusChangeEvent(host, props.editor.get, (focus) => {
     editorFocused = focus
   })
 
+  // Selection mode (default): only active while no custom anchor is set.
   let prevSelection: Selection | undefined
   useEditorUpdateEvent(host, props.editor.get, (view) => {
+    if (props.anchor.get()) return
+
     const isPopoverFocused = !editorFocused && host.contains(host.ownerDocument.activeElement)
     if (isPopoverFocused) return
 

--- a/packages/web/src/components/inline-popover/inline-popover-root.ts
+++ b/packages/web/src/components/inline-popover/inline-popover-root.ts
@@ -6,7 +6,7 @@ import {
   type HostElement,
   type HostElementConstructor,
   type PropsDeclaration,
-  type State,
+  type State, computed
 } from '@aria-ui/core'
 import type { OpenChangeEvent } from '@aria-ui/elements/overlay'
 import { OverlayRootPropsDeclaration, useOverlayStore, type OverlayRootProps } from '@aria-ui/elements/overlay'
@@ -85,23 +85,25 @@ export function setupInlinePopoverRoot(
   const store = useOverlayStore(host, props)
   InlinePopoverStoreContext.provide(host, store)
 
-  // Custom-anchor mode: the consumer supplies the reference element and controls
-  // the open state. Re-runs whenever the `anchor` property changes.
-  useEffect(host, () => {
-    const anchor = resolveAnchor(props.anchor.get())
-    if (!anchor) return
-    store.setAnchorElement(anchor)
-  })
 
   let editorFocused = false
   useEditorFocusChangeEvent(host, props.editor.get, (focus) => {
     editorFocused = focus
   })
 
-  // Selection mode (default): only active while no custom anchor is set.
+  const hasCustomAnchor = computed(() => !!props.anchor.get())
+
+  useEffect(host, () => {
+    if (!hasCustomAnchor()) return
+    const anchor = resolveAnchor(props.anchor.get())
+    if (!anchor) return
+    store.setAnchorElement(anchor)
+  })
+
+
   let prevSelection: Selection | undefined
   useEditorUpdateEvent(host, props.editor.get, (view) => {
-    if (props.anchor.get()) return
+    if (hasCustomAnchor()) return
 
     const isPopoverFocused = !editorFocused && host.contains(host.ownerDocument.activeElement)
     if (isPopoverFocused) return

--- a/packages/web/src/components/inline-popover/inline-popover-root.ts
+++ b/packages/web/src/components/inline-popover/inline-popover-root.ts
@@ -16,7 +16,7 @@ import type { Selection } from '@prosekit/pm/state'
 import { useEditorFocusChangeEvent } from '../../hooks/use-editor-focus-event.ts'
 import { useEditorUpdateEvent } from '../../hooks/use-editor-update-event.ts'
 import { useKeymap } from '../../hooks/use-keymap.ts'
-import { resolveAnchor, type AnchorProp } from '../../utils/resolve-anchor.ts'
+import { resolveAnchor, type AnchorReference } from '../../utils/resolve-anchor.ts'
 
 import { InlinePopoverStoreContext } from './store.ts'
 import { getVirtualSelectionElement } from './virtual-selection-element.ts'
@@ -56,7 +56,7 @@ export interface InlinePopoverRootProps extends OverlayRootProps {
    *
    * @default null
    */
-  anchor: AnchorProp
+  anchor: AnchorReference
 }
 
 /** @internal */

--- a/packages/web/src/utils/resolve-anchor.spec.ts
+++ b/packages/web/src/utils/resolve-anchor.spec.ts
@@ -1,0 +1,31 @@
+import type { VirtualElement } from '@floating-ui/dom'
+import { describe, expect, it } from 'vitest'
+
+import { resolveAnchor } from './resolve-anchor.ts'
+
+describe('resolveAnchor', () => {
+  it('returns undefined for null', () => {
+    expect(resolveAnchor(null)).toBe(undefined)
+  })
+
+  it('returns the element for an element', () => {
+    const element = { nodeType: 1 } as unknown as Element
+    expect(resolveAnchor(element)).toBe(element)
+  })
+
+  it('returns the virtual element for a virtual element', () => {
+    const virtualElement: VirtualElement = {
+      getBoundingClientRect: () => ({}) as DOMRect,
+    }
+    expect(resolveAnchor(virtualElement)).toBe(virtualElement)
+  })
+
+  it('calls a function anchor and returns its result', () => {
+    const element = { nodeType: 1 } as unknown as Element
+    expect(resolveAnchor(() => element)).toBe(element)
+  })
+
+  it('returns undefined when a function anchor returns null', () => {
+    expect(resolveAnchor(() => null)).toBe(undefined)
+  })
+})

--- a/packages/web/src/utils/resolve-anchor.ts
+++ b/packages/web/src/utils/resolve-anchor.ts
@@ -4,17 +4,17 @@ import type { ReferenceElement, VirtualElement } from '@floating-ui/dom'
  * A reference for an overlay to position against. This can be a DOM element, a
  * Floating UI virtual element, or a function that returns either of them.
  */
-export type AnchorProp =
+export type AnchorReference =
   | Element
   | VirtualElement
   | (() => Element | VirtualElement | null)
   | null
 
 /**
- * Resolves an {@link AnchorProp} to a Floating UI reference element, or
+ * Resolves an {@link AnchorReference} to a Floating UI reference element, or
  * `undefined` when no anchor is available.
  */
-export function resolveAnchor(anchor: AnchorProp): ReferenceElement | undefined {
+export function resolveAnchor(anchor: AnchorReference): ReferenceElement | undefined {
   if (!anchor) {
     return undefined
   }

--- a/packages/web/src/utils/resolve-anchor.ts
+++ b/packages/web/src/utils/resolve-anchor.ts
@@ -1,0 +1,25 @@
+import type { ReferenceElement, VirtualElement } from '@floating-ui/dom'
+
+/**
+ * A reference for an overlay to position against. This can be a DOM element, a
+ * Floating UI virtual element, or a function that returns either of them.
+ */
+export type AnchorProp =
+  | Element
+  | VirtualElement
+  | (() => Element | VirtualElement | null)
+  | null
+
+/**
+ * Resolves an {@link AnchorProp} to a Floating UI reference element, or
+ * `undefined` when no anchor is available.
+ */
+export function resolveAnchor(anchor: AnchorProp): ReferenceElement | undefined {
+  if (!anchor) {
+    return undefined
+  }
+  if (typeof anchor === 'function') {
+    return anchor() ?? undefined
+  }
+  return anchor
+}

--- a/packages/web/src/utils/resolve-anchor.ts
+++ b/packages/web/src/utils/resolve-anchor.ts
@@ -7,7 +7,7 @@ import type { ReferenceElement, VirtualElement } from '@floating-ui/dom'
 export type AnchorReference =
   | Element
   | VirtualElement
-  | (() => Element | VirtualElement | null)
+  | (() => Element | VirtualElement | null | undefined)
   | null
 
 /**


### PR DESCRIPTION
Add an `anchor` property to `InlinePopoverRoot` so the inline popover can be positioned against an arbitrary element or virtual element instead of only the current text selection. When `anchor` is set, the popover anchors to it and the text selection no longer drives the open state (control it with `open`).

This mirrors the existing `anchor` property on `AutocompleteRoot`. The anchor-resolution logic is extracted into a shared `resolveAnchor` helper used by both `InlinePopoverRoot` and `AutocompleteRoot`.

Opened as a draft to consume the pkg-pr-new snapshot downstream (meowdown link/wikilink hover cards).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * InlinePopoverRoot component now accepts an optional `anchor` prop to specify custom reference elements for popover positioning across React, Preact, Vue, Svelte, and Solid.

* **Tests**
  * Added test coverage for anchor resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->