### PR TITLE
fix(web): keep table handles and open menu visible while scrolling

### DIFF
--- a/.changeset/table-handle-menu-scroll.md
+++ b/.changeset/table-handle-menu-scroll.md
@@ -1,0 +1,6 @@
+---
+'prosekit': patch
+"@prosekit/web": patch
+---
+
+Keep the table handles and an open handle menu visible while scrolling.

--- a/packages/web/src/components/table-handle/store.ts
+++ b/packages/web/src/components/table-handle/store.ts
@@ -57,19 +57,20 @@ export function createTableHandleStore(
     isColumnMenuOpen.set(open)
   }
 
-  const referenceCellInfo = createSignal<HoveringCellInfo | undefined>(undefined)
-
   let prevHoveringCellInfo: HoveringCellInfo | undefined = undefined
 
   const getReferenceCell = computed((): HoveringCellInfo | undefined => {
-    if (!getCanShow()) {
-      referenceCellInfo.set(undefined)
-      return
-    }
-
-    // Do not toggle/update the menu when hovering another cell if the menu is already open
+    // Keep the handles anchored to the same cell while a menu is open: don't
+    // follow the pointer to another cell, and don't let scrolling (or the
+    // other `getCanShow` conditions) hide the handles. Hiding them would also
+    // hide the open menu without closing it, leaving a menu that is invisible
+    // but still open.
     if (getHasMenuOpen()) {
       return prevHoveringCellInfo
+    }
+
+    if (!getCanShow()) {
+      return undefined
     }
 
     prevHoveringCellInfo = getHoveringCellInfo()


### PR DESCRIPTION
With a table handle menu open, scrolling used to hide the handles through the `getCanShow` path, which bypassed both the menu-open freeze and the `handleOpenChange` guard: the menu disappeared while its open state stayed true, and the next mouse move resurrected it with a broken position animation. Reorder `getReferenceCell` so an open menu pins the handles first; while the menu is open, `autoUpdate` keeps everything anchored to the cell during scrolling (standard dropdown behavior). This covers both the column and the row menu, which share the same store.


**Before**:


https://github.com/user-attachments/assets/3a602bc3-6bf5-430c-b7a4-8307a143c16d

**After**:


https://github.com/user-attachments/assets/cb7dfece-dd35-482f-9b1b-66699f2fc1cb



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Table handles and any open table menu now stay visible while scrolling, so they won’t disappear unexpectedly.
  * Improved the stability of table interactions when visibility conditions change during scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->