### PR TITLE
fix(horizontal-rule): let the `---` input rule replace an empty list item

### DIFF
--- a/.changeset/horizontal-rule-replace-empty-item.md
+++ b/.changeset/horizontal-rule-replace-empty-item.md
@@ -1,0 +1,6 @@
+---
+'prosekit': patch
+'@prosekit/extensions': patch
+---
+
+Typing `---` in an otherwise-empty block (e.g. an empty list item) now replaces that block with the horizontal rule instead of inserting the rule inside it.

--- a/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.spec.ts
+++ b/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.spec.ts
@@ -56,6 +56,56 @@ describe('defineHorizontalRuleInputRule', () => {
     )
   })
 
+  it('should replace an otherwise-empty bullet list item', async () => {
+    const doc = n.doc(n.bullet(n.p('<a>')))
+    editor.set(doc)
+
+    await inputText('---')
+    expect(editor.view.state.doc.toJSON()).toEqual(
+      n.doc(n.horizontalRule(), n.p()).toJSON(),
+    )
+  })
+
+  it('should replace an otherwise-empty ordered list item', async () => {
+    const doc = n.doc(n.ordered(n.p('<a>')))
+    editor.set(doc)
+
+    await inputText('---')
+    expect(editor.view.state.doc.toJSON()).toEqual(
+      n.doc(n.horizontalRule(), n.p()).toJSON(),
+    )
+  })
+
+  it('should replace only the list item under the caret', async () => {
+    const doc = n.doc(n.bullet(n.p('a')), n.bullet(n.p('<a>')), n.bullet(n.p('b')))
+    editor.set(doc)
+
+    await inputText('---')
+    expect(editor.view.state.doc.toJSON()).toEqual(
+      n.doc(n.bullet(n.p('a')), n.horizontalRule(), n.bullet(n.p('b'))).toJSON(),
+    )
+  })
+
+  it('should keep a list item that still has other content', async () => {
+    const doc = n.doc(n.bullet(n.p('first'), n.p('<a>')))
+    editor.set(doc)
+
+    await inputText('---')
+    expect(editor.view.state.doc.toJSON()).toEqual(
+      n.doc(n.bullet(n.p('first'), n.horizontalRule(), n.p())).toJSON(),
+    )
+  })
+
+  it('should replace a nested list item inside its parent item', async () => {
+    const doc = n.doc(n.bullet(n.p('foo'), n.bullet(n.p('<a>'))))
+    editor.set(doc)
+
+    await inputText('---')
+    expect(editor.view.state.doc.toJSON()).toEqual(
+      n.doc(n.bullet(n.p('foo'), n.horizontalRule(), n.p())).toJSON(),
+    )
+  })
+
   it('should insert inside when the parent allows a horizontal rule', async () => {
     const { editor, n } = setupTestFromExtension(
       union(defineTestExtension()),

--- a/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.ts
+++ b/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.ts
@@ -1,12 +1,11 @@
-import { defaultBlockAt, getNodeType, isNodeSelection, union, type PlainExtension } from '@prosekit/core'
+import { defaultBlockAt, getNodeType, isNodeSelection, type PlainExtension } from '@prosekit/core'
 import { InputRule } from '@prosekit/pm/inputrules'
 import { TextSelection } from '@prosekit/pm/state'
 
 import { defineInputRule } from '../input-rule/index.ts'
 
 export function defineHorizontalRuleInputRule(): PlainExtension {
-  return union(
-    defineInputRule(
+  return  defineInputRule(
       new InputRule(/^---$/, (state, match, start, end) => {
         const { schema } = state
         const { tr } = state
@@ -36,6 +35,5 @@ export function defineHorizontalRuleInputRule(): PlainExtension {
         }
         return tr.scrollIntoView()
       }),
-    ),
-  )
+    )
 }

--- a/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.ts
+++ b/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.ts
@@ -5,35 +5,35 @@ import { TextSelection } from '@prosekit/pm/state'
 import { defineInputRule } from '../input-rule/index.ts'
 
 export function defineHorizontalRuleInputRule(): PlainExtension {
-  return  defineInputRule(
-      new InputRule(/^---$/, (state, match, start, end) => {
-        const { schema } = state
-        const { tr } = state
-        const type = getNodeType(schema, 'horizontalRule')
-        const $start = state.doc.resolve(start)
-        const index = $start.index(-1)
-        // Bail when the parent cannot hold a horizontal rule
-        if (!$start.node(-1).canReplaceWith(index, index, type)) {
-          return null
+  return defineInputRule(
+    new InputRule(/^---$/, (state, match, start, end) => {
+      const { schema } = state
+      const { tr } = state
+      const type = getNodeType(schema, 'horizontalRule')
+      const $start = state.doc.resolve(start)
+      const index = $start.index(-1)
+      // Bail when the parent cannot hold a horizontal rule
+      if (!$start.node(-1).canReplaceWith(index, index, type)) {
+        return null
+      }
+      const node = type.createChecked()
+      // Replace from just before the textblock, so an ancestor that the
+      // replacement leaves empty (e.g. an empty list item) is consumed
+      // instead of wrapping the new horizontal rule.
+      tr.replaceRangeWith($start.before(), end, node)
+      // When no textblock follows the rule, append one to hold the caret.
+      const { selection } = tr
+      if (isNodeSelection(selection) && selection.node.type === type) {
+        const pos = selection.$to.pos
+        const $pos = tr.doc.resolve(pos)
+        const blockType = defaultBlockAt($pos.parent.contentMatchAt($pos.index()))
+        const block = blockType?.createAndFill()
+        if (block) {
+          tr.insert(pos, block)
+          tr.setSelection(TextSelection.create(tr.doc, pos + 1))
         }
-        const node = type.createChecked()
-        // Replace from just before the textblock, so an ancestor that the
-        // replacement leaves empty (e.g. an empty list item) is consumed
-        // instead of wrapping the new horizontal rule.
-        tr.replaceRangeWith($start.before(), end, node)
-        // When no textblock follows the rule, append one to hold the caret.
-        const { selection } = tr
-        if (isNodeSelection(selection) && selection.node.type === type) {
-          const pos = selection.$to.pos
-          const $pos = tr.doc.resolve(pos)
-          const blockType = defaultBlockAt($pos.parent.contentMatchAt($pos.index()))
-          const block = blockType?.createAndFill()
-          if (block) {
-            tr.insert(pos, block)
-            tr.setSelection(TextSelection.create(tr.doc, pos + 1))
-          }
-        }
-        return tr.scrollIntoView()
-      }),
-    )
+      }
+      return tr.scrollIntoView()
+    }),
+  )
 }

--- a/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.ts
+++ b/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.ts
@@ -1,6 +1,6 @@
-import { defaultBlockAt, getNodeType, union, type PlainExtension } from '@prosekit/core'
+import { defaultBlockAt, getNodeType, isNodeSelection, union, type PlainExtension } from '@prosekit/core'
 import { InputRule } from '@prosekit/pm/inputrules'
-import { NodeSelection, TextSelection } from '@prosekit/pm/state'
+import { TextSelection } from '@prosekit/pm/state'
 
 import { defineInputRule } from '../input-rule/index.ts'
 
@@ -24,7 +24,7 @@ export function defineHorizontalRuleInputRule(): PlainExtension {
         tr.replaceRangeWith($start.before(), end, node)
         // When no textblock follows the rule, append one to hold the caret.
         const { selection } = tr
-        if (selection instanceof NodeSelection && selection.node.type === type) {
+        if (isNodeSelection(selection) && selection.node.type === type) {
           const pos = selection.$to.pos
           const $pos = tr.doc.resolve(pos)
           const blockType = defaultBlockAt($pos.parent.contentMatchAt($pos.index()))

--- a/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.ts
+++ b/packages/extensions/src/horizontal-rule/horizontal-rule-input-rule.ts
@@ -1,5 +1,6 @@
-import { getNodeType, union, type PlainExtension } from '@prosekit/core'
+import { defaultBlockAt, getNodeType, union, type PlainExtension } from '@prosekit/core'
 import { InputRule } from '@prosekit/pm/inputrules'
+import { NodeSelection, TextSelection } from '@prosekit/pm/state'
 
 import { defineInputRule } from '../input-rule/index.ts'
 
@@ -17,7 +18,22 @@ export function defineHorizontalRuleInputRule(): PlainExtension {
           return null
         }
         const node = type.createChecked()
-        tr.delete(start, end).insert(start - 1, node)
+        // Replace from just before the textblock, so an ancestor that the
+        // replacement leaves empty (e.g. an empty list item) is consumed
+        // instead of wrapping the new horizontal rule.
+        tr.replaceRangeWith($start.before(), end, node)
+        // When no textblock follows the rule, append one to hold the caret.
+        const { selection } = tr
+        if (selection instanceof NodeSelection && selection.node.type === type) {
+          const pos = selection.$to.pos
+          const $pos = tr.doc.resolve(pos)
+          const blockType = defaultBlockAt($pos.parent.contentMatchAt($pos.index()))
+          const block = blockType?.createAndFill()
+          if (block) {
+            tr.insert(pos, block)
+            tr.setSelection(TextSelection.create(tr.doc, pos + 1))
+          }
+        }
         return tr.scrollIntoView()
       }),
     ),


### PR DESCRIPTION
Typing `---` in an otherwise-empty block, such as an empty list item, now replaces that block with the horizontal rule (via `replaceRangeWith`) instead of inserting the rule inside it, matching the interaction in editors like Remirror.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Typing `---` in an otherwise-empty list item now replaces the item with a horizontal rule instead of inserting the rule inside the list.
  * This behavior also works correctly in nested and multi-item list structures.
  * After inserting a horizontal rule, the editor now places the cursor in a new text block below it for easier continued typing.

* **Chores**
  * Included a patch release note for the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->