### PR TITLE
fix: construct lookbehind regexes with `new RegExp`

### DIFF
--- a/.changeset/lookbehind-regex-construction.md
+++ b/.changeset/lookbehind-regex-construction.md
@@ -4,4 +4,4 @@
 "prosekit-registry": patch
 ---
 
-Construct lookbehind trigger expressions with `new RegExp` so that modules still parse on engines without lookbehind support, and reject a second slash in the slash menu trigger.
+Construct lookbehind trigger expressions with `new RegExp` so that modules still parse on engines without lookbehind support. The matched expressions are unchanged.

--- a/.changeset/lookbehind-regex-construction.md
+++ b/.changeset/lookbehind-regex-construction.md
@@ -1,7 +1,6 @@
 ---
 "@prosekit/extensions": patch
 "prosekit": patch
-"prosekit-registry": patch
 ---
 
 Construct lookbehind trigger expressions with `new RegExp` so that modules still parse on engines without lookbehind support.

--- a/.changeset/lookbehind-regex-construction.md
+++ b/.changeset/lookbehind-regex-construction.md
@@ -1,0 +1,7 @@
+---
+"@prosekit/extensions": patch
+"prosekit": patch
+"prosekit-registry": patch
+---
+
+Construct lookbehind trigger expressions with `new RegExp` so that modules still parse on engines without lookbehind support, and reject a second slash in the slash menu trigger.

--- a/.changeset/lookbehind-regex-construction.md
+++ b/.changeset/lookbehind-regex-construction.md
@@ -4,4 +4,4 @@
 "prosekit-registry": patch
 ---
 
-Construct lookbehind trigger expressions with `new RegExp` so that modules still parse on engines without lookbehind support. The matched expressions are unchanged.
+Construct lookbehind trigger expressions with `new RegExp` so that modules still parse on engines without lookbehind support.

--- a/packages/extensions/src/autocomplete/autocomplete-rule.ts
+++ b/packages/extensions/src/autocomplete/autocomplete-rule.ts
@@ -69,8 +69,11 @@ export interface AutocompleteRuleOptions {
    * The regular expression to match against the text before the cursor. The
    * last match before the cursor is used.
    *
-   * For a slash menu, you might use `/(?<!\S)\/(\S.*)?$/u`.
+   * For a slash menu, you might use `/(?<!\S)\/(?!\/)(\S.*)?$/u`.
    * For a mention, you might use `/@\w*$/`
+   *
+   * To keep a file parseable by engines without lookbehind support, build
+   * the expression with `new RegExp` instead of a lookbehind regex literal.
    */
   regex: RegExp
 

--- a/packages/extensions/src/autocomplete/autocomplete-rule.ts
+++ b/packages/extensions/src/autocomplete/autocomplete-rule.ts
@@ -71,9 +71,6 @@ export interface AutocompleteRuleOptions {
    *
    * For a slash menu, you might use `/(?<!\S)\/(\S.*)?$/u`.
    * For a mention, you might use `/@\w*$/`
-   *
-   * To keep a file parseable by engines without lookbehind support, build
-   * the expression with `new RegExp` instead of a lookbehind regex literal.
    */
   regex: RegExp
 

--- a/packages/extensions/src/autocomplete/autocomplete-rule.ts
+++ b/packages/extensions/src/autocomplete/autocomplete-rule.ts
@@ -69,7 +69,7 @@ export interface AutocompleteRuleOptions {
    * The regular expression to match against the text before the cursor. The
    * last match before the cursor is used.
    *
-   * For a slash menu, you might use `/(?<!\S)\/(?!\/)(\S.*)?$/u`.
+   * For a slash menu, you might use `/(?<!\S)\/(\S.*)?$/u`.
    * For a mention, you might use `/@\w*$/`
    *
    * To keep a file parseable by engines without lookbehind support, build

--- a/packages/extensions/src/autocomplete/autocomplete.spec.ts
+++ b/packages/extensions/src/autocomplete/autocomplete.spec.ts
@@ -1,4 +1,4 @@
-import { canUseRegexLookbehind, union } from '@prosekit/core'
+import { union } from '@prosekit/core'
 import { TextSelection } from '@prosekit/pm/state'
 import { describe, expect, it, vi } from 'vitest'
 import { keyboard } from 'vitest-browser-commands/playwright'
@@ -10,7 +10,7 @@ import { AutocompleteRule, type MatchHandler, type MatchHandlerOptions } from '.
 import { defineAutocomplete, triggerAutocomplete } from './autocomplete.ts'
 
 function setupSlashMenu(options?: { followCursor?: boolean }) {
-  const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+  const regex = /(?<!\S)\/(\S.*)?$/u
 
   let matching: MatchHandlerOptions | null = null
 

--- a/packages/extensions/src/bold/bold-input-rule.ts
+++ b/packages/extensions/src/bold/bold-input-rule.ts
@@ -7,9 +7,11 @@ import { defineMarkInputRule } from '../input-rule/index.ts'
  */
 export function defineBoldInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: canUseRegexLookbehind()
-      ? /(?<=\s|^)\*\*([^\s*]|[^\s*][^*]*[^\s*])\*\*$/
-      : /\*\*([^\s*]|[^\s*][^*]*[^\s*])\*\*$/,
+    regex: new RegExp(
+      canUseRegexLookbehind()
+        ? String.raw`(?<=\s|^)\*\*([^\s*]|[^\s*][^*]*[^\s*])\*\*$`
+        : String.raw`\*\*([^\s*]|[^\s*][^*]*[^\s*])\*\*$`,
+    ),
     type: 'bold',
   })
 }

--- a/packages/extensions/src/bold/bold-input-rule.ts
+++ b/packages/extensions/src/bold/bold-input-rule.ts
@@ -7,7 +7,10 @@ import { defineMarkInputRule } from '../input-rule/index.ts'
  */
 export function defineBoldInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`\*\*([^\s*]|[^\s*][^*]*[^\s*])\*\*$`),
