### PR TITLE
ci: fix token conflict on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,7 @@ jobs:
           commit-message: "chore: version packages"
           pr-title: "chore: version packages"
           create-github-releases: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
   publish:
     name: Publish


### PR DESCRIPTION
## Summary

Master Release **Prepare** is red after the Changesets v3 migration because `changesets/action@v2.1.0` rejects setting a custom token via `env.GITHUB_TOKEN` when it conflicts with the action input.

Failed run: https://github.com/prosekit/prosekit/actions/runs/34021396260

Error:

```
The GITHUB_TOKEN environment variable is set and does not match the "github-token" input. Please pass the custom GitHub token to the "github-token" input and remove the GITHUB_TOKEN environment variable to avoid conflicts.
```

## Fix

Per https://changesets.dev/guide/migration — pass `BOT_GITHUB_TOKEN` through the `github-token` input and remove `env.GITHUB_TOKEN`.

Minimal workflow-only change; SHA pin on `changesets/action` unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation workflow to provide authentication through the action’s supported configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->