### PR TITLE
feat(table): export table editing commands

### DIFF
--- a/.changeset/export-table-edit-commands.md
+++ b/.changeset/export-table-edit-commands.md
@@ -1,0 +1,17 @@
+---
+"@prosekit/extensions": patch
+"prosekit": patch
+---
+
+Export the following table command functions:
+
+- `deleteTable`
+- `deleteTableColumn`
+- `deleteTableRow`
+- `addTableColumnBefore`
+- `addTableColumnAfter`
+- `addTableRowAbove`
+- `addTableRowBelow`
+- `mergeTableCells`
+- `splitTableCell`
+- `deleteCellSelection`

--- a/packages/extensions/src/table/index.ts
+++ b/packages/extensions/src/table/index.ts
@@ -1,4 +1,17 @@
-export { defineTableCommands, type TableCommandsExtension } from './table-commands.ts'
+export {
+  addTableColumnAfter,
+  addTableColumnBefore,
+  addTableRowAbove,
+  addTableRowBelow,
+  defineTableCommands,
+  deleteTable,
+  deleteTableColumn,
+  deleteTableRow,
+  mergeTableCells,
+  splitTableCell,
+  type TableCommandsExtension,
+} from './table-commands.ts'
+export { deleteCellSelection } from './table-commands/delete-cell-selection.ts'
 export { exitTable } from './table-commands/exit-table.ts'
 export { insertTable, type InsertTableOptions } from './table-commands/insert-table.ts'
 export { moveTableColumn, type MoveTableColumnOptions } from './table-commands/move-table-column.ts'

--- a/packages/extensions/src/table/table-commands.ts
+++ b/packages/extensions/src/table/table-commands.ts
@@ -1,14 +1,14 @@
 import { defineCommands, type Extension } from '@prosekit/core'
 import {
-  addColumnAfter,
-  addColumnBefore,
-  addRowAfter,
-  addRowBefore,
-  deleteColumn,
-  deleteRow,
+  addColumnAfter as addTableColumnAfter,
+  addColumnBefore as addTableColumnBefore,
+  addRowAfter as addTableRowBelow,
+  addRowBefore as addTableRowAbove,
+  deleteColumn as deleteTableColumn,
+  deleteRow as deleteTableRow,
   deleteTable,
-  mergeCells,
-  splitCell,
+  mergeCells as mergeTableCells,
+  splitCell as splitTableCell,
 } from 'prosemirror-tables'
 
 import { deleteCellSelection } from './table-commands/delete-cell-selection.ts'
@@ -20,6 +20,18 @@ import { selectTableCell, type SelectTableCellOptions } from './table-commands/s
 import { selectTableColumn, type SelectTableColumnOptions } from './table-commands/select-table-column.ts'
 import { selectTableRow, type SelectTableRowOptions } from './table-commands/select-table-row.ts'
 import { selectTable, type SelectTableOptions } from './table-commands/select-table.ts'
+
+export {
+  addTableColumnAfter,
+  addTableColumnBefore,
+  addTableRowAbove,
+  addTableRowBelow,
+  deleteTable,
+  deleteTableColumn,
+  deleteTableRow,
+  mergeTableCells,
+  splitTableCell,
+}
 
 /**
  * @internal
@@ -65,18 +77,18 @@ export function defineTableCommands(): TableCommandsExtension {
     selectTableColumn,
     selectTableRow,
 
-    addTableColumnBefore: () => addColumnBefore,
-    addTableColumnAfter: () => addColumnAfter,
-    addTableRowAbove: () => addRowBefore,
-    addTableRowBelow: () => addRowAfter,
+    addTableColumnBefore: () => addTableColumnBefore,
+    addTableColumnAfter: () => addTableColumnAfter,
+    addTableRowAbove: () => addTableRowAbove,
+    addTableRowBelow: () => addTableRowBelow,
 
     deleteTable: () => deleteTable,
-    deleteTableColumn: () => deleteColumn,
-    deleteTableRow: () => deleteRow,
+    deleteTableColumn: () => deleteTableColumn,
+    deleteTableRow: () => deleteTableRow,
     deleteCellSelection: () => deleteCellSelection,
 
-    mergeTableCells: () => mergeCells,
-    splitTableCell: () => splitCell,
+    mergeTableCells: () => mergeTableCells,
+    splitTableCell: () => splitTableCell,
 
     moveTableRow,
     moveTableColumn,


### PR DESCRIPTION
Export the table editing commands as standalone `Command` functions from `@prosekit/extensions/table`: `deleteTable`, `deleteTableColumn`, `deleteTableRow`, `addTableColumnBefore`, `addTableColumnAfter`, `addTableRowAbove`, `addTableRowBelow`, `mergeTableCells`, `splitTableCell`, and `deleteCellSelection`. They were previously only reachable via `editor.commands`, so composing one (e.g. in a custom keymap) meant depending on `prosemirror-tables` directly. Command names and `defineTableCommands` behavior are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exported table command functions for programmatic table manipulation, including adding/deleting rows and columns, merging and splitting cells, and clearing cell selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->