+    regex: new RegExp(
+      (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+        + String.raw`\*\*([^\s*]|[^\s*][^*]*[^\s*])\*\*$`,
+    ),
     type: 'bold',
   })
 }

--- a/packages/extensions/src/bold/bold-input-rule.ts
+++ b/packages/extensions/src/bold/bold-input-rule.ts
@@ -7,11 +7,7 @@ import { defineMarkInputRule } from '../input-rule/index.ts'
  */
 export function defineBoldInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: new RegExp(
-      canUseRegexLookbehind()
-        ? String.raw`(?<=\s|^)\*\*([^\s*]|[^\s*][^*]*[^\s*])\*\*$`
-        : String.raw`\*\*([^\s*]|[^\s*][^*]*[^\s*])\*\*$`,
-    ),
+    regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`\*\*([^\s*]|[^\s*][^*]*[^\s*])\*\*$`),
     type: 'bold',
   })
 }

--- a/packages/extensions/src/code/code-input-rule.ts
+++ b/packages/extensions/src/code/code-input-rule.ts
@@ -7,9 +7,11 @@ import { defineMarkInputRule } from '../input-rule/index.ts'
  */
 export function defineCodeInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: canUseRegexLookbehind()
-      ? /(?<=\s|^)`([^\s`]|[^\s`][^`]*[^\s`])`$/
-      : /`([^\s`]|[^\s`][^`]*[^\s`])`$/,
+    regex: new RegExp(
+      canUseRegexLookbehind()
+        ? '(?<=\\s|^)`([^\\s`]|[^\\s`][^`]*[^\\s`])`$'
+        : '`([^\\s`]|[^\\s`][^`]*[^\\s`])`$',
+    ),
     type: 'code',
   })
 }

--- a/packages/extensions/src/code/code-input-rule.ts
+++ b/packages/extensions/src/code/code-input-rule.ts
@@ -7,7 +7,10 @@ import { defineMarkInputRule } from '../input-rule/index.ts'
  */
 export function defineCodeInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + '`([^\\s`]|[^\\s`][^`]*[^\\s`])`$'),
+    regex: new RegExp(
+      (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+        + '`([^\\s`]|[^\\s`][^`]*[^\\s`])`$',
+    ),
     type: 'code',
   })
 }

--- a/packages/extensions/src/code/code-input-rule.ts
+++ b/packages/extensions/src/code/code-input-rule.ts
@@ -7,11 +7,7 @@ import { defineMarkInputRule } from '../input-rule/index.ts'
  */
 export function defineCodeInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: new RegExp(
-      canUseRegexLookbehind()
-        ? '(?<=\\s|^)`([^\\s`]|[^\\s`][^`]*[^\\s`])`$'
-        : '`([^\\s`]|[^\\s`][^`]*[^\\s`])`$',
-    ),
+    regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + '`([^\\s`]|[^\\s`][^`]*[^\\s`])`$'),
     type: 'code',
   })
 }

--- a/packages/extensions/src/highlight/highlight-input-rule.ts
+++ b/packages/extensions/src/highlight/highlight-input-rule.ts
@@ -7,11 +7,7 @@ import { defineMarkInputRule } from '../input-rule/index.ts'
  */
 export function defineHighlightInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: new RegExp(
-      canUseRegexLookbehind()
-        ? String.raw`(?<=\s|^)==([^\s=]|[^\s=][^=]*[^\s=])==$`
-        : String.raw`==([^\s=]|[^\s=][^=]*[^\s=])==$`,
-    ),
+    regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`==([^\s=]|[^\s=][^=]*[^\s=])==$`),
     type: 'highlight',
   })
 }

--- a/packages/extensions/src/highlight/highlight-input-rule.ts
+++ b/packages/extensions/src/highlight/highlight-input-rule.ts
@@ -7,9 +7,11 @@ import { defineMarkInputRule } from '../input-rule/index.ts'
  */
 export function defineHighlightInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: canUseRegexLookbehind()
-      ? /(?<=\s|^)==([^\s=]|[^\s=][^=]*[^\s=])==$/
-      : /==([^\s=]|[^\s=][^=]*[^\s=])==$/,
+    regex: new RegExp(
+      canUseRegexLookbehind()
+        ? String.raw`(?<=\s|^)==([^\s=]|[^\s=][^=]*[^\s=])==$`
+        : String.raw`==([^\s=]|[^\s=][^=]*[^\s=])==$`,
+    ),
     type: 'highlight',
   })
 }

--- a/packages/extensions/src/highlight/highlight-input-rule.ts
+++ b/packages/extensions/src/highlight/highlight-input-rule.ts
@@ -7,7 +7,10 @@ import { defineMarkInputRule } from '../input-rule/index.ts'
  */
 export function defineHighlightInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`==([^\s=]|[^\s=][^=]*[^\s=])==$`),
+    regex: new RegExp(
+      (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+        + String.raw`==([^\s=]|[^\s=][^=]*[^\s=])==$`,
+    ),
     type: 'highlight',
   })
 }

