### PR TITLE
fix(web): write ProseMirror clipboard data on block handle drag

### DIFF
--- a/.changeset/block-handle-drag-clipboard.md
+++ b/.changeset/block-handle-drag-clipboard.md
@@ -1,0 +1,6 @@
+---
+"prosekit": patch
+"@prosekit/web": patch
+---
+
+Write ProseMirror-native clipboard data (`data-pm-slice` HTML and plain text) when dragging a block with the block handle, so a drop into another editor keeps the block intact, and clear the stale `dragging` state on the source view after the drag ends.

--- a/packages/web/src/components/block-handle/block-handle-draggable.ts
+++ b/packages/web/src/components/block-handle/block-handle-draggable.ts
@@ -64,8 +64,7 @@ export function setupBlockHandleDraggable(
 
     if (view && hoverState) {
       view.dom.classList.add(DRAGGING_CLASS_NAME)
-      createDraggingPreview(view, hoverState, event)
-      setViewDragging(view, hoverState)
+      startViewDragging(view, hoverState, event)
     }
   })
 
@@ -76,6 +75,7 @@ export function setupBlockHandleDraggable(
     const view = getSafeEditorView(props.editor.get())
     if (view) {
       view.dom.classList.remove(DRAGGING_CLASS_NAME)
+      clearViewDragging(view)
     }
   })
 
@@ -116,36 +116,51 @@ function usePointerDownHandler(
   })
 }
 
-function createDraggingPreview(view: EditorView, hoverState: HoverState, event: DragEvent): void {
-  if (!event.dataTransfer) {
-    return
-  }
-
-  const { pos } = hoverState
-
-  const element = view.nodeDOM(pos)
-  if (!element || !isHTMLElement(element)) {
-    return
-  }
-
-  event.dataTransfer.clearData()
-  event.dataTransfer.setData('text/html', element.outerHTML)
-  event.dataTransfer.effectAllowed = 'copyMove'
-  setDragPreview(event, element)
-
-  return
-}
-
-function setViewDragging(view: EditorView, hoverState: HoverState): void {
+function startViewDragging(view: EditorView, hoverState: HoverState, event: DragEvent): void {
   const { node, pos } = hoverState
 
+  // Serialize through the editor's clipboard pipeline so the transfer carries
+  // the `data-pm-slice` envelope and a plain-text fallback: a drop into
+  // another editor parses the transfer data and never sees this view's
+  // `dragging` state.
+  const { dom, text, slice } = view.serializeForClipboard(new Slice(Fragment.from(node), 0, 0))
+
+  if (event.dataTransfer) {
+    event.dataTransfer.clearData()
+    event.dataTransfer.setData('text/html', dom.innerHTML)
+    event.dataTransfer.setData('text/plain', text)
+    event.dataTransfer.effectAllowed = 'copyMove'
+
+    const element = view.nodeDOM(pos)
+    if (element && isHTMLElement(element)) {
+      setDragPreview(event, element)
+    }
+  }
+
   const dragging: ViewDragging = {
-    slice: new Slice(Fragment.from(node), 0, 0),
+    slice,
     move: true,
     node: NodeSelection.create(view.state.doc, pos),
   }
 
   view.dragging = dragging
+}
+
+function clearViewDragging(view: EditorView): void {
+  const dragging = view.dragging
+  if (!dragging) {
+    return
+  }
+
+  // The handle lives outside `view.dom`, so ProseMirror's own dragend handler
+  // never fires for handle drags; without this, a cross-editor drop or a
+  // canceled drag would leave a stale `dragging` on the source view. Delay
+  // like ProseMirror does, in case a same-view drop is still being processed.
+  window.setTimeout(() => {
+    if (view.dragging === dragging) {
+      view.dragging = null
+    }
+  }, 50)
 }
 
 const BlockHandleDraggableElementBase: HostElementConstructor<BlockHandleDraggableProps> = defineCustomElement(

--- a/registry/test/block-handle.test.ts
+++ b/registry/test/block-handle.test.ts
@@ -1,4 +1,5 @@
-import { expect, it } from 'vitest'
+import type { Editor } from 'prosekit/core'
+import { expect, it, vi } from 'vitest'
 import { keyboard } from 'vitest-browser-commands/playwright'
 import { page, userEvent, type Locator } from 'vitest/browser'
 
@@ -135,6 +136,44 @@ testStory({ story: 'block-handle', emptyContent: true }, () => {
     await expect.element(listNode).toHaveClass(/ProseMirror-selectednode/)
     await expect.element(p1).not.toHaveClass(/ProseMirror-selectednode/)
     await expect.element(p2).not.toHaveClass(/ProseMirror-selectednode/)
+
+    await closeBlockHandle()
+  })
+
+  it('writes ProseMirror clipboard data when dragging the handle', async () => {
+    const editor = await waitForEditor()
+    await editor.click()
+    await unhover()
+
+    await userEvent.type(editor, 'Paragraph 1')
+    await keyboard.press('Enter')
+    await userEvent.type(editor, 'Paragraph 2')
+
+    const p1 = editor.locate('p', { hasText: 'Paragraph 1' })
+    await hover(p1)
+    await expectBlockHandleToOpen()
+
+    const blockHandleDraggable = page.locate('prosekit-block-handle-draggable')
+    const draggableElement = blockHandleDraggable.element() as HTMLElement & { editor: Editor | null }
+    const view = draggableElement.editor?.view
+    expect(view).toBeTruthy()
+
+    const dataTransfer = new DataTransfer()
+    draggableElement.dispatchEvent(
+      new DragEvent('dragstart', { bubbles: true, cancelable: true, dataTransfer }),
+    )
+
+    // A drop into another editor can only read the data transfer, so the HTML
+    // must carry the `data-pm-slice` envelope and a plain-text fallback.
+    const html = dataTransfer.getData('text/html')
+    expect(html).toContain('data-pm-slice')
+    expect(html).toContain('Paragraph 1')
+    expect(html).not.toContain('Paragraph 2')
+    expect(dataTransfer.getData('text/plain')).toBe('Paragraph 1')
+    expect(view?.dragging).toBeTruthy()
+
+    draggableElement.dispatchEvent(new DragEvent('dragend', { bubbles: true }))
+    await vi.waitFor(() => expect(view?.dragging).toBeFalsy())
 
     await closeBlockHandle()
   })


### PR DESCRIPTION
The block handle's dragstart only wrote the rendered block's `outerHTML` to the data transfer, so a drop into another editor parsed it as foreign HTML and corrupted the block. Serialize the dragged slice through `view.serializeForClipboard` so the transfer carries the `data-pm-slice` envelope plus a `text/plain` fallback, matching ProseMirror's own dragstart behavior. Also clear the source view's `dragging` state on dragend, which ProseMirror's own cleanup never does for handle drags because the handle lives outside `view.dom`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Block handle dragging now preserves ProseMirror clipboard data when content is dropped into another editor.
  * Dragged blocks include formatted HTML and plain text, preserving only the selected block.
  * Cleared stale drag state after dragging ends for more reliable subsequent interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->