### PR TITLE
docs(registry): forward `SelectEvent` detail in lit slash-menu item

### DIFF
--- a/.changeset/lit-slash-menu-select-detail.md
+++ b/.changeset/lit-slash-menu-select-detail.md
@@ -1,0 +1,5 @@
+---
+"prosekit-registry": patch
+---
+
+The lit slash-menu item now forwards the selected item's value as the `detail` of its `select` event.

--- a/.changeset/lit-slash-menu-select-detail.md
+++ b/.changeset/lit-slash-menu-select-detail.md
@@ -1,5 +1,0 @@
----
-"prosekit-registry": patch
----
-
-The lit slash-menu item now forwards the selected item's value as the `detail` of its `select` event.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@aria-ui/core": "^0.2.1",
-    "@aria-ui/elements": "^0.1.12",
+    "@aria-ui/elements": "^0.1.13",
     "@aria-ui/utils": "^0.1.7",
     "@floating-ui/dom": "^1.8.0",
     "@ocavue/utils": "^1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -841,8 +841,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       '@aria-ui/elements':
-        specifier: ^0.1.12
-        version: 0.1.12
+        specifier: ^0.1.13
+        version: 0.1.13
       '@aria-ui/utils':
         specifier: ^0.1.7
         version: 0.1.7
@@ -1244,8 +1244,8 @@ packages:
   '@aria-ui/core@0.2.1':
     resolution: {integrity: sha512-EEh2mIHL4HnfjIgZocxhCCqPRU6EE5eLFQcGw4FOfomil11jIBKtmqCQkz8qJ9Ni3IBoh/5DvUFaY206X0oY6A==}
 
-  '@aria-ui/elements@0.1.12':
-    resolution: {integrity: sha512-NnYKMCpUoSZYUSSXYrWOSiLih67iptxc+kLfrHbPW1BG1aFz9Bmofb2rljE7mQzU1iA5fUzPIFC0tgFH8DUoCA==}
+  '@aria-ui/elements@0.1.13':
+    resolution: {integrity: sha512-+uZaWhNobVCIncKn6wBsnVstWet9IM/W7zmDVk71Ktui4ZNRGSj9tudwnsQdnIPtIqDLHiUIr03NPCEnf99lBg==}
 
   '@aria-ui/utils@0.1.7':
     resolution: {integrity: sha512-ZKc/JOugSEYqsPUHYomxSbLyK9TcypsnhGL/yK2X14q6qyXVax5vHjLqgZmX5pwm28vYP4FOsUiUUtuSIK/eKw==}
@@ -4534,20 +4534,20 @@ packages:
   '@yuku-toolchain/types@0.6.8':
     resolution: {integrity: sha512-AbUd1775RVkOxJkh8hkldIWoU6kRMTCsZFSZq8Ny53q7GkbaVe5UCfleNZ3RWCoz/ZKE8qwfeB7Cj0xqhLWsKA==}
 
-  '@zag-js/dismissable@1.42.0':
-    resolution: {integrity: sha512-Cx/FAQ2MuQy3kecdmswrFk94Zie1ieBa1Pnt/2ECI5FR914EJd3DwY9Krsmlrq4Z15Wm+pVtfLXgakDewVgsiQ==}
+  '@zag-js/dismissable@1.43.0':
+    resolution: {integrity: sha512-bf19aG9iLxwivpC+lntS2Lzkr4OB73zzPJWI21eIeyMDOX5+QDAZEX9gwNZRKYh1AkEq/oVHYWu71aZKNmdR8w==}
 
-  '@zag-js/dom-query@1.42.0':
-    resolution: {integrity: sha512-JgCNfp7F+YNFNb7Xmt6rXQr3N3V9Mp+pFRvZ8j5BTC3/G8ZYj/enrgOcuVwPlXPBGtA7ysvjig2x1c0Uou/6kg==}
+  '@zag-js/dom-query@1.43.0':
+    resolution: {integrity: sha512-yQDR00jJj0tgrRH43QJx7NtQH+EBxQtEdFKMzG7c88xL1ZRtqXYpqNNSmCuGj5RTsEceQjEhAxeTJikUYp9M0g==}
 
-  '@zag-js/interact-outside@1.42.0':
-    resolution: {integrity: sha512-CNNT1OtASacXEst8NMWDGmDwkOQgVQ0Ahc2SpPjSBZoVpxQIfhZ9FoeqcggDX7Nvze7kl6/OwA7pPi5TGQTVZQ==}
+  '@zag-js/interact-outside@1.43.0':
+    resolution: {integrity: sha512-mQ/6HT6Tn99H4l7u7FaxvXirE4wYenlZFuFkR0qXGRaR7bDRUeWm3dJKcV0Ex3gwcs+G5Z0ZdvA++VBfVh+WUg==}
 
