### PR TITLE
fix(extensions): match horizontal rule wrapper div in parseDOM

### DIFF
--- a/.changeset/horizontal-rule-attr-roundtrip.md
+++ b/.changeset/horizontal-rule-attr-roundtrip.md
@@ -1,0 +1,6 @@
+---
+'prosekit': patch
+'@prosekit/extensions': patch
+---
+
+Recognize the rendered `<div>` wrapper in the `horizontalRule` node's `parseDOM`. Its `toDOM` renders `['div', ['hr']]`, but `parseDOM` only matched `hr`, so an attribute added with `defineNodeAttr` (written onto the outer `<div>`) was dropped when the node was parsed back from the DOM. The node now parses its own rendered output, with a bare `<hr>` kept as a fallback.

--- a/packages/extensions/src/horizontal-rule/horizontal-rule-spec.spec.ts
+++ b/packages/extensions/src/horizontal-rule/horizontal-rule-spec.spec.ts
@@ -1,0 +1,57 @@
+import { defineNodeAttr, union } from '@prosekit/core'
+import { describe, expect, it } from 'vitest'
+
+import { defineDoc } from '../doc/index.ts'
+import { defineParagraph } from '../paragraph/index.ts'
+import { setupTestFromExtension } from '../testing/index.ts'
+import { defineText } from '../text/index.ts'
+
+import { defineHorizontalRule } from './horizontal-rule.ts'
+
+function defineMarkerAttr() {
+  return defineNodeAttr<'horizontalRule', 'marker', string | null>({
+    type: 'horizontalRule',
+    attr: 'marker',
+    default: null,
+    toDOM: (value) => (value ? ['data-hr-marker', value] : null),
+    parseDOM: (node: HTMLElement) => node.getAttribute('data-hr-marker'),
+  })
+}
+
+function setup() {
+  const extension = union(
+    defineDoc(),
+    defineText(),
+    defineParagraph(),
+    defineHorizontalRule(),
+    defineMarkerAttr(),
+  )
+  return setupTestFromExtension(extension)
+}
+
+describe('defineHorizontalRuleSpec', () => {
+  it('persists a node attribute through a DOM round-trip', () => {
+    const { editor } = setup()
+    const withMarker = {
+      type: 'doc',
+      content: [{ type: 'horizontalRule', attrs: { marker: '***' } }],
+    }
+
+    // The attribute lives on the rendered `<div>`, where `defineNodeAttr` writes it.
+    editor.setContent('<div class="prosekit-horizontal-rule" data-hr-marker="***"><hr></div>')
+    expect(editor.getDocJSON()).toEqual(withMarker)
+
+    // It survives a serialize/parse round-trip through the editor's own HTML.
+    editor.setContent(editor.getDocHTML())
+    expect(editor.getDocJSON()).toEqual(withMarker)
+  })
+
+  it('parses a bare <hr> as a horizontal rule', () => {
+    const { editor } = setup()
+    editor.setContent('<hr>')
+    expect(editor.getDocJSON()).toEqual({
+      type: 'doc',
+      content: [{ type: 'horizontalRule', attrs: { marker: null } }],
+    })
+  })
+})

--- a/packages/extensions/src/horizontal-rule/horizontal-rule-spec.ts
+++ b/packages/extensions/src/horizontal-rule/horizontal-rule-spec.ts
@@ -11,7 +11,10 @@ export function defineHorizontalRuleSpec(): HorizontalRuleSpecExtension {
   return defineNodeSpec({
     name: 'horizontalRule',
     group: 'block',
-    parseDOM: [{ tag: 'hr' }],
+    // Match the rendered `<div>` first so attributes added via `defineNodeAttr`
+    // (written onto the outer element) round-trip; fall back to a bare `<hr>`
+    // for foreign HTML and pasted content.
+    parseDOM: [{ tag: 'div.prosekit-horizontal-rule' }, { tag: 'hr' }],
     // Wrap the `<hr>` in a `<div>` so that we can make it taller and easier to click.
     toDOM: () => ['div', { class: 'prosekit-horizontal-rule' }, ['hr']],
   })


### PR DESCRIPTION
The `horizontalRule` node renders `['div', { class: 'prosekit-horizontal-rule' }, ['hr']]` but its `parseDOM` only matched `hr`. Because `defineNodeAttr` writes its DOM attribute onto the outer element (the `<div>`), an attribute added to `horizontalRule` was silently dropped when the node round-tripped through the DOM (e.g. copy/paste, `setContent` of the editor's own HTML). `parseDOM` now matches the wrapper `<div>` first and keeps a bare `<hr>` as a fallback for foreign/pasted HTML.

Found while adding a thematic-break marker attribute downstream in meowdown. Includes a regression test and a changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where custom attributes on horizontal rule elements were lost during content parsing and serialization.
  * Improved parsing to support both rendered horizontal rule structures and bare horizontal rule elements.

* **Tests**
  * Added test coverage verifying horizontal rule attributes persist through DOM round-trip operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->