--- a/packages/extensions/src/italic/italic-input-rule.ts
+++ b/packages/extensions/src/italic/italic-input-rule.ts
@@ -7,11 +7,7 @@ import { defineMarkInputRule } from '../input-rule/index.ts'
  */
 export function defineItalicInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: new RegExp(
-      canUseRegexLookbehind()
-        ? String.raw`(?<=\s|^)\*([^\s*]|[^\s*][^*]*[^\s*])\*$`
-        : String.raw`\*([^\s*]|[^\s*][^*]*[^\s*])\*$`,
-    ),
+    regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`\*([^\s*]|[^\s*][^*]*[^\s*])\*$`),
     type: 'italic',
   })
 }

--- a/packages/extensions/src/italic/italic-input-rule.ts
+++ b/packages/extensions/src/italic/italic-input-rule.ts
@@ -7,7 +7,10 @@ import { defineMarkInputRule } from '../input-rule/index.ts'
  */
 export function defineItalicInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`\*([^\s*]|[^\s*][^*]*[^\s*])\*$`),
+    regex: new RegExp(
+      (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+        + String.raw`\*([^\s*]|[^\s*][^*]*[^\s*])\*$`,
+    ),
     type: 'italic',
   })
 }

--- a/packages/extensions/src/italic/italic-input-rule.ts
+++ b/packages/extensions/src/italic/italic-input-rule.ts
@@ -7,9 +7,11 @@ import { defineMarkInputRule } from '../input-rule/index.ts'
  */
 export function defineItalicInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: canUseRegexLookbehind()
-      ? /(?<=\s|^)\*([^\s*]|[^\s*][^*]*[^\s*])\*$/
-      : /\*([^\s*]|[^\s*][^*]*[^\s*])\*$/,
+    regex: new RegExp(
+      canUseRegexLookbehind()
+        ? String.raw`(?<=\s|^)\*([^\s*]|[^\s*][^*]*[^\s*])\*$`
+        : String.raw`\*([^\s*]|[^\s*][^*]*[^\s*])\*$`,
+    ),
     type: 'italic',
   })
 }

--- a/packages/extensions/src/strike/index.ts
+++ b/packages/extensions/src/strike/index.ts
@@ -74,11 +74,7 @@ export function defineStrikeKeymap(): PlainExtension {
  */
 export function defineStrikeInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: new RegExp(
-      canUseRegexLookbehind()
-        ? String.raw`(?<=\s|^)~~([^\s~]|[^\s~][^~]*[^\s~])~~$`
-        : String.raw`~~([^\s~]|[^\s~][^~]*[^\s~])~~$`,
-    ),
+    regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`~~([^\s~]|[^\s~][^~]*[^\s~])~~$`),
     type: 'strike',
   })
 }

--- a/packages/extensions/src/strike/index.ts
+++ b/packages/extensions/src/strike/index.ts
@@ -74,7 +74,10 @@ export function defineStrikeKeymap(): PlainExtension {
  */
 export function defineStrikeInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`~~([^\s~]|[^\s~][^~]*[^\s~])~~$`),
+    regex: new RegExp(
+      (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+        + String.raw`~~([^\s~]|[^\s~][^~]*[^\s~])~~$`,
+    ),
     type: 'strike',
   })
 }