-  '@zag-js/types@1.42.0':
-    resolution: {integrity: sha512-4ghao1wuLouepdYMheEYtyOlKpVsvL0Eg9tf//5VyAf7S9zC7cgGxD6ttGTlIMxqKqnAuxIMsYHG76qkb8tv1w==}
+  '@zag-js/types@1.43.0':
+    resolution: {integrity: sha512-pheZyCiVjJaXBzbfoj/gMKXkZUo1D5JWd46QVYWonHJZIdUfDRDwBvDKcXGIHmpuq7fJrnGXbegAk0+D2aa4bw==}
 
-  '@zag-js/utils@1.42.0':
-    resolution: {integrity: sha512-Km0r9hY+f6/oCJXrO4nqCIuo+4gTqbloD0V0q7B8Jq8qeWte7HN+YJSagVlk8tfADqFMRgEW4Rug0bYHzrGbVA==}
+  '@zag-js/utils@1.43.0':
+    resolution: {integrity: sha512-ZxkL+AuKRv/UGmmp5iZwmzfcVV7iWiDIrhYiMrKDKPJGdIPIFpMOisM+bTKYVkvn0jmCZV0CTF0jJm29hEV+LQ==}
 
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
@@ -8323,22 +8323,22 @@ snapshots:
   '@aria-ui/core@0.2.1':
     dependencies:
       '@ocavue/utils': 1.7.0
-      '@zag-js/dom-query': 1.42.0
+      '@zag-js/dom-query': 1.43.0
       alien-signals: 3.2.1
       server-dom-shim: 1.1.0
 
-  '@aria-ui/elements@0.1.12':
+  '@aria-ui/elements@0.1.13':
     dependencies:
       '@aria-ui/core': 0.2.1
       '@aria-ui/utils': 0.1.7
       '@floating-ui/dom': 1.8.0
-      '@zag-js/dismissable': 1.42.0
-      '@zag-js/dom-query': 1.42.0
+      '@zag-js/dismissable': 1.43.0
+      '@zag-js/dom-query': 1.43.0
 
   '@aria-ui/utils@0.1.7':
     dependencies:
       '@aria-ui/core': 0.2.1
-      '@zag-js/dom-query': 1.42.0
+      '@zag-js/dom-query': 1.43.0
 
   '@asamuzakjp/css-color@6.0.5':
     dependencies:
@@ -11571,26 +11571,26 @@ snapshots:
 
   '@yuku-toolchain/types@0.6.8': {}
 
-  '@zag-js/dismissable@1.42.0':
+  '@zag-js/dismissable@1.43.0':
     dependencies:
-      '@zag-js/dom-query': 1.42.0
-      '@zag-js/interact-outside': 1.42.0
-      '@zag-js/utils': 1.42.0
+      '@zag-js/dom-query': 1.43.0
+      '@zag-js/interact-outside': 1.43.0
+      '@zag-js/utils': 1.43.0
 
-  '@zag-js/dom-query@1.42.0':
+  '@zag-js/dom-query@1.43.0':
     dependencies:
-      '@zag-js/types': 1.42.0
+      '@zag-js/types': 1.43.0
 
-  '@zag-js/interact-outside@1.42.0':
+  '@zag-js/interact-outside@1.43.0':
     dependencies:
-      '@zag-js/dom-query': 1.42.0
-      '@zag-js/utils': 1.42.0
+      '@zag-js/dom-query': 1.43.0
+      '@zag-js/utils': 1.43.0
 
-  '@zag-js/types@1.42.0':
+  '@zag-js/types@1.43.0':
     dependencies:
       csstype: 3.2.3
 
-  '@zag-js/utils@1.42.0': {}
+  '@zag-js/utils@1.43.0': {}
 
   abbrev@2.0.0: {}
 
@@ -14993,7 +14993,7 @@ snapshots:
   shiki-twoslash-renderer@0.3.5(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
       '@aria-ui/core': 0.2.1
-      '@aria-ui/elements': 0.1.12
+      '@aria-ui/elements': 0.1.13
       '@shikijs/twoslash': 4.3.1(supports-color@10.2.2)(typescript@6.0.3)
       '@shikijs/types': 4.3.1
       '@types/hast': 3.0.5

--- a/registry/src/lit/ui/slash-menu/slash-menu-item.ts
+++ b/registry/src/lit/ui/slash-menu/slash-menu-item.ts
@@ -1,4 +1,5 @@
 import { html, LitElement } from 'lit'
+import type { SelectEvent } from 'prosekit/lit/autocomplete'
 
 export class SlashMenuItemElement extends LitElement {
   static override properties = {
@@ -19,9 +20,10 @@ export class SlashMenuItemElement extends LitElement {
     return this
   }
 
-  // TODO: maybe this should changed to valueChange event??
-  handleSelect = () => {
-    this.dispatchEvent(new CustomEvent('select'))
+  // Relay the inner item's non-bubbling `select` event on this element, so
+  // consumers can listen for it without reaching into the light DOM.
+  handleSelect = (event: SelectEvent) => {
+    this.dispatchEvent(new CustomEvent('select', { detail: event.detail }))
   }
 
   override render() {


### PR DESCRIPTION
The lit slash-menu item wrapper now relays the selected item's value as the `detail` of its re-dispatched `select` event, resolving the old `valueChange` TODO. Typecheck stays red until this PR also bumps `@aria-ui/elements` to a release containing https://github.com/ocavue/aria-ui/pull/347.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved slash menu item selection so selected-item details are preserved when events are handled.
  - Selection events now propagate consistently, enabling more reliable responses from connected UI components.

- **Compatibility**
  - Updated the underlying UI elements package to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->