### PR TITLE
fix(web): place drop indicator relative to offset parent

### DIFF
--- a/.changeset/drop-indicator-hoist.md
+++ b/.changeset/drop-indicator-hoist.md
@@ -3,4 +3,4 @@
 "@prosekit/web": patch
 ---
 
-Fix the drop indicator being mispositioned when an ancestor (such as a virtualized list item using `transform`) establishes a containing block for fixed-positioned descendants. The indicator now resolves its position with Floating UI relative to its offset parent, the same way the table drop indicator does.
+Position the drop indicator relative to its offset parent.

--- a/.changeset/drop-indicator-hoist.md
+++ b/.changeset/drop-indicator-hoist.md
@@ -1,0 +1,6 @@
+---
+'prosekit': patch
+"@prosekit/web": patch
+---
+
+Fix the drop indicator being mispositioned when an ancestor (such as a virtualized list item using `transform`) establishes a containing block for fixed-positioned descendants. The indicator now resolves its position with Floating UI relative to its offset parent, the same way the table drop indicator does.

--- a/packages/web/src/components/drop-indicator/drop-indicator.ts
+++ b/packages/web/src/components/drop-indicator/drop-indicator.ts
@@ -11,6 +11,7 @@ import {
   type State,
 } from '@aria-ui/core'
 import { usePresence } from '@aria-ui/utils'
+import { computePosition, offset, type VirtualElement } from '@floating-ui/dom'
 import type { Editor } from '@prosekit/core'
 import { defineDropIndicator, type ShowHandlerOptions } from '@prosekit/extensions/drop-indicator'
 
@@ -66,47 +67,62 @@ export function setupDropIndicator(
 
   useEditorExtension(host, props.editor.get, extension)
 
-  const getLine = computed(() => context.get()?.line)
   const getScrolling = useScrolling(host)
   const getPresence = computed(() => !!context.get() && !getScrolling())
   usePresence(host, getPresence)
 
   useEffect(host, () => {
-    const lineValue = getLine()
+    const ctx = context.get()
+    if (!ctx) return
+
+    const { view, line } = ctx
     const lineWidth = props.width.get()
+    const { p1, p2 } = line
+    const horizontal = p1.y === p2.y
 
-    if (!lineValue) return
-
-    const { p1: { x: x1, y: y1 }, p2: { x: x2, y: y2 } } = lineValue
-    const horizontal = y1 === y2
-
-    let width: number
-    let height: number
-    let top: number = y1
-    let left: number = x1
-
-    if (horizontal) {
-      width = x2 - x1
-      height = lineWidth
-      top -= lineWidth / 2
-    } else {
-      width = lineWidth
-      height = y2 - y1
-      left -= lineWidth / 2
+    // The drop point is a line in viewport coordinates (from
+    // `getBoundingClientRect`). Applying those directly to a `position: fixed`
+    // element breaks whenever an ancestor establishes a containing block for
+    // fixed descendants (e.g. a virtualized list item with `transform`), which
+    // offsets the line. Instead, describe the line as a Floating UI virtual
+    // element and let `computePosition` resolve it into the host's offset-parent
+    // space, the same way the table drop indicator and block handle position
+    // themselves. This is correct regardless of any transformed ancestor.
+    const reference: VirtualElement = {
+      getBoundingClientRect: () => ({
+        x: p1.x,
+        y: p1.y,
+        left: p1.x,
+        top: p1.y,
+        right: p2.x,
+        bottom: p2.y,
+        width: p2.x - p1.x,
+        height: p2.y - p1.y,
+      }),
+      contextElement: view.dom,
     }
 
-    top = Math.round(top)
-    left = Math.round(left)
-
-    assignStyles(host, {
-      position: 'fixed',
-      pointerEvents: 'none',
-      width: `${width}px`,
-      height: `${height}px`,
-      transform: `translate(${left}px, ${top}px)`,
-      left: '0px',
-      top: '0px',
+    let cancelled = false
+    void computePosition(reference, host, {
+      // Anchor the host's leading edge to the line, then pull it back by half
+      // the thickness so the line is centered on the drop point.
+      placement: horizontal ? 'bottom-start' : 'right-start',
+      middleware: [offset(-lineWidth / 2)],
+    }).then(({ x, y }) => {
+      if (cancelled) return
+      assignStyles(host, {
+        position: 'absolute',
+        pointerEvents: 'none',
+        width: `${horizontal ? p2.x - p1.x : lineWidth}px`,
+        height: `${horizontal ? lineWidth : p2.y - p1.y}px`,
+        left: `${Math.round(x)}px`,
+        top: `${Math.round(y)}px`,
+      })
     })
+
+    return () => {
+      cancelled = true
+    }
   })
 }
 

--- a/packages/web/src/components/drop-indicator/drop-indicator.ts
+++ b/packages/web/src/components/drop-indicator/drop-indicator.ts
@@ -80,14 +80,8 @@ export function setupDropIndicator(
     const { p1, p2 } = line
     const horizontal = p1.y === p2.y
 
-    // The drop point is a line in viewport coordinates (from
-    // `getBoundingClientRect`). Applying those directly to a `position: fixed`
-    // element breaks whenever an ancestor establishes a containing block for
-    // fixed descendants (e.g. a virtualized list item with `transform`), which
-    // offsets the line. Instead, describe the line as a Floating UI virtual
-    // element and let `computePosition` resolve it into the host's offset-parent
-    // space, the same way the table drop indicator and block handle position
-    // themselves. This is correct regardless of any transformed ancestor.
+    // Use a Floating UI virtual element for the line so it's positioned relative
+    // to the offset parent, not the (possibly transformed) viewport.
     const reference: VirtualElement = {
       getBoundingClientRect: () => ({
         x: p1.x,


### PR DESCRIPTION
## Problem

The drop indicator is positioned with viewport coordinates from `getBoundingClientRect()` applied to a `position: fixed` element. That only resolves against the viewport when no ancestor establishes a containing block for fixed descendants. When an ancestor has `transform` / `filter` / `contain` (e.g. a virtualized list item using `transform: translateY(...)`, as TanStack Virtual does), that ancestor becomes the containing block and the line is offset by the ancestor's on-screen position, landing far from the real drop point.

## Fix

Describe the drop line as a Floating UI [virtual element](https://floating-ui.com/docs/virtual-elements) and let `computePosition` resolve it into the host's offset-parent coordinate space, then apply the result with `position: absolute`. This is the same mechanism the sibling table drop indicator (`table-handle-drop-indicator.ts`) and the block handle already use, so it is correct regardless of any transformed/positioned ancestor. `usePresence` and the rest of the lifecycle are unchanged.

Compared to hoisting into the top layer (an earlier draft of this PR), this keeps the line in the normal flow, so it clips naturally to the editor's scroll area and reuses an in-repo pattern instead of hand-rolling a Popover lifecycle.

## Notes

- Drop handling is unaffected: the actual drop is the editor's `handleDrop` / `dragover` listeners; the indicator is decorative and already `pointer-events: none`.
- No public API change, so no framework-wrapper codegen.
- Draft: still want an integration test that wraps the editor in a `transform: translateY` ancestor and asserts the indicator rect matches the target line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the drop indicator’s positioning so it aligns consistently with its nearest offset parent.
  * Updated the drop indicator placement logic for more accurate on-screen alignment during scrolling and layout changes.
* **Release**
  * Shipped patch updates for both the core and web packages to deliver this positioning fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->