### PR TITLE
feat(core): add create method to mark builders

### DIFF
--- a/.changeset/mark-builder-create.md
+++ b/.changeset/mark-builder-create.md
@@ -1,0 +1,6 @@
+---
+"@prosekit/core": minor
+"prosekit": minor
+---
+
+Add a `create` method to mark builders (`editor.marks.<name>.create(attrs?)` and the builders returned by `createMarkBuilders`). It returns a bare `Mark` instance with optional, typed attributes, without applying it to any children.

--- a/packages/core/src/editor/action.ts
+++ b/packages/core/src/editor/action.ts
@@ -57,6 +57,13 @@ export interface MarkBuilder<Attrs extends AnyAttrs = AnyAttrs> {
    * Applies a mark with any number of children.
    */
   (...children: NodeChild[]): ProseMirrorNode[]
+
+  /**
+   * Creates a {@link Mark} of this type with optional attributes, without
+   * applying it to any children. Unlike calling the builder, which returns
+   * nodes with the mark applied, this returns the bare mark instance.
+   */
+  create: (attrs?: Attrs | null) => Mark
 }
 
 /**
@@ -119,9 +126,11 @@ export function createMarkBuildersRaw(
 }
 
 function createMarkBuilder(type: MarkType, applyMark: ApplyMarkFunction): MarkBuilder {
-  return function markBuilder(...args: [Attrs | NodeChild | null | undefined, ...NodeChild[]]) {
+  function markBuilder(...args: [Attrs | NodeChild | null | undefined, ...NodeChild[]]) {
     return buildMark(type, args, applyMark)
   }
+  markBuilder.create = (attrs?: Attrs | null): Mark => type.create(attrs)
+  return markBuilder
 }
 
 /**
@@ -143,6 +152,7 @@ function createMarkAction(
   function markAction(...args: [Attrs | NodeChild | null | undefined, ...NodeChild[]]) {
     return buildMark(type, args, applyMark)
   }
+  markAction.create = (attrs?: Attrs | null): Mark => type.create(attrs)
   markAction.isActive = (attrs?: Attrs) => {
     const state = getState()
     return state ? isMarkActive(state, type, attrs) : false

--- a/packages/core/src/editor/builder.spec.ts
+++ b/packages/core/src/editor/builder.spec.ts
@@ -112,4 +112,23 @@ describe('createMarkBuilders', () => {
     expectTypeOf(m.bold).toBeFunction()
     expectTypeOf(m).not.toHaveProperty('nonExistentMark')
   })
+
+  describe('create', () => {
+    it('returns a bare mark without applying it to children', () => {
+      const mark = m.bold.create()
+      expect(mark.type.name).toBe('bold')
+      expect(mark.attrs).toEqual({})
+    })
+
+    it('creates a mark with attributes', () => {
+      const mark = m.link.create({ href: 'https://example.com' })
+      expect(mark.type.name).toBe('link')
+      expect(mark.attrs).toEqual({ href: 'https://example.com', target: null, rel: null })
+    })
+
+    it('is typed per mark name', () => {
+      expectTypeOf(m.bold.create).toBeFunction()
+      expectTypeOf(m.link.create).toBeCallableWith({ href: 'https://example.com' })
+    })
+  })
 })


### PR DESCRIPTION
Adds a `create` method to mark builders, so you can get a bare `Mark` instance from a typed builder without applying it to any children.

```ts
const mark = editor.marks.link.create({ href: 'https://example.com' })
```

It is also available on the builders returned by `createMarkBuilders`. Attributes are typed per mark, mirroring ProseMirror's own `MarkType.create`.

This fills the one gap left by `createNodeBuilders` / `createMarkBuilders`: a typed way to produce a bare `Mark` (needed when applying marks to existing text, e.g. via a custom step, rather than building marked nodes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mark builders now expose a `create()` method, allowing you to construct Mark instances directly with optional attributes without applying them to content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->