--- a/packages/extensions/src/strike/index.ts
+++ b/packages/extensions/src/strike/index.ts
@@ -74,9 +74,11 @@ export function defineStrikeKeymap(): PlainExtension {
  */
 export function defineStrikeInputRule(): PlainExtension {
   return defineMarkInputRule({
-    regex: canUseRegexLookbehind()
-      ? /(?<=\s|^)~~([^\s~]|[^\s~][^~]*[^\s~])~~$/
-      : /~~([^\s~]|[^\s~][^~]*[^\s~])~~$/,
+    regex: new RegExp(
+      canUseRegexLookbehind()
+        ? String.raw`(?<=\s|^)~~([^\s~]|[^\s~][^~]*[^\s~])~~$`
+        : String.raw`~~([^\s~]|[^\s~][^~]*[^\s~])~~$`,
+    ),
     type: 'strike',
   })
 }

--- a/registry/src/lit/ui/slash-menu/slash-menu.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu.ts
@@ -16,9 +16,9 @@ import { editorContext } from '../editor-context.ts'
 import { SlashMenuEmptyElement } from './slash-menu-empty.ts'
 import { SlashMenuItemElement } from './slash-menu-item.ts'
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
 const regex = new RegExp(
-  canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`,
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`,
   'u',
 )
 

--- a/registry/src/lit/ui/slash-menu/slash-menu.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu.ts
@@ -18,8 +18,7 @@ import { SlashMenuItemElement } from './slash-menu-item.ts'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
 const regex = new RegExp(
-  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
-  + String.raw`\/(\S.*)?$`,
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`,
   'u',
 )
 

--- a/registry/src/lit/ui/slash-menu/slash-menu.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu.ts
@@ -18,7 +18,8 @@ import { SlashMenuItemElement } from './slash-menu-item.ts'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
 const regex = new RegExp(
-  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`,
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
+  + String.raw`\/(\S.*)?$`,
   'u',
 )
 

--- a/registry/src/lit/ui/slash-menu/slash-menu.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu.ts
@@ -16,8 +16,11 @@ import { editorContext } from '../editor-context.ts'
 import { SlashMenuEmptyElement } from './slash-menu-empty.ts'
 import { SlashMenuItemElement } from './slash-menu-item.ts'
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
+const regex = new RegExp(
+  canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`,
+  'u',
+)
 
 class SlashMenuElement extends LitElement {
   private editorConsumer = new ContextConsumer(this, {

--- a/registry/src/lit/ui/user-menu/user-menu.ts
+++ b/registry/src/lit/ui/user-menu/user-menu.ts
@@ -16,7 +16,10 @@ import {
 import { editorContext } from '../editor-context.ts'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = canUseRegexLookbehind() ? /(?<!\S)@(\S.*)?$/u : /@(\S.*)?$/u
+const regex = new RegExp(
+  canUseRegexLookbehind() ? String.raw`(?<!\S)@(\S.*)?$` : String.raw`@(\S.*)?$`,
+  'u',
+)
 
 interface User {
   id: number

--- a/registry/src/lit/ui/user-menu/user-menu.ts
+++ b/registry/src/lit/ui/user-menu/user-menu.ts
@@ -17,8 +17,7 @@ import { editorContext } from '../editor-context.ts'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
 const regex = new RegExp(
-  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
-  + String.raw`@(\S.*)?$`,
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`@(\S.*)?$`,
   'u',
 )
 

--- a/registry/src/lit/ui/user-menu/user-menu.ts
+++ b/registry/src/lit/ui/user-menu/user-menu.ts
@@ -17,7 +17,8 @@ import { editorContext } from '../editor-context.ts'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
 const regex = new RegExp(
-  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`@(\S.*)?$`,
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
+  + String.raw`@(\S.*)?$`,
   'u',
 )
 

--- a/registry/src/lit/ui/user-menu/user-menu.ts
+++ b/registry/src/lit/ui/user-menu/user-menu.ts
@@ -17,7 +17,7 @@ import { editorContext } from '../editor-context.ts'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
 const regex = new RegExp(
-  canUseRegexLookbehind() ? String.raw`(?<!\S)@(\S.*)?$` : String.raw`@(\S.*)?$`,
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`@(\S.*)?$`,
   'u',
 )
 

--- a/registry/src/preact/examples/sub-sup/extension.ts
+++ b/registry/src/preact/examples/sub-sup/extension.ts
@@ -15,19 +15,11 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: new RegExp(
-        canUseRegexLookbehind()
-          ? String.raw`(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$`
-          : String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
-      ),
+      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: new RegExp(
-        canUseRegexLookbehind()
-          ? String.raw`(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$`
-          : String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
-      ),
+      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`),
       type: 'superscript',
     }),
   )

--- a/registry/src/preact/examples/sub-sup/extension.ts
+++ b/registry/src/preact/examples/sub-sup/extension.ts
@@ -15,11 +15,17 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`),
+      regex: new RegExp(
+        (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+          + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
+      ),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`),
+      regex: new RegExp(
+        (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+          + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
+      ),
       type: 'superscript',
     }),
   )

--- a/registry/src/preact/examples/sub-sup/extension.ts
+++ b/registry/src/preact/examples/sub-sup/extension.ts
@@ -15,15 +15,19 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: canUseRegexLookbehind()
-        ? /(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$/
-        : /~([^\s~]|[^\s~][^~]*[^\s~])~$/,
+      regex: new RegExp(
+        canUseRegexLookbehind()
+          ? String.raw`(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$`
+          : String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
+      ),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: canUseRegexLookbehind()
-        ? /(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$/
-        : /\^([^\s^]|[^\s^][^^]*[^\s^])\^$/,
+      regex: new RegExp(
+        canUseRegexLookbehind()
+          ? String.raw`(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$`
+          : String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
+      ),
       type: 'superscript',
     }),
   )

--- a/registry/src/preact/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/preact/ui/slash-menu/slash-menu.tsx
@@ -6,8 +6,8 @@ import { AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'pro
 import SlashMenuEmpty from './slash-menu-empty.tsx'
 import SlashMenuItem from './slash-menu-item.tsx'
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
-const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`, 'u')
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
+const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`, 'u')
 
 export default function SlashMenu() {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/preact/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/preact/ui/slash-menu/slash-menu.tsx
@@ -7,7 +7,11 @@ import SlashMenuEmpty from './slash-menu-empty.tsx'
 import SlashMenuItem from './slash-menu-item.tsx'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`, 'u')
+const regex = new RegExp(
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
+    + String.raw`\/(\S.*)?$`,
+  'u',
+)
 
 export default function SlashMenu() {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/preact/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/preact/ui/slash-menu/slash-menu.tsx
@@ -6,8 +6,8 @@ import { AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'pro
 import SlashMenuEmpty from './slash-menu-empty.tsx'
 import SlashMenuItem from './slash-menu-item.tsx'
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
+const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`, 'u')
 
 export default function SlashMenu() {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/preact/ui/user-menu/user-menu.tsx
+++ b/registry/src/preact/ui/user-menu/user-menu.tsx
@@ -11,7 +11,7 @@ import {
 } from 'prosekit/preact/autocomplete'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = canUseRegexLookbehind() ? /(?<!\S)@(\S.*)?$/u : /@(\S.*)?$/u
+const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)@(\S.*)?$` : String.raw`@(\S.*)?$`, 'u')
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/preact/ui/user-menu/user-menu.tsx
+++ b/registry/src/preact/ui/user-menu/user-menu.tsx
@@ -11,7 +11,11 @@ import {
 } from 'prosekit/preact/autocomplete'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`@(\S.*)?$`, 'u')
+const regex = new RegExp(
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
+    + String.raw`@(\S.*)?$`,
+  'u',
+)
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/preact/ui/user-menu/user-menu.tsx
+++ b/registry/src/preact/ui/user-menu/user-menu.tsx
@@ -11,7 +11,7 @@ import {
 } from 'prosekit/preact/autocomplete'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)@(\S.*)?$` : String.raw`@(\S.*)?$`, 'u')
