### PR TITLE
feat(list): export list commands

### DIFF
--- a/.changeset/export-list-commands.md
+++ b/.changeset/export-list-commands.md
@@ -1,0 +1,16 @@
+---
+"@prosekit/extensions": patch
+"prosekit": patch
+---
+
+Export the following list command functions:
+
+- `dedentList`
+- `indentList`
+- `moveList`
+- `splitList`
+- `toggleCollapsed`
+- `unwrapList`
+- `toggleList`
+- `wrapInList`
+- `insertList`

--- a/packages/extensions/src/list/index.ts
+++ b/packages/extensions/src/list/index.ts
@@ -6,7 +6,20 @@ export type {
   UnwrapListOptions,
   WrapInListGetAttrs,
 } from 'prosemirror-flat-list'
-export { defineListCommands, type ListCommandsExtension } from './list-commands.ts'
+export {
+  dedentList,
+  defineListCommands,
+  indentList,
+  insertList,
+  moveList,
+  splitList,
+  toggleCollapsed,
+  toggleList,
+  unwrapList,
+  wrapInList,
+  type ListCommandsExtension,
+} from './list-commands.ts'
+export { defineListDropIndicator } from './list-drop-indicator.ts'
 export { defineListInputRules } from './list-input-rules.ts'
 export { defineListKeymap } from './list-keymap.ts'
 export { defineListPlugins } from './list-plugins.ts'

--- a/packages/extensions/src/list/list-commands.ts
+++ b/packages/extensions/src/list/list-commands.ts
@@ -55,3 +55,5 @@ export function defineListCommands(): ListCommandsExtension {
     insertList,
   })
 }
+
+export { dedentList, indentList, insertList, moveList, splitList, toggleCollapsed, toggleList, unwrapList, wrapInList }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Individual list command functions (`dedentList`, `indentList`, `moveList`, `splitList`, `toggleCollapsed`, `unwrapList`, `toggleList`, `wrapInList`, `insertList`) are now available for direct import.
  * Added `defineListDropIndicator` to the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->