### PR TITLE
fix(web): avoid focusing destroyed editor view

### DIFF
--- a/.changeset/block-handle-focus-check.md
+++ b/.changeset/block-handle-focus-check.md
@@ -1,0 +1,6 @@
+---
+'prosekit': patch
+"@prosekit/web": patch
+---
+
+Avoid focusing the editor view from the block handle after the view has been destroyed.

--- a/packages/web/src/components/block-handle/block-handle-draggable.ts
+++ b/packages/web/src/components/block-handle/block-handle-draggable.ts
@@ -91,11 +91,15 @@ function usePointerDownHandler(
     const hoverState = getHoverState()
     const editor = getEditor()
 
-    if (hoverState?.pos == null || !editor?.view) {
+    if (hoverState?.pos == null) {
       return
     }
 
-    const { view } = editor
+    const view = editor?.view
+    if (!view || view.isDestroyed) {
+      return
+    }
+
     view.dispatch(
       view.state.tr.setSelection(NodeSelection.create(view.state.doc, hoverState.pos)),
     )
@@ -104,6 +108,9 @@ function usePointerDownHandler(
     // We cannot call `event.preventDefault()` here to prevent the blur
     // because it will prevent the drag event from firing.
     requestAnimationFrame(() => {
+      if (view.isDestroyed) {
+        return
+      }
       view.focus()
     })
   })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where the editor view could be focused after being destroyed, preventing potential errors when interacting with the block handle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->