+const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`@(\S.*)?$`, 'u')
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/react/examples/notion/slash-menu/slash-menu.tsx
+++ b/registry/src/react/examples/notion/slash-menu/slash-menu.tsx
@@ -8,8 +8,8 @@ import { AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'pro
 import SlashMenuEmpty from './slash-menu-empty.tsx'
 import SlashMenuItem from './slash-menu-item.tsx'
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
+const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`, 'u')
 
 interface Props {
   onOpenChange: (open: boolean) => void

--- a/registry/src/react/examples/notion/slash-menu/slash-menu.tsx
+++ b/registry/src/react/examples/notion/slash-menu/slash-menu.tsx
@@ -9,7 +9,11 @@ import SlashMenuEmpty from './slash-menu-empty.tsx'
 import SlashMenuItem from './slash-menu-item.tsx'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`, 'u')
+const regex = new RegExp(
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
+    + String.raw`\/(\S.*)?$`,
+  'u',
+)
 
 interface Props {
   onOpenChange: (open: boolean) => void

--- a/registry/src/react/examples/notion/slash-menu/slash-menu.tsx
+++ b/registry/src/react/examples/notion/slash-menu/slash-menu.tsx
@@ -8,8 +8,8 @@ import { AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'pro
 import SlashMenuEmpty from './slash-menu-empty.tsx'
 import SlashMenuItem from './slash-menu-item.tsx'
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
-const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`, 'u')
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
+const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`, 'u')
 
 interface Props {
   onOpenChange: (open: boolean) => void

--- a/registry/src/react/examples/sub-sup/extension.ts
+++ b/registry/src/react/examples/sub-sup/extension.ts
@@ -15,19 +15,11 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: new RegExp(
-        canUseRegexLookbehind()
-          ? String.raw`(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$`
-          : String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
-      ),
+      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: new RegExp(
-        canUseRegexLookbehind()
-          ? String.raw`(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$`
-          : String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
-      ),
+      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`),
       type: 'superscript',
     }),
   )

--- a/registry/src/react/examples/sub-sup/extension.ts
+++ b/registry/src/react/examples/sub-sup/extension.ts
@@ -15,11 +15,17 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`),
+      regex: new RegExp(
+        (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+          + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
+      ),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`),
+      regex: new RegExp(
+        (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+          + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
+      ),
       type: 'superscript',
     }),
   )

--- a/registry/src/react/examples/sub-sup/extension.ts
+++ b/registry/src/react/examples/sub-sup/extension.ts
@@ -15,15 +15,19 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: canUseRegexLookbehind()
-        ? /(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$/
-        : /~([^\s~]|[^\s~][^~]*[^\s~])~$/,
+      regex: new RegExp(
+        canUseRegexLookbehind()
+          ? String.raw`(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$`
+          : String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
+      ),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: canUseRegexLookbehind()
-        ? /(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$/
-        : /\^([^\s^]|[^\s^][^^]*[^\s^])\^$/,
+      regex: new RegExp(
+        canUseRegexLookbehind()
+          ? String.raw`(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$`
+          : String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
+      ),
       type: 'superscript',
     }),
   )

--- a/registry/src/react/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/react/ui/slash-menu/slash-menu.tsx
@@ -8,8 +8,8 @@ import { AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'pro
 import SlashMenuEmpty from './slash-menu-empty.tsx'
 import SlashMenuItem from './slash-menu-item.tsx'
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
+const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`, 'u')
 
 export default function SlashMenu() {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/react/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/react/ui/slash-menu/slash-menu.tsx
@@ -9,7 +9,11 @@ import SlashMenuEmpty from './slash-menu-empty.tsx'
 import SlashMenuItem from './slash-menu-item.tsx'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`, 'u')
+const regex = new RegExp(
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
+    + String.raw`\/(\S.*)?$`,
+  'u',
+)
 
 export default function SlashMenu() {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/react/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/react/ui/slash-menu/slash-menu.tsx
@@ -8,8 +8,8 @@ import { AutocompletePopup, AutocompletePositioner, AutocompleteRoot } from 'pro
 import SlashMenuEmpty from './slash-menu-empty.tsx'
 import SlashMenuItem from './slash-menu-item.tsx'
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
-const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`, 'u')
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
+const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`, 'u')
 
 export default function SlashMenu() {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/react/ui/user-menu/user-menu.tsx
+++ b/registry/src/react/ui/user-menu/user-menu.tsx
@@ -13,7 +13,7 @@ import {
 } from 'prosekit/react/autocomplete'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = canUseRegexLookbehind() ? /(?<!\S)@(\S.*)?$/u : /@(\S.*)?$/u
+const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)@(\S.*)?$` : String.raw`@(\S.*)?$`, 'u')
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/react/ui/user-menu/user-menu.tsx
+++ b/registry/src/react/ui/user-menu/user-menu.tsx
@@ -13,7 +13,7 @@ import {
 } from 'prosekit/react/autocomplete'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)@(\S.*)?$` : String.raw`@(\S.*)?$`, 'u')
+const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`@(\S.*)?$`, 'u')
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/react/ui/user-menu/user-menu.tsx
+++ b/registry/src/react/ui/user-menu/user-menu.tsx
@@ -13,7 +13,11 @@ import {
 } from 'prosekit/react/autocomplete'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`@(\S.*)?$`, 'u')
+const regex = new RegExp(
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
+    + String.raw`@(\S.*)?$`,
+  'u',
+)
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/solid/examples/sub-sup/extension.ts
+++ b/registry/src/solid/examples/sub-sup/extension.ts
@@ -15,19 +15,11 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: new RegExp(
-        canUseRegexLookbehind()
-          ? String.raw`(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$`
-          : String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
-      ),
+      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: new RegExp(
-        canUseRegexLookbehind()
-          ? String.raw`(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$`
-          : String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
-      ),
+      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`),
       type: 'superscript',
     }),
   )

