### PR TITLE
feat(autocomplete): add triggerAutocomplete command

### DIFF
--- a/.changeset/trigger-autocomplete.md
+++ b/.changeset/trigger-autocomplete.md
@@ -3,4 +3,4 @@
 "prosekit": minor
 ---
 
-Add `triggerAutocomplete`, a command that re-scans the text before the cursor and opens the autocomplete menu if a rule matches. Use it to open a slash, mention, or tag menu imperatively (for example from a toolbar button or a keyboard shortcut after inserting the trigger text), since autocomplete otherwise only opens while the user is typing.
+Add `triggerAutocomplete`, a command that re-scans the text before the cursor and opens the autocomplete menu if a rule matches.

--- a/.changeset/trigger-autocomplete.md
+++ b/.changeset/trigger-autocomplete.md
@@ -1,0 +1,6 @@
+---
+"@prosekit/extensions": minor
+"prosekit": minor
+---
+
+Add `triggerAutocomplete`, a command that re-scans the text before the cursor and opens the autocomplete menu if a rule matches. Use it to open a slash, mention, or tag menu imperatively (for example from a toolbar button or a keyboard shortcut after inserting the trigger text), since autocomplete otherwise only opens while the user is typing.

--- a/packages/extensions/src/autocomplete/autocomplete-commands.ts
+++ b/packages/extensions/src/autocomplete/autocomplete-commands.ts
@@ -1,0 +1,21 @@
+import type { Command } from '@prosekit/pm/state'
+
+import { setTrMeta } from './autocomplete-helpers.ts'
+
+const scanCommand: Command = (state, dispatch) => {
+  dispatch?.(setTrMeta(state.tr, { type: 'scan' }))
+  return true
+}
+
+/**
+ * Returns a command that re-scans the text before the cursor for an autocomplete
+ * match and opens the menu if a rule matches.
+ *
+ * Autocomplete normally only opens while the user is typing. Use this command to
+ * open a slash, mention, or tag menu imperatively, for example from a toolbar
+ * button or a keyboard shortcut after inserting the trigger text. It is intended
+ * for an empty (cursor) selection.
+ */
+export function triggerAutocomplete(): Command {
+  return scanCommand
+}

