### PR TITLE
fix(core): make `Editor<any>` accept any typed editor

### DIFF
--- a/.changeset/editor-any-typing.md
+++ b/.changeset/editor-any-typing.md
@@ -1,0 +1,6 @@
+---
+"@prosekit/core": patch
+"prosekit": patch
+---
+
+Make `Editor<any>` accept any typed editor, so an editor with concrete commands can be passed where a generic `Editor` is expected.

--- a/packages/core/src/editor/editor.spec.ts
+++ b/packages/core/src/editor/editor.spec.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 
 import { insertText } from '../commands/insert-text.ts'
 import { wrap } from '../commands/wrap.ts'
 import { defineTestExtension, setupTest } from '../testing/index.ts'
 import type { NodeJSON } from '../types/model.ts'
 
-import { createEditor } from './editor.ts'
+import { createEditor, type Editor } from './editor.ts'
 
 describe('createEditor', () => {
   it('can mount the editor', () => {
@@ -175,5 +175,15 @@ describe('createEditor', () => {
 
     expect(editor.canExec(wrap({ type: 'paragraph' }))).toBe(false)
     expect(editor.commands.wrap.canExec({ type: 'paragraph' })).toBe(false)
+  })
+})
+
+describe('Editor<any>', () => {
+  it('accepts any typed editor', () => {
+    const { editor } = setupTest()
+    const anyEditor: Editor = editor
+    expectTypeOf(anyEditor.commands).not.toBeNever()
+    expectTypeOf(anyEditor.nodes).not.toBeNever()
+    expectTypeOf(anyEditor.marks).not.toBeNever()
   })
 })

--- a/packages/core/src/types/extension-command.ts
+++ b/packages/core/src/types/extension-command.ts
@@ -38,6 +38,6 @@ export type ToCommandCreators<T extends CommandTyping> = {
   [K in keyof T]: CommandCreator<T[K]>
 }
 
-export type ToCommandAction<T extends CommandTyping> = {
+export type ToCommandAction<T extends CommandTyping> = [T] extends [never] ? Record<never, never> : {
   [K in keyof T]: CommandAction<T[K]>
 }

--- a/packages/core/src/types/extension-mark.ts
+++ b/packages/core/src/types/extension-mark.ts
@@ -17,6 +17,6 @@ export type ToMarkBuilder<T extends MarkTyping> = {
 /**
  * @internal
  */
-export type ToMarkAction<T extends MarkTyping> = {
+export type ToMarkAction<T extends MarkTyping> = [T] extends [never] ? Record<never, never> : {
   [K in keyof T]: MarkAction<T[K]>
 }

--- a/packages/core/src/types/extension-node.ts
+++ b/packages/core/src/types/extension-node.ts
@@ -17,6 +17,6 @@ export type ToNodeBuilder<T extends NodeTyping> = {
 /**
  * @internal
  */
-export type ToNodeAction<T extends NodeTyping> = {
+export type ToNodeAction<T extends NodeTyping> = [T] extends [never] ? Record<never, never> : {
   [K in keyof T]: NodeAction<T[K]>
 }

--- a/packages/core/src/types/extension.ts
+++ b/packages/core/src/types/extension.ts
@@ -1,5 +1,4 @@
 import type { Schema } from '@prosekit/pm/model'
-import type { IsAny } from 'type-fest'
 
 import type { CommandTyping, ToCommandAction, ToCommandCreators } from './extension-command.ts'
 import type { MarkTyping, ToMarkAction, ToMarkBuilder } from './extension-mark.ts'
@@ -59,15 +58,17 @@ export type PlainExtension = Extension<{
   Commands: never
 }>
 
-export type ExtractNodes<E extends Extension> = IsAny<E> extends true ? NodeTyping
-  : SimplifyDeeper<SimplifyUnion<ExtractTyping<E>['Nodes']>>
+export type ExtractNodes<E extends Extension> = SimplifyDeeper<
+  SimplifyUnion<ExtractTyping<E>['Nodes']>
+>
 
 export type ExtractNodeNames<E extends Extension> = PickStringLiteral<
   keyof ExtractNodes<E>
 >
 
-export type ExtractMarks<E extends Extension> = IsAny<E> extends true ? MarkTyping
-  : SimplifyDeeper<SimplifyUnion<ExtractTyping<E>['Marks']>>
+export type ExtractMarks<E extends Extension> = SimplifyDeeper<
+  SimplifyUnion<ExtractTyping<E>['Marks']>
+>
 
 export type ExtractMarkNames<E extends Extension> = PickStringLiteral<
   keyof ExtractMarks<E>
@@ -76,8 +77,9 @@ export type ExtractMarkNames<E extends Extension> = PickStringLiteral<
 /**
  * @internal
  */
-export type ExtractCommands<E extends Extension> = IsAny<E> extends true ? CommandTyping
-  : SimplifyUnion<ExtractTyping<E>['Commands']>
+export type ExtractCommands<E extends Extension> = SimplifyUnion<
+  ExtractTyping<E>['Commands']
+>
 
 export type ExtractCommandCreators<E extends Extension> = ToCommandCreators<
   ExtractCommands<E>

--- a/packages/core/src/types/extension.ts
+++ b/packages/core/src/types/extension.ts
@@ -1,4 +1,5 @@
 import type { Schema } from '@prosekit/pm/model'
+import type { IsAny } from 'type-fest'
 
 import type { CommandTyping, ToCommandAction, ToCommandCreators } from './extension-command.ts'
 import type { MarkTyping, ToMarkAction, ToMarkBuilder } from './extension-mark.ts'
@@ -58,17 +59,15 @@ export type PlainExtension = Extension<{
   Commands: never
 }>
 
-export type ExtractNodes<E extends Extension> = SimplifyDeeper<
-  SimplifyUnion<ExtractTyping<E>['Nodes']>
->
+export type ExtractNodes<E extends Extension> = IsAny<E> extends true ? NodeTyping
+  : SimplifyDeeper<SimplifyUnion<ExtractTyping<E>['Nodes']>>
 
 export type ExtractNodeNames<E extends Extension> = PickStringLiteral<
   keyof ExtractNodes<E>
 >
 
-export type ExtractMarks<E extends Extension> = SimplifyDeeper<
-  SimplifyUnion<ExtractTyping<E>['Marks']>
->
+export type ExtractMarks<E extends Extension> = IsAny<E> extends true ? MarkTyping
+  : SimplifyDeeper<SimplifyUnion<ExtractTyping<E>['Marks']>>
 
 export type ExtractMarkNames<E extends Extension> = PickStringLiteral<
   keyof ExtractMarks<E>
@@ -77,9 +76,8 @@ export type ExtractMarkNames<E extends Extension> = PickStringLiteral<
 /**
  * @internal
  */
-export type ExtractCommands<E extends Extension> = SimplifyUnion<
-  ExtractTyping<E>['Commands']
->
+export type ExtractCommands<E extends Extension> = IsAny<E> extends true ? CommandTyping
+  : SimplifyUnion<ExtractTyping<E>['Commands']>
 
 export type ExtractCommandCreators<E extends Extension> = ToCommandCreators<
   ExtractCommands<E>


### PR DESCRIPTION
`Editor<any>` and `Editor<Extension>` resolved `commands`, `nodes`, and `marks` to `never`, so a concretely typed editor such as a `TestEditor` was not assignable to a plain `Editor` parameter; the `To*Action` mapped types now resolve an empty typing to an empty object instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved editor typing so unparameterized editors expose usable commands, nodes, and marks.
  - Corrected type behavior when no command, node, or mark definitions are available, preventing invalid action mappings.

- **Tests**
  - Added type-level coverage to verify editor properties and empty-definition handling.

- **Documentation**
  - Documented the improved typing support for editors with concrete commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->