--- a/registry/src/solid/examples/sub-sup/extension.ts
+++ b/registry/src/solid/examples/sub-sup/extension.ts
@@ -15,11 +15,17 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`),
+      regex: new RegExp(
+        (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+          + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
+      ),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`),
+      regex: new RegExp(
+        (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+          + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
+      ),
       type: 'superscript',
     }),
   )

--- a/registry/src/solid/examples/sub-sup/extension.ts
+++ b/registry/src/solid/examples/sub-sup/extension.ts
@@ -15,15 +15,19 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: canUseRegexLookbehind()
-        ? /(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$/
-        : /~([^\s~]|[^\s~][^~]*[^\s~])~$/,
+      regex: new RegExp(
+        canUseRegexLookbehind()
+          ? String.raw`(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$`
+          : String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
+      ),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: canUseRegexLookbehind()
-        ? /(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$/
-        : /\^([^\s^]|[^\s^][^^]*[^\s^])\^$/,
+      regex: new RegExp(
+        canUseRegexLookbehind()
+          ? String.raw`(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$`
+          : String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
+      ),
       type: 'superscript',
     }),
   )

--- a/registry/src/solid/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/solid/ui/slash-menu/slash-menu.tsx
@@ -7,8 +7,8 @@ import type { JSX } from 'solid-js'
 import SlashMenuEmpty from './slash-menu-empty.tsx'
 import SlashMenuItem from './slash-menu-item.tsx'
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
+const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`, 'u')
 
 export default function SlashMenu(): JSX.Element {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/solid/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/solid/ui/slash-menu/slash-menu.tsx
@@ -7,8 +7,8 @@ import type { JSX } from 'solid-js'
 import SlashMenuEmpty from './slash-menu-empty.tsx'
 import SlashMenuItem from './slash-menu-item.tsx'
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
-const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`, 'u')
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
+const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`, 'u')
 
 export default function SlashMenu(): JSX.Element {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/solid/ui/slash-menu/slash-menu.tsx
+++ b/registry/src/solid/ui/slash-menu/slash-menu.tsx
@@ -8,7 +8,11 @@ import SlashMenuEmpty from './slash-menu-empty.tsx'
 import SlashMenuItem from './slash-menu-item.tsx'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`, 'u')
+const regex = new RegExp(
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
+    + String.raw`\/(\S.*)?$`,
+  'u',
+)
 
 export default function SlashMenu(): JSX.Element {
   const editor = useEditor<BasicExtension>()

--- a/registry/src/solid/ui/user-menu/user-menu.tsx
+++ b/registry/src/solid/ui/user-menu/user-menu.tsx
@@ -12,7 +12,11 @@ import {
 import { For, type JSX } from 'solid-js'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`@(\S.*)?$`, 'u')
+const regex = new RegExp(
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
+    + String.raw`@(\S.*)?$`,
+  'u',
+)
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/solid/ui/user-menu/user-menu.tsx
+++ b/registry/src/solid/ui/user-menu/user-menu.tsx
@@ -12,7 +12,7 @@ import {
 import { For, type JSX } from 'solid-js'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)@(\S.*)?$` : String.raw`@(\S.*)?$`, 'u')
+const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`@(\S.*)?$`, 'u')
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/solid/ui/user-menu/user-menu.tsx
+++ b/registry/src/solid/ui/user-menu/user-menu.tsx
@@ -12,7 +12,7 @@ import {
 import { For, type JSX } from 'solid-js'
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = canUseRegexLookbehind() ? /(?<!\S)@(\S.*)?$/u : /@(\S.*)?$/u
+const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)@(\S.*)?$` : String.raw`@(\S.*)?$`, 'u')
 
 export default function UserMenu(props: {
   users: { id: number; name: string }[]

--- a/registry/src/svelte/examples/sub-sup/extension.ts
+++ b/registry/src/svelte/examples/sub-sup/extension.ts
@@ -15,19 +15,11 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: new RegExp(
-        canUseRegexLookbehind()
-          ? String.raw`(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$`
-          : String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
-      ),
+      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: new RegExp(
-        canUseRegexLookbehind()
-          ? String.raw`(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$`
-          : String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
-      ),
+      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`),
       type: 'superscript',
     }),
   )

--- a/registry/src/svelte/examples/sub-sup/extension.ts
+++ b/registry/src/svelte/examples/sub-sup/extension.ts
@@ -15,11 +15,17 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`),
+      regex: new RegExp(
+        (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+          + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
+      ),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`),
+      regex: new RegExp(
+        (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+          + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
+      ),
       type: 'superscript',
     }),
   )

--- a/registry/src/svelte/examples/sub-sup/extension.ts
+++ b/registry/src/svelte/examples/sub-sup/extension.ts
@@ -15,15 +15,19 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: canUseRegexLookbehind()
-        ? /(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$/
-        : /~([^\s~]|[^\s~][^~]*[^\s~])~$/,
+      regex: new RegExp(
+        canUseRegexLookbehind()
+          ? String.raw`(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$`
+          : String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
+      ),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: canUseRegexLookbehind()
-        ? /(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$/
-        : /\^([^\s^]|[^\s^][^^]*[^\s^])\^$/,
+      regex: new RegExp(
+        canUseRegexLookbehind()
+          ? String.raw`(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$`
+          : String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
+      ),
       type: 'superscript',
     }),
   )

--- a/registry/src/svelte/ui/slash-menu/slash-menu.svelte
+++ b/registry/src/svelte/ui/slash-menu/slash-menu.svelte
@@ -9,8 +9,8 @@ import SlashMenuItem from './slash-menu-item.svelte'
 
 const editor = useEditor<BasicExtension>()
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
+const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`, 'u')
 </script>
 
 <AutocompleteRoot {regex}>

--- a/registry/src/svelte/ui/slash-menu/slash-menu.svelte
+++ b/registry/src/svelte/ui/slash-menu/slash-menu.svelte
@@ -10,7 +10,11 @@ import SlashMenuItem from './slash-menu-item.svelte'
 const editor = useEditor<BasicExtension>()
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`, 'u')
+const regex = new RegExp(
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
+    + String.raw`\/(\S.*)?$`,
+  'u',
+)
 </script>
 
 <AutocompleteRoot {regex}>

--- a/registry/src/svelte/ui/slash-menu/slash-menu.svelte
+++ b/registry/src/svelte/ui/slash-menu/slash-menu.svelte
@@ -9,8 +9,8 @@ import SlashMenuItem from './slash-menu-item.svelte'
 
 const editor = useEditor<BasicExtension>()
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
-const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`, 'u')
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
+const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`, 'u')
 </script>
 
 <AutocompleteRoot {regex}>

--- a/registry/src/svelte/ui/user-menu/user-menu.svelte
+++ b/registry/src/svelte/ui/user-menu/user-menu.svelte
@@ -33,7 +33,7 @@ function handleUserInsert(id: number, username: string) {
 }
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)@(\S.*)?$` : String.raw`@(\S.*)?$`, 'u')
+const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`@(\S.*)?$`, 'u')
 </script>
 
 <AutocompleteRoot