--- a/packages/extensions/src/autocomplete/autocomplete-commands.ts
+++ b/packages/extensions/src/autocomplete/autocomplete-commands.ts
@@ -12,9 +12,7 @@ const scanCommand: Command = (state, dispatch) => {
  * match and opens the menu if a rule matches.
  *
  * Autocomplete normally only opens while the user is typing. Use this command to
- * open a slash, mention, or tag menu imperatively, for example from a toolbar
- * button or a keyboard shortcut after inserting the trigger text. It is intended
- * for an empty (cursor) selection.
+ * open a menu imperatively. It is intended for an empty (cursor) selection.
  */
 export function triggerAutocomplete(): Command {
   return scanCommand

--- a/packages/extensions/src/autocomplete/autocomplete-helpers.ts
+++ b/packages/extensions/src/autocomplete/autocomplete-helpers.ts
@@ -59,6 +59,8 @@ export type PredictionTransactionMeta = {
   matching: PredictionPluginMatching
 } | {
   type: 'leave'
+} | {
+  type: 'scan'
 }
 
 export function getPluginState(state: EditorState): PredictionPluginState | undefined {

--- a/packages/extensions/src/autocomplete/autocomplete-plugin.ts
+++ b/packages/extensions/src/autocomplete/autocomplete-plugin.ts
@@ -181,6 +181,28 @@ function handleTransaction(
     return { matching: null, ignores }
   }
 
+  // If a scan is requested, look for a new matching at the cursor. Mirrors
+  // `handleTextInput`, but runs against the already-updated state so the menu
+  // can be opened imperatively after the trigger text is inserted.
+  if (meta.type === 'scan') {
+    const $head = newState.selection.$head
+    const textBackward = getTextBackward($head)
+    const textTo = $head.pos
+    const textFrom = textTo - textBackward.length
+    const currMatching = matchRule(
+      newState,
+      getRules(),
+      textBackward,
+      textFrom,
+      textTo,
+      ignores,
+    )
+    if (currMatching && prevMatching && prevMatching.from !== currMatching.from) {
+      ignores.push(prevMatching.from)
+    }
+    return { matching: currMatching ?? null, ignores }
+  }
+
   throw new Error(`Invalid transaction meta: ${meta satisfies never}`)
 }
 

--- a/packages/extensions/src/autocomplete/autocomplete-plugin.ts
+++ b/packages/extensions/src/autocomplete/autocomplete-plugin.ts
@@ -181,9 +181,7 @@ function handleTransaction(
     return { matching: null, ignores }
   }
 
-  // If a scan is requested, look for a new matching at the cursor. Mirrors
-  // `handleTextInput`, but runs against the already-updated state so the menu
-  // can be opened imperatively after the trigger text is inserted.
+  // If a scan is requested, look for a new matching at the cursor.
   if (meta.type === 'scan') {
     const $head = newState.selection.$head
     const textBackward = getTextBackward($head)

--- a/packages/extensions/src/autocomplete/autocomplete.spec.ts
+++ b/packages/extensions/src/autocomplete/autocomplete.spec.ts
@@ -5,6 +5,7 @@ import { keyboard } from 'vitest-browser-commands/playwright'
 import { defineTestExtension, setupTestFromExtension } from '../testing/index.ts'
 import { inputText } from '../testing/keyboard.ts'
 
+import { triggerAutocomplete } from './autocomplete-commands.ts'
 import { AutocompleteRule, type MatchHandler, type MatchHandlerOptions } from './autocomplete-rule.ts'
 import { defineAutocomplete } from './autocomplete.ts'
 
@@ -227,6 +228,31 @@ describe('defineAutocomplete', () => {
     expect(showSelection()).toMatchInlineSnapshot(`"a /b /c<cursor>"`)
     expect(isMatching()).toBe(true)
     expect(getMatchingText()).toBe('/c')
+  })
+
+  it('does not open from a programmatic insert, but opens via triggerAutocomplete', () => {
+    const { editor, onEnter, isMatching, getMatchingText } = setupSlashMenu()
+
+    // A programmatic insert bypasses `handleTextInput`, so the menu stays closed.
+    editor.commands.insertText({ text: '/' })
+    expect(editor.state.doc.textContent).toBe('/')
+    expect(isMatching()).toBe(false)
+    expect(onEnter).not.toHaveBeenCalled()
+
+    // `triggerAutocomplete` re-scans at the cursor and opens the menu.
+    editor.exec(triggerAutocomplete())
+    expect(isMatching()).toBe(true)
+    expect(onEnter).toHaveBeenCalledTimes(1)
+    expect(getMatchingText()).toBe('/')
+  })
+
+  it('triggerAutocomplete does nothing when no rule matches at the cursor', () => {
+    const { editor, onEnter, isMatching } = setupSlashMenu()
+
+    editor.commands.insertText({ text: 'hello' })
+    editor.exec(triggerAutocomplete())
+    expect(isMatching()).toBe(false)
+    expect(onEnter).not.toHaveBeenCalled()
   })
 
   it('can dismiss the match by creating a new paragraph', async () => {

--- a/packages/extensions/src/autocomplete/index.ts
+++ b/packages/extensions/src/autocomplete/index.ts
@@ -1,3 +1,4 @@
+export { triggerAutocomplete } from './autocomplete-commands.ts'
 export {
   AutocompleteRule,
   type AutocompleteRuleOptions,


### PR DESCRIPTION
Adds `triggerAutocomplete()`, a command that re-scans the text before the cursor and opens the autocomplete menu if a rule matches, so a slash/mention/tag menu can be opened imperatively (e.g. from a shortcut after inserting the trigger text) rather than only while typing. Implemented as a new `scan` transaction meta handled by the autocomplete plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `triggerAutocomplete` command, allowing users to manually trigger the autocomplete menu. The command scans for applicable rules at the current cursor position and opens the autocomplete menu when a match is found.

* **Tests**
  * Added comprehensive test coverage for the autocomplete trigger feature, including validation of behavior when rules match and when no rules apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->