### PR TITLE
fix(horizontal-rule): guard `---` input rule against invalid parents

### DIFF
--- a/.changeset/horizontal-rule-input-rule-guard.md
+++ b/.changeset/horizontal-rule-input-rule-guard.md
@@ -3,4 +3,4 @@
 '@prosekit/extensions': patch
 ---
 
-Guard the `---` horizontal rule input rule against parents that cannot hold a horizontal rule. Previously, typing `---` in an inline-only container (such as a table cell restricted to a single paragraph) deleted the typed text without inserting anything. The rule now checks `canReplaceWith` first and leaves the text untouched when the parent forbids the node.
+Guard the `---` horizontal rule input rule against parents that cannot hold a horizontal rule.

--- a/.changeset/horizontal-rule-input-rule-guard.md
+++ b/.changeset/horizontal-rule-input-rule-guard.md
@@ -1,0 +1,6 @@
+---
+'prosekit': patch
+'@prosekit/extensions': patch
+---
+
+Guard the `---` horizontal rule input rule against parents that cannot hold a horizontal rule. Previously, typing `---` in an inline-only container (such as a table cell restricted to a single paragraph) deleted the typed text without inserting anything. The rule now checks `canReplaceWith` first and leaves the text untouched when the parent forbids the node.

--- a/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.spec.ts
+++ b/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.spec.ts
@@ -56,6 +56,19 @@ describe('defineHorizontalRuleInputRule', () => {
     )
   })
 
+  it('should insert inside when the parent allows a horizontal rule', async () => {
+    const { editor, n } = setupTestFromExtension(
+      union(defineTestExtension()),
+    )
+    const doc = n.doc(n.table(n.tableRow(n.tableCell(n.paragraph('<a>')))))
+    editor.set(doc)
+
+    await inputText('---')
+    expect(editor.view.state.doc.toJSON()).toEqual(
+      n.doc(n.table(n.tableRow(n.tableCell(n.horizontalRule(), n.paragraph())))).toJSON(),
+    )
+  })
+
   it('should not insert when the parent forbids a horizontal rule', async () => {
     // Restrict table cells to a single paragraph so they cannot hold a
     // horizontal rule, the way GFM table cells work.

--- a/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.spec.ts
+++ b/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.spec.ts
@@ -1,6 +1,7 @@
+import { defineNodeSpec, union } from '@prosekit/core'
 import { describe, expect, it } from 'vitest'
 
-import { setupTest } from '../testing/index.ts'
+import { defineTestExtension, setupTest, setupTestFromExtension } from '../testing/index.ts'
 import { inputText } from '../testing/keyboard.ts'
 
 describe('defineHorizontalRuleInputRule', () => {
@@ -52,6 +53,25 @@ describe('defineHorizontalRuleInputRule', () => {
     await inputText('---')
     expect(editor.view.state.doc.toJSON()).toEqual(
       n.doc(n.codeBlock('---')).toJSON(),
+    )
+  })
+
+  it('should not insert when the parent forbids a horizontal rule', async () => {
+    // Restrict table cells to a single paragraph so they cannot hold a
+    // horizontal rule, the way GFM table cells work.
+    const { editor, n } = setupTestFromExtension(
+      union(
+        defineTestExtension(),
+        defineNodeSpec({ name: 'tableCell', content: 'paragraph' }),
+        defineNodeSpec({ name: 'tableHeaderCell', content: 'paragraph' }),
+      ),
+    )
+    const doc = n.doc(n.table(n.tableRow(n.tableCell(n.paragraph('<a>')))))
+    editor.set(doc)
+
+    await inputText('---')
+    expect(editor.view.state.doc.toJSON()).toEqual(
+      n.doc(n.table(n.tableRow(n.tableCell(n.paragraph('---'))))).toJSON(),
     )
   })
 })

--- a/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.ts
+++ b/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.ts
@@ -12,9 +12,7 @@ export function defineHorizontalRuleInputRule(): PlainExtension {
         const type = getNodeType(schema, 'horizontalRule')
         const $start = state.doc.resolve(start)
         const index = $start.index(-1)
-        // Bail when the parent (e.g. an inline-only table cell) cannot hold a
-        // horizontal rule, so typing "---" there leaves the text untouched
-        // instead of deleting it.
+        // Bail when the parent cannot hold a horizontal rule
         if (!$start.node(-1).canReplaceWith(index, index, type)) {
           return null
         }

--- a/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.ts
+++ b/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.ts
@@ -10,6 +10,14 @@ export function defineHorizontalRuleInputRule(): PlainExtension {
         const { schema } = state
         const { tr } = state
         const type = getNodeType(schema, 'horizontalRule')
+        const $start = state.doc.resolve(start)
+        const index = $start.index(-1)
+        // Bail when the parent (e.g. an inline-only table cell) cannot hold a
+        // horizontal rule, so typing "---" there leaves the text untouched
+        // instead of deleting it.
+        if (!$start.node(-1).canReplaceWith(index, index, type)) {
+          return null
+        }
         const node = type.createChecked()
         tr.delete(start, end).insert(start - 1, node)
         return tr.scrollIntoView()


### PR DESCRIPTION
Typing `---` in an inline-only container (such as a table cell restricted to a single paragraph) deleted the typed text without inserting anything, because the input rule ran `tr.delete` then a no-op `tr.insert` of a node the parent cannot hold. The rule now checks `canReplaceWith` first and leaves the text untouched when the parent forbids a horizontal rule. Covered by a new spec case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal rule input handling so typing `---` no longer inserts a rule in places that can’t support it.
  * Table-related editing now behaves more safely, allowing horizontal rules only where the surrounding content permits them.

* **Tests**
  * Expanded coverage for horizontal rule insertion in table contexts, including both allowed and disallowed cases.

* **Chores**
  * Included a patch release note for the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->