--- a/registry/src/svelte/ui/user-menu/user-menu.svelte
+++ b/registry/src/svelte/ui/user-menu/user-menu.svelte
@@ -33,7 +33,7 @@ function handleUserInsert(id: number, username: string) {
 }
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = canUseRegexLookbehind() ? /(?<!\S)@(\S.*)?$/u : /@(\S.*)?$/u
+const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)@(\S.*)?$` : String.raw`@(\S.*)?$`, 'u')
 </script>
 
 <AutocompleteRoot

--- a/registry/src/svelte/ui/user-menu/user-menu.svelte
+++ b/registry/src/svelte/ui/user-menu/user-menu.svelte
@@ -33,7 +33,11 @@ function handleUserInsert(id: number, username: string) {
 }
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`@(\S.*)?$`, 'u')
+const regex = new RegExp(
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
+    + String.raw`@(\S.*)?$`,
+  'u',
+)
 </script>
 
 <AutocompleteRoot

--- a/registry/src/vanilla/ui/slash-menu/slash-menu.ts
+++ b/registry/src/vanilla/ui/slash-menu/slash-menu.ts
@@ -9,7 +9,11 @@ import { renderSlashMenuEmpty } from './slash-menu-empty.ts'
 import { renderSlashMenuItem } from './slash-menu-item.ts'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`, 'u')
+const regex = new RegExp(
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
+    + String.raw`\/(\S.*)?$`,
+  'u',
+)
 
 export function renderSlashMenu(
   editor: Editor<BasicExtension>,

--- a/registry/src/vanilla/ui/slash-menu/slash-menu.ts
+++ b/registry/src/vanilla/ui/slash-menu/slash-menu.ts
@@ -8,8 +8,8 @@ import type { AutocompletePopupElement, AutocompletePositionerElement, Autocompl
 import { renderSlashMenuEmpty } from './slash-menu-empty.ts'
 import { renderSlashMenuItem } from './slash-menu-item.ts'
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
+const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`, 'u')
 
 export function renderSlashMenu(
   editor: Editor<BasicExtension>,

--- a/registry/src/vanilla/ui/slash-menu/slash-menu.ts
+++ b/registry/src/vanilla/ui/slash-menu/slash-menu.ts
@@ -8,8 +8,8 @@ import type { AutocompletePopupElement, AutocompletePositionerElement, Autocompl
 import { renderSlashMenuEmpty } from './slash-menu-empty.ts'
 import { renderSlashMenuItem } from './slash-menu-item.ts'
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
-const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`, 'u')
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
+const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`, 'u')
 
 export function renderSlashMenu(
   editor: Editor<BasicExtension>,

--- a/registry/src/vue/examples/sub-sup/extension.ts
+++ b/registry/src/vue/examples/sub-sup/extension.ts
@@ -15,19 +15,11 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: new RegExp(
-        canUseRegexLookbehind()
-          ? String.raw`(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$`
-          : String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
-      ),
+      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: new RegExp(
-        canUseRegexLookbehind()
-          ? String.raw`(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$`
-          : String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
-      ),
+      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`),
       type: 'superscript',
     }),
   )

--- a/registry/src/vue/examples/sub-sup/extension.ts
+++ b/registry/src/vue/examples/sub-sup/extension.ts
@@ -15,11 +15,17 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`),
+      regex: new RegExp(
+        (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+          + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
+      ),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: new RegExp((canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '') + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`),
+      regex: new RegExp(
+        (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+          + String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
+      ),
       type: 'superscript',
     }),
   )

