### PR TITLE
fix(virtual-selection): remove the native selection on blur

### DIFF
--- a/.changeset/plenty-pants-search.md
+++ b/.changeset/plenty-pants-search.md
@@ -1,0 +1,6 @@
+---
+'prosekit': patch
+"@prosekit/extensions": patch
+---
+
+Fix `defineVirtualSelection` leaving a stale native selection visible on top of the virtual selection after the editor loses focus.

--- a/packages/extensions/src/virtual-selection/index.spec.ts
+++ b/packages/extensions/src/virtual-selection/index.spec.ts
@@ -1,0 +1,96 @@
+import { union } from '@prosekit/core'
+import { TextSelection } from '@prosekit/pm/state'
+import { describe, expect, it, vi } from 'vitest'
+
+import { defineDoc } from '../doc/index.ts'
+import { defineParagraph } from '../paragraph/index.ts'
+import { setupTestFromExtension } from '../testing/index.ts'
+import { defineText } from '../text/index.ts'
+
+import { defineVirtualSelection } from './index.ts'
+
+function setup() {
+  const extension = union(
+    defineDoc(),
+    defineText(),
+    defineParagraph(),
+    defineVirtualSelection(),
+  )
+  const { editor, n } = setupTestFromExtension(extension)
+  editor.set(n.doc(n.paragraph('hello world')))
+
+  const setSelection = (from: number, to: number) => {
+    editor.view.dispatch(
+      editor.state.tr.setSelection(TextSelection.create(editor.state.doc, from, to)),
+    )
+  }
+
+  const getVirtualSelectionText = () => {
+    return Array.from(editor.view.dom.querySelectorAll('.prosekit-virtual-selection'))
+      .map((element) => element.textContent)
+      .join('|')
+  }
+
+  return {
+    editor,
+    getVirtualSelectionText,
+    setSelection,
+  }
+}
+
+describe('defineVirtualSelection', () => {
+  it('shows the selection as a decoration after blur', () => {
+    const { editor, getVirtualSelectionText, setSelection } = setup()
+
+    setSelection(1, 6)
+    expect(getVirtualSelectionText()).toBe('')
+
+    editor.blur()
+    expect(getVirtualSelectionText()).toBe('hello')
+  })
+
+  it('removes the native selection inside the editor on blur', () => {
+    const { editor, setSelection } = setup()
+
+    setSelection(1, 6)
+    expect(window.getSelection()?.toString()).toBe('hello')
+
+    editor.blur()
+    expect(window.getSelection()?.rangeCount).toBe(0)
+  })
+
+  it('follows selection changes dispatched while blurred', () => {
+    const { editor, getVirtualSelectionText, setSelection } = setup()
+
+    setSelection(1, 6)
+    editor.blur()
+    expect(getVirtualSelectionText()).toBe('hello')
+
+    setSelection(7, 12)
+    expect(getVirtualSelectionText()).toBe('world')
+  })
+
+  it('keeps the decoration through doc changes', () => {
+    const { editor, getVirtualSelectionText, setSelection } = setup()
+
+    setSelection(1, 6)
+    editor.blur()
+
+    editor.view.dispatch(editor.state.tr.insertText('say ', 1))
+    expect(getVirtualSelectionText()).toBe('hello')
+  })
+
+  it('restores the native selection on focus', async () => {
+    const { editor, getVirtualSelectionText, setSelection } = setup()
+
+    setSelection(1, 6)
+    editor.blur()
+    expect(window.getSelection()?.rangeCount).toBe(0)
+
+    editor.focus()
+    await vi.waitFor(() => {
+      expect(window.getSelection()?.toString()).toBe('hello')
+    })
+    expect(getVirtualSelectionText()).toBe('')
+  })
+})

--- a/packages/extensions/src/virtual-selection/index.ts
+++ b/packages/extensions/src/virtual-selection/index.ts
@@ -1,6 +1,6 @@
 import { definePlugin, type PlainExtension } from '@prosekit/core'
 import { PluginKey, ProseMirrorPlugin, type EditorState, type Transaction } from '@prosekit/pm/state'
-import { Decoration, DecorationSet } from '@prosekit/pm/view'
+import { Decoration, DecorationSet, type EditorView } from '@prosekit/pm/view'
 
 /**
  * @internal
@@ -36,6 +36,27 @@ function getFocusState(state: EditorState): PluginState | undefined {
   return key.getState(state)
 }
 
+/**
+ * Removes the native selection when it's inside the editor. Otherwise the
+ * browser would keep painting it while the editor is blurred, and any DOM
+ * update dispatched while blurred (starting with the virtual selection
+ * decoration itself) re-anchors its endpoints to node boundaries, making the
+ * painted highlight drift away from the actual selection. ProseMirror
+ * restores the DOM selection from the state when the editor regains focus.
+ */
+function removeNativeSelection(view: EditorView): void {
+  const { dom, root } = view
+  const { selection } = view.state
+  if (selection.empty || !selection.visible) return
+
+  const domSelection = 'getSelection' in root
+    ? root.getSelection()
+    : window.getSelection()
+  if (domSelection?.anchorNode && dom.contains(domSelection.anchorNode)) {
+    domSelection.removeAllRanges()
+  }
+}
+
 const virtualSelectionPlugin = new ProseMirrorPlugin<PluginState>({
   key,
   state: {
@@ -57,6 +78,8 @@ const virtualSelectionPlugin = new ProseMirrorPlugin<PluginState>({
         // Don't show the decoration if the dom is blurred because the focus
         // moved outside the browser window.
         if (activeElement === dom) return
+
+        removeNativeSelection(view)
 
         view.dispatch(setFocusMeta(view.state.tr, true))
       },


### PR DESCRIPTION
Remove the native selection inside the editor on blur, so DOM updates dispatched while the editor is blurred can no longer re-anchor its endpoints and paint a drifting highlight on top of the virtual selection.

Closes https://github.com/prosekit/prosekit/issues/1670

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed editor selection behavior so the native selection highlight no longer lingers after the editor loses focus.
  * Improved selection syncing when switching focus, editing content, or changing the selected text while blurred.
  * Restoring focus now brings back the expected selection cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->