--- a/registry/src/vue/examples/sub-sup/extension.ts
+++ b/registry/src/vue/examples/sub-sup/extension.ts
@@ -15,15 +15,19 @@ export function defineExtension() {
     defineSubscript(),
     defineSuperscript(),
     defineMarkInputRule({
-      regex: canUseRegexLookbehind()
-        ? /(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$/
-        : /~([^\s~]|[^\s~][^~]*[^\s~])~$/,
+      regex: new RegExp(
+        canUseRegexLookbehind()
+          ? String.raw`(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$`
+          : String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
+      ),
       type: 'subscript',
     }),
     defineMarkInputRule({
-      regex: canUseRegexLookbehind()
-        ? /(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$/
-        : /\^([^\s^]|[^\s^][^^]*[^\s^])\^$/,
+      regex: new RegExp(
+        canUseRegexLookbehind()
+          ? String.raw`(?<=\s|^)\^([^\s^]|[^\s^][^^]*[^\s^])\^$`
+          : String.raw`\^([^\s^]|[^\s^][^^]*[^\s^])\^$`,
+      ),
       type: 'superscript',
     }),
   )

--- a/registry/src/vue/ui/slash-menu/slash-menu.vue
+++ b/registry/src/vue/ui/slash-menu/slash-menu.vue
@@ -9,8 +9,8 @@ import SlashMenuItem from './slash-menu-item.vue'
 
 const editor = useEditor<BasicExtension>()
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
-const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`, 'u')
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
+const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`, 'u')
 </script>
 
 <template>

--- a/registry/src/vue/ui/slash-menu/slash-menu.vue
+++ b/registry/src/vue/ui/slash-menu/slash-menu.vue
@@ -10,7 +10,11 @@ import SlashMenuItem from './slash-menu-item.vue'
 const editor = useEditor<BasicExtension>()
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`, 'u')
+const regex = new RegExp(
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
+    + String.raw`\/(\S.*)?$`,
+  'u',
+)
 </script>
 
 <template>

--- a/registry/src/vue/ui/slash-menu/slash-menu.vue
+++ b/registry/src/vue/ui/slash-menu/slash-menu.vue
@@ -9,8 +9,8 @@ import SlashMenuItem from './slash-menu-item.vue'
 
 const editor = useEditor<BasicExtension>()
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading" or "//".
+const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)\/(?!\/)(\S.*)?$` : String.raw`\/(?!\/)(\S.*)?$`, 'u')
 </script>
 
 <template>

--- a/registry/src/vue/ui/user-menu/user-menu.vue
+++ b/registry/src/vue/ui/user-menu/user-menu.vue
@@ -24,7 +24,7 @@ function handleUserInsert(id: number, username: string) {
 }
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)@(\S.*)?$` : String.raw`@(\S.*)?$`, 'u')
+const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`@(\S.*)?$`, 'u')
 </script>
 
 <template>

--- a/registry/src/vue/ui/user-menu/user-menu.vue
+++ b/registry/src/vue/ui/user-menu/user-menu.vue
@@ -24,7 +24,7 @@ function handleUserInsert(id: number, username: string) {
 }
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = canUseRegexLookbehind() ? /(?<!\S)@(\S.*)?$/u : /@(\S.*)?$/u
+const regex = new RegExp(canUseRegexLookbehind() ? String.raw`(?<!\S)@(\S.*)?$` : String.raw`@(\S.*)?$`, 'u')
 </script>
 
 <template>

--- a/registry/src/vue/ui/user-menu/user-menu.vue
+++ b/registry/src/vue/ui/user-menu/user-menu.vue
@@ -24,7 +24,11 @@ function handleUserInsert(id: number, username: string) {
 }
 
 // Match inputs like "@", "@foo", "@foo bar" etc. Do not match "@ foo".
-const regex = new RegExp((canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`@(\S.*)?$`, 'u')
+const regex = new RegExp(
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '')
+    + String.raw`@(\S.*)?$`,
+  'u',
+)
 </script>
 
 <template>

--- a/website/src/content/docs/extensions/subscript.mdx
+++ b/website/src/content/docs/extensions/subscript.mdx
@@ -35,9 +35,10 @@ import { defineSubscript } from 'prosekit/extensions/subscript'
 const extension = union(
   defineSubscript(),
   defineMarkInputRule({
-    regex: canUseRegexLookbehind()
-      ? /(?<=\s|^)~([^\s~]|[^\s~][^~]*[^\s~])~$/
-      : /~([^\s~]|[^\s~][^~]*[^\s~])~$/,
+    regex: new RegExp(
+      (canUseRegexLookbehind() ? String.raw`(?<=\s|^)` : '')
+        + String.raw`~([^\s~]|[^\s~][^~]*[^\s~])~$`,
+    ),
     type: 'subscript',
   }),
 )


### PR DESCRIPTION
Regex literals containing lookbehind syntax fail at module parse time on engines without lookbehind support, before `canUseRegexLookbehind()` can select the fallback, so the mark input rules and the slash-menu, user-menu, and sub-sup registry files now build each pattern with `new RegExp`, prepending the lookbehind prefix to a shared source string, with no change to the matched expressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for autocomplete triggers, slash menus, mentions, and text formatting across JavaScript environments with limited regular-expression support.
  * Preserved existing matching behavior for bold, italic, code, highlights, strikethrough, subscript, and superscript input rules.

* **Documentation**
  * Updated the subscript extension documentation examples to